### PR TITLE
link against system libraries when WEZRERM_SYSDEPS envvar is set to 1

### DIFF
--- a/deps/freetype/build.rs
+++ b/deps/freetype/build.rs
@@ -74,9 +74,16 @@ fn freetype() {
 }
 
 fn main() {
-    zlib();
-    libpng();
-    freetype();
+    println!("cargo:rerun-if-env-changed=WEZRERM_SYSDEPS");
+    if cfg!(unix) && env::var("WEZRERM_SYSDEPS").map(|x| x == "1").unwrap_or(false) {
+        println!("cargo:rustc-link-lib=z");
+        println!("cargo:rustc-link-lib=png");
+        println!("cargo:rustc-link-lib=freetype");
+    } else {
+        zlib();
+        libpng();
+        freetype();
+    }
     let out_dir = env::var("OUT_DIR").unwrap();
     println!("cargo:outdir={}", out_dir);
 }

--- a/deps/harfbuzz/build.rs
+++ b/deps/harfbuzz/build.rs
@@ -45,7 +45,12 @@ fn emit_libdirs(p: &Path) {
 }
 
 fn main() {
-    harfbuzz();
+    println!("cargo:rerun-if-env-changed=WEZRERM_SYSDEPS");
+    if cfg!(unix) && env::var("WEZRERM_SYSDEPS").map(|x| x == "1").unwrap_or(false) {
+        println!("cargo:rustc-link-lib=harfbuzz");
+    } else {
+        harfbuzz();
+    }
     let out_dir = env::var("OUT_DIR").unwrap();
     println!("cargo:outdir={}", out_dir);
 }


### PR DESCRIPTION
Following #46, this patch makes it possible to use system libraries instead.

I don't know how well this will work on different distributions but it works on Arch, and freetype2 (and related) API should be stable enough.