### PR TITLE
Cleanup: let structopt parse ssh user/host/port instead of doing it by hand

### DIFF
--- a/src/config/tls.rs
+++ b/src/config/tls.rs
@@ -85,6 +85,6 @@ impl TlsDomainClient {
     pub fn ssh_parameters(&self) -> Option<anyhow::Result<SshParameters>> {
         self.bootstrap_via_ssh
             .as_ref()
-            .map(|user_at_host_and_port| SshParameters::parse(user_at_host_and_port))
+            .map(|user_at_host_and_port| user_at_host_and_port.parse())
     }
 }


### PR DESCRIPTION
Implement FromStr and Display for SshParameters, so that they can be
parsed and displayed in the standard way.

The motivation for this is that I want to add gateway hosts to the ssh command, and
would like to be able to add something like `gateway: Vec<SshParamters>` to SshCommand
to do it.