### PR TITLE
Support GNUReadline-style Alt-Backspace

### DIFF
--- a/term/src/terminalstate.rs
+++ b/term/src/terminalstate.rs
@@ -846,6 +846,7 @@ impl TerminalState {
         let to_send = match (key, ctrl, alt, shift, self.application_cursor_keys) {
             (Tab, ..) => "\t",
             (Enter, ..) => "\r",
+            (Backspace, _, ALT, ..) => "\x1b\x08",
             (Backspace, ..) => "\x08",
             (Escape, ..) => "\x1b",
             // Delete


### PR DESCRIPTION
Alt-Backspace is the GNUReadline-style shortcut for kill-previous-word.
In wezterm, this currently doesn't work, since this gets trapped by the generic `Backspace` match case.
This diff adds a more specific case for when Backspace is combined with Alt to produce the correct sequence.

This is definitely a hack and there should probably be a more general solution for GNUReadline combinations, but this solves the immediate problem.