### PR TITLE
Add support for more sequences to the input parser's keymap

### DIFF
--- a/termwiz/src/input.rs
+++ b/termwiz/src/input.rs
@@ -497,13 +497,13 @@ impl InputParser {
             (";7", Modifiers::CTRL | Modifiers::ALT),
             (";8", Modifiers::CTRL | Modifiers::ALT | Modifiers::SHIFT),
         ];
-        // iTerm2 will use a few of the these (with `meta` standing in for
-        // option) in both the "default" and "xterm default" configurations.
-        //
-        // According to https://invisible-island.net/xterm/ctlseqs/ctlseqs.html
-        // (search for `alwaysUseMods`, and scroll up a little) there are
-        // configurations under which xterm will send them as well, as well as
-        // some older obscure terminals.
+        // Meta is theoretically a distinct modifier of its own, but modern systems don't
+        // have a dedicated Meta key and use the Alt/Option key instead.  The mapping
+        // below is reproduced from the xterm documentation from a time where it was
+        // possible to hold both Alt and Meta down as modifiers.  Since we define meta to
+        // ALT, the use of `meta | ALT` in the table below appears to be redundant,
+        // but makes it easier to see that the mapping matches xterm when viewing
+        // its documentation.
         let meta = Modifiers::ALT;
         let meta_modifier_combos = &[
             (";9", meta),


### PR DESCRIPTION
We talked about this in gitter. I didn't end up adding the changes to Capabilities to make this work for Terminal.app.

(I don't feel like asking people to update their terminfo on mac is at all practical (I'm pretty sure it only works here because we don't use system ncurses -- AFAICT system ncurses on mac is compiled to ignore `$TERMINFO`, `$TERMINFO_DIRS` -- but that said yeah, not sure, adding it to Capabilities feels wrong given that it *is* something nominally reported by terminfo)

This doesn't have any tests. For this kind of thing it feels like it might be more effective to add a script similar to examples/key_tester.rs that instead recorded what escape sequences were parsed in what way -- this way you could record a sequence of interactions, save it to a test file, and then ensure replaying those is parsed as desired.

That said doing that looks like it would be a pain right now (no way to hook into i/o for UnixTerminal) so I didn't bother.