### PR TITLE
Drop unnecessary mut from WindowsTerminalWaker::wake

### DIFF
--- a/termwiz/src/terminal/windows.rs
+++ b/termwiz/src/terminal/windows.rs
@@ -443,7 +443,7 @@ pub struct WindowsTerminalWaker {
 }
 
 impl WindowsTerminalWaker {
-    pub fn wake(&mut self) -> IoResult<()> {
+    pub fn wake(&self) -> IoResult<()> {
         self.handle.set()?;
         Ok(())
     }


### PR DESCRIPTION
This matches `UnixTerminalWaker`.