### PR TITLE
Preserve clipboard contents on single left click

### DIFF
--- a/src/frontend/gui/termwindow.rs
+++ b/src/frontend/gui/termwindow.rs
@@ -2792,7 +2792,6 @@ impl TermWindow {
                         // Initiate a selection
                         self.selection(tab.tab_id())
                             .begin(SelectionCoordinate { x, y: stable_row });
-                        self.window.as_ref().unwrap().set_clipboard(String::new());
                     } else {
                         // Extend selection
                         let end = SelectionCoordinate { x, y: stable_row };
@@ -2825,7 +2824,7 @@ impl TermWindow {
                                 log::error!("failed to open {}: {:?}", link.uri(), err);
                             }
                         });
-                    } else {
+                    } else if !text.is_empty() {
                         self.window.as_ref().unwrap().set_clipboard(text);
                         context.invalidate();
                     }


### PR DESCRIPTION
Previously, left clicking into a wezterm window would empty the clipboard, even if the mouse wasn't dragged.

This PR changes that behavior; now the clipboard contents are preserved unless the selection is non-empty.

This required two changes; one on mouse press and one on mouse release. I'm calling this out because I'm not sure why the clipboard contents were set to a new String on left mouse press before.

I tested this change by running in lldb with a breakpoint on [this line](https://github.com/wez/wezterm/blob/6d5a7ad143872374b0fc480d529ea619f6d850af/src/frontend/gui/termwindow.rs#L2748), clicking into the terminal, and stepping through, validating the clipboard contents before and after.