### PR TITLE
CI: remove --target from windows build

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -47,13 +47,13 @@ jobs:
         key: ${{ matrix.os }}-${{ matrix.rust_toolchain }}-cargo-build-target-${{ hashFiles('Cargo.lock') }}
     - name: Build
       shell: cmd
-      run: cargo build --all --release --target ${{ matrix.rust_toolchain }}
+      run: cargo build --all --release
     - name: Test
       shell: cmd
-      run: cargo test --all --release --target ${{ matrix.rust_toolchain }}
+      run: cargo test --all --release
     - name: Package
       shell: cmd
-      run: bash ci/deploy.sh target/x86_64-pc-windows-msvc
+      run: bash ci/deploy.sh
     - name: Move Windows Package
       shell: bash
       run: |


### PR DESCRIPTION
I'd like to try to converge on fewer differences in the workflow files,
so let's see if this works.