### PR TITLE
linux binary: strip and add a tarball

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -177,6 +177,7 @@ jobs:
           assets: |
             $(Build.SourcesDirectory)/*.zip
             $(Build.SourcesDirectory)/*.deb
+            $(Build.SourcesDirectory)/*.tar.xz
           title: "Nightly Builds"
           assetUploadMode: replace
           addChangeLog: false

--- a/ci/deploy.sh
+++ b/ci/deploy.sh
@@ -70,13 +70,14 @@ Description: Wez's Terminal Emulator.
  windows.
 Depends: libc6, libegl-mesa0, libxcb-icccm4, libxcb-ewmh2, libxcb-keysyms1, libxcb-xkb1, libxkbcommon0, libxkbcommon-x11-0, libfontconfig1, xdg-utils, libxcb-render0, libxcb-shape0, libx11-6, libegl1
 EOF
-        cp target/release/wezterm pkg/debian/usr/bin
+        install -Dsm755 target/release/wezterm pkg/debian/usr/bin
         if [[ "$BUILD_REASON" == "Schedule" ]] ; then
           debname=wezterm-nightly
         else
           debname=wezterm-$TAG_NAME
         fi
         fakeroot dpkg-deb --build pkg/debian $debname.deb
+        tar cJf $debname.tar.xz -C pkg/debian/usr/bin wezterm
         rm -rf pkg
       ;;
     esac


### PR DESCRIPTION
Following #46, this patch tries to

1. strip the binary in deb release (31M => 4.1M)
2. create a tarball for other distribution to use. I expect it runs on more distributions since it references only a few system libraries that don't bump their soname often. It requires glibc >= 2.18 however.

I'm not familiar with Azure so I hope this change works.