### PR TITLE
Add color palette to RenderableState

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -927,6 +927,13 @@ impl Config {
 
         Ok(cmd)
     }
+
+    pub fn palette(&self) -> term::color::ColorPalette {
+        self.colors
+            .as_ref()
+            .map(Into::into)
+            .unwrap_or_else(Default::default)
+    }
 }
 
 #[derive(Debug, Deserialize, Clone)]
@@ -948,8 +955,8 @@ pub struct Palette {
     pub brights: Option<[RgbColor; 8]>,
 }
 
-impl From<Palette> for term::color::ColorPalette {
-    fn from(cfg: Palette) -> term::color::ColorPalette {
+impl From<&Palette> for term::color::ColorPalette {
+    fn from(cfg: &Palette) -> term::color::ColorPalette {
         let mut p = term::color::ColorPalette::default();
         macro_rules! apply_color {
             ($name:ident) => {
@@ -976,5 +983,11 @@ impl From<Palette> for term::color::ColorPalette {
             }
         }
         p
+    }
+}
+
+impl From<Palette> for term::color::ColorPalette {
+    fn from(cfg: Palette) -> term::color::ColorPalette {
+        (&cfg).into()
     }
 }

--- a/src/server/domain.rs
+++ b/src/server/domain.rs
@@ -179,8 +179,9 @@ impl Domain for ClientDomain {
 
             result.tab_id
         };
-        let tab: Rc<dyn Tab> = Rc::new(ClientTab::new(&inner, remote_tab_id, size));
         let mux = Mux::get().unwrap();
+        let palette = mux.config().palette();
+        let tab: Rc<dyn Tab> = Rc::new(ClientTab::new(&inner, remote_tab_id, size, palette));
         mux.add_tab(&tab)?;
         mux.add_tab_to_window(&tab, window)?;
 
@@ -189,6 +190,7 @@ impl Domain for ClientDomain {
 
     fn attach(&self) -> Fallible<()> {
         let mux = Mux::get().unwrap();
+        let palette = mux.config().palette();
         let client = match &self.config {
             ClientDomainConfig::Unix(unix) => {
                 let initial = true;
@@ -215,7 +217,12 @@ impl Domain for ClientDomain {
                 entry.window_id,
                 entry.title
             );
-            let tab: Rc<dyn Tab> = Rc::new(ClientTab::new(&inner, entry.tab_id, entry.size));
+            let tab: Rc<dyn Tab> = Rc::new(ClientTab::new(
+                &inner,
+                entry.tab_id,
+                entry.size,
+                palette.clone(),
+            ));
             mux.add_tab(&tab)?;
 
             if let Some(local_window_id) = inner.remote_to_local_window(entry.window_id) {

--- a/src/server/tab.rs
+++ b/src/server/tab.rs
@@ -137,7 +137,12 @@ pub struct ClientTab {
 }
 
 impl ClientTab {
-    pub fn new(client: &Arc<ClientInner>, remote_tab_id: TabId, size: PtySize) -> Self {
+    pub fn new(
+        client: &Arc<ClientInner>,
+        remote_tab_id: TabId,
+        size: PtySize,
+        palette: ColorPalette,
+    ) -> Self {
         let local_tab_id = alloc_tab_id();
         let writer = TabWriter {
             client: Arc::clone(client),
@@ -170,6 +175,7 @@ impl ClientTab {
                 selection_range,
                 something_changed,
                 highlight,
+                palette,
             }),
         };
 
@@ -295,7 +301,7 @@ impl Tab for ClientTab {
     }
 
     fn palette(&self) -> ColorPalette {
-        Default::default()
+        self.renderable.borrow().inner.borrow().palette.clone()
     }
 
     fn domain_id(&self) -> DomainId {
@@ -327,6 +333,7 @@ struct RenderableInner {
     selection_range: Arc<Mutex<Option<SelectionRange>>>,
     something_changed: Arc<AtomicBool>,
     highlight: Arc<Mutex<Option<Arc<Hyperlink>>>>,
+    palette: ColorPalette,
 }
 
 struct RenderableState {


### PR DESCRIPTION
`ClientTab` was returning the default palette since it doesn't really have `ColorPalette` stored anywhere. We can actually get a copy of `ColorPalette` when we create `ClientTab`s from `Mux`, and we can store it in the `RenderableState`. (As `LocalTab` stores it in `TerminalState`, I didn't look into why but I guess it is a state because we can change the color palette on the fly.)

----

As a result, now running WezTerm with `connect sb` can show me the correct palette configured in my local WezTerm configuration.
﻿
<img width="752" alt="image" src="https://user-images.githubusercontent.com/409951/68185438-5df33100-ff56-11e9-8c7a-3f0b901e2fe0.png">
