### PR TITLE
Make some termwiz deps optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ ssh2 = "0.7"
 structopt = "0.3"
 tabout = { path = "tabout" }
 term = { path = "term" }
-termwiz = { path = "termwiz"}
+termwiz = { path = "termwiz" }
 textwrap = "0.11"
 toml = "0.4"
 unicode-normalization = "0.1"

--- a/termwiz/Cargo.toml
+++ b/termwiz/Cargo.toml
@@ -14,7 +14,6 @@ readme = "README.md"
 base64 = "0.10"
 bitflags = "1.0"
 cassowary = {version="0.3", optional=true}
-derive_builder = "0.7"
 anyhow = "1.0"
 filedescriptor = { version="0.7", path = "../filedescriptor" }
 fnv = {version="1.0", optional=true}

--- a/termwiz/Cargo.toml
+++ b/termwiz/Cargo.toml
@@ -25,7 +25,6 @@ memmem = "0.1"
 num = "0.2"
 num-traits = "0.2"
 ordered-float = "1.0"
-palette = "0.5"
 regex = "0.2"
 semver = "0.9"
 serde = {version="1.0", features = ["rc", "derive"]}

--- a/termwiz/Cargo.toml
+++ b/termwiz/Cargo.toml
@@ -24,7 +24,7 @@ memmem = "0.1"
 num = "0.2"
 num-traits = "0.2"
 ordered-float = "1.0"
-regex = "0.2"
+regex = "1"
 semver = "0.9"
 serde = {version="1.0", features = ["rc", "derive"]}
 smallvec = "0.6"

--- a/termwiz/src/lib.rs
+++ b/termwiz/src/lib.rs
@@ -46,6 +46,7 @@ pub mod input;
 pub mod istty;
 pub mod keymap;
 pub mod lineedit;
+mod macros;
 mod readbuf;
 pub mod render;
 pub mod surface;

--- a/termwiz/src/lineedit/mod.rs
+++ b/termwiz/src/lineedit/mod.rs
@@ -34,12 +34,11 @@
 //! Ctrl-W        | Delete word leading up to cursor
 //! Alt-b, Alt-Left | Move the cursor backwards one word
 //! Alt-f, Alt-Right | Move the cursor forwards one word
-use crate::caps::{Capabilities, ProbeHintsBuilder};
+use crate::caps::{Capabilities, ProbeHints};
 use crate::cell::unicode_column_width;
 use crate::input::{InputEvent, KeyCode, KeyEvent, Modifiers};
 use crate::surface::{Change, Position};
 use crate::terminal::{new_terminal, Terminal};
-use anyhow::Error;
 use unicode_segmentation::GraphemeCursor;
 
 mod actions;
@@ -118,14 +117,12 @@ impl<T: Terminal> LineEditor<T> {
     /// editor:
     ///
     /// ```no_run
-    /// use termwiz::caps::{Capabilities, ProbeHintsBuilder};
+    /// use termwiz::caps::{Capabilities, ProbeHints};
     /// use termwiz::terminal::new_terminal;
     /// use anyhow::Error;
     /// // Disable mouse input in the line editor
-    /// let hints = ProbeHintsBuilder::new_from_env()
-    ///     .mouse_reporting(Some(false))
-    ///     .build()
-    ///     .map_err(Error::msg)?;
+    /// let hints = ProbeHints::new_from_env()
+    ///     .mouse_reporting(Some(false));
     /// let caps = Capabilities::new_with_hints(hints)?;
     /// let terminal = new_terminal(caps)?;
     /// # Ok::<(), Error>(())
@@ -561,10 +558,7 @@ impl<T: Terminal> LineEditor<T> {
 /// Create a `Terminal` with the recommended settings, and use that
 /// to create a `LineEditor` instance.
 pub fn line_editor() -> anyhow::Result<LineEditor<impl Terminal>> {
-    let hints = ProbeHintsBuilder::new_from_env()
-        .mouse_reporting(Some(false))
-        .build()
-        .map_err(Error::msg)?;
+    let hints = ProbeHints::new_from_env().mouse_reporting(Some(false));
     let caps = Capabilities::new_with_hints(hints)?;
     let terminal = new_terminal(caps)?;
     Ok(LineEditor::new(terminal))

--- a/termwiz/src/macros.rs
+++ b/termwiz/src/macros.rs
@@ -1,0 +1,30 @@
+#[doc(hidden)]
+#[macro_export]
+macro_rules! builder {
+    (
+        $( #[ $( $meta:tt )* ] )*
+        $vis:vis struct $name:ident {
+            $(
+                $( #[doc=$doc:expr] )*
+                $field:ident : $type:ty,
+            )*
+        }
+    ) => {
+        $( #[ $( $meta )* ] )*
+        $vis struct $name {
+            $(
+                $( #[doc=$doc] )*
+                $field : $type,
+            )*
+        }
+
+        impl $name {
+            $(
+                pub fn $field(mut self, value: $type) -> Self {
+                    self.$field = value;
+                    self
+                }
+            )*
+        }
+    }
+}

--- a/termwiz/src/render/terminfo.rs
+++ b/termwiz/src/render/terminfo.rs
@@ -671,7 +671,7 @@ impl TerminfoRenderer {
 #[cfg(all(test, unix))]
 mod test {
     use super::*;
-    use crate::caps::ProbeHintsBuilder;
+    use crate::caps::ProbeHints;
     use crate::color::{AnsiColor, ColorAttribute, RgbColor};
     use crate::escape::parser::Parser;
     use crate::escape::{Action, Esc, EscCode};
@@ -692,25 +692,15 @@ mod test {
         // Load our own compiled data so that the tests have an
         // environment that doesn't vary machine by machine.
         let data = include_bytes!("../../data/xterm-256color");
-        Capabilities::new_with_hints(
-            ProbeHintsBuilder::default()
-                .terminfo_db(Some(
-                    terminfo::Database::from_buffer(data.as_ref()).unwrap(),
-                ))
-                .build()
-                .unwrap(),
-        )
+        Capabilities::new_with_hints(ProbeHints::default().terminfo_db(Some(
+            terminfo::Database::from_buffer(data.as_ref()).unwrap(),
+        )))
         .unwrap()
     }
 
     fn no_terminfo_all_enabled() -> Capabilities {
-        Capabilities::new_with_hints(
-            ProbeHintsBuilder::default()
-                .color_level(Some(ColorLevel::TrueColor))
-                .build()
-                .unwrap(),
-        )
-        .unwrap()
+        Capabilities::new_with_hints(ProbeHints::default().color_level(Some(ColorLevel::TrueColor)))
+            .unwrap()
     }
 
     struct FakeTty {


### PR DESCRIPTION
The main issue is `palette`, which does not build with buck. I also replaced `derive_builder` with an ad-hoc macro.