### PR TITLE
CI: target older macos versions

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -16,6 +16,7 @@ fn main() {
         }
     }
     println!("cargo:rustc-env=WEZTERM_CI_TAG={}", ci_tag);
+    println!("cargo:rustc-env=MACOSX_DEPLOYMENT_TARGET=10.9");
 
     #[cfg(windows)]
     embed_resource::compile("assets/windows/resource.rc");


### PR DESCRIPTION
I'm just randomly picking 10.9 to see if it even builds... if that
doesn't work out I'll probably just pick 10.14

refs: https://github.com/wez/wezterm/issues/128