### PR TITLE
X11: update readme to require OpenGl ES3

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Despite the warning above, I've been using `wezterm` as my daily driver since
 the middle of Feb 2018.  The following features are done:
 
 - [x] Runs on
- * Linux under X (requires OpenGL ES 2)
+ * Linux under X (requires OpenGL ES 3)
  * macOS
  * Windows 10 with [ConPty](https://blogs.msdn.microsoft.com/commandline/2018/08/02/windows-command-line-introducing-the-windows-pseudo-console-conpty/)
 - [x] True Color support


### PR DESCRIPTION
The story as I understand it:
The current shaders requires GLSL 3.30 but OpenGL ES 2.0 is bound to GLSL
1.20.
The confusion arise when creating EGL context. We ask for ES2 because crate egli
doesn't provide a ES3 one "yet". On a recent system, the driver will probably return
a ES3 conformant context anyway .. lucky for us because because the shaders won't
compile on ES2 (which does not even have a `out` keyword).