### PR TITLE
ci: change git download URL

### DIFF
--- a/.github/workflows/gen_centos7.yml
+++ b/.github/workflows/gen_centos7.yml
@@ -31,7 +31,7 @@ jobs:
             if test ! -x /usr/local/git/bin/git ; then
                 cd /tmp
                 wget https://github.com/git/git/archive/v2.26.2.tar.gz
-                tar xzf git-2.26.2.tar.gz
+                tar xzf v2.26.2.tar.gz
                 cd git-2.26.2
                 make prefix=/usr/local/git install
             fi

--- a/.github/workflows/gen_centos7.yml
+++ b/.github/workflows/gen_centos7.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/cache@v1
       with:
          path: "/usr/local/git"
-         key: "centos7-git-2.25.0"
+         key: "centos7-git-2.26.2"
     - name: "Install Git from source"
       shell: bash
       run: |
@@ -30,9 +30,9 @@ jobs:
             
             if test ! -x /usr/local/git/bin/git ; then
                 cd /tmp
-                wget https://mirrors.edge.kernel.org/pub/software/scm/git/git-2.25.0.tar.gz
-                tar xzf git-2.25.0.tar.gz
-                cd git-2.25.0
+                wget https://github.com/git/git/archive/v2.26.2.tar.gz
+                tar xzf git-2.26.2.tar.gz
+                cd git-2.26.2
                 make prefix=/usr/local/git install
             fi
             

--- a/.github/workflows/gen_centos7_continuous.yml
+++ b/.github/workflows/gen_centos7_continuous.yml
@@ -28,7 +28,7 @@ jobs:
             if test ! -x /usr/local/git/bin/git ; then
                 cd /tmp
                 wget https://github.com/git/git/archive/v2.26.2.tar.gz
-                tar xzf git-2.26.2.tar.gz
+                tar xzf v2.26.2.tar.gz
                 cd git-2.26.2
                 make prefix=/usr/local/git install
             fi

--- a/.github/workflows/gen_centos7_continuous.yml
+++ b/.github/workflows/gen_centos7_continuous.yml
@@ -17,7 +17,7 @@ jobs:
       uses: actions/cache@v1
       with:
          path: "/usr/local/git"
-         key: "centos7-git-2.25.0"
+         key: "centos7-git-2.26.2"
     - name: "Install Git from source"
       shell: bash
       run: |
@@ -27,9 +27,9 @@ jobs:
             
             if test ! -x /usr/local/git/bin/git ; then
                 cd /tmp
-                wget https://mirrors.edge.kernel.org/pub/software/scm/git/git-2.25.0.tar.gz
-                tar xzf git-2.25.0.tar.gz
-                cd git-2.25.0
+                wget https://github.com/git/git/archive/v2.26.2.tar.gz
+                tar xzf git-2.26.2.tar.gz
+                cd git-2.26.2
                 make prefix=/usr/local/git install
             fi
             

--- a/.github/workflows/gen_centos7_tag.yml
+++ b/.github/workflows/gen_centos7_tag.yml
@@ -28,7 +28,7 @@ jobs:
             if test ! -x /usr/local/git/bin/git ; then
                 cd /tmp
                 wget https://github.com/git/git/archive/v2.26.2.tar.gz
-                tar xzf git-2.26.2.tar.gz
+                tar xzf v2.26.2.tar.gz
                 cd git-2.26.2
                 make prefix=/usr/local/git install
             fi

--- a/.github/workflows/gen_centos7_tag.yml
+++ b/.github/workflows/gen_centos7_tag.yml
@@ -18,7 +18,7 @@ jobs:
       uses: actions/cache@v1
       with:
          path: "/usr/local/git"
-         key: "centos7-git-2.25.0"
+         key: "centos7-git-2.26.2"
     - name: "Install Git from source"
       shell: bash
       run: |
@@ -27,9 +27,9 @@ jobs:
             
             if test ! -x /usr/local/git/bin/git ; then
                 cd /tmp
-                wget https://mirrors.edge.kernel.org/pub/software/scm/git/git-2.25.0.tar.gz
-                tar xzf git-2.25.0.tar.gz
-                cd git-2.25.0
+                wget https://github.com/git/git/archive/v2.26.2.tar.gz
+                tar xzf git-2.26.2.tar.gz
+                cd git-2.26.2
                 make prefix=/usr/local/git install
             fi
             

--- a/.github/workflows/gen_debian9.12.yml
+++ b/.github/workflows/gen_debian9.12.yml
@@ -27,7 +27,7 @@ jobs:
       uses: actions/cache@v1
       with:
          path: "/usr/local/git"
-         key: "debian9.12-git-2.25.0"
+         key: "debian9.12-git-2.26.2"
     - name: "Install Git from source"
       shell: bash
       run: |
@@ -36,9 +36,9 @@ jobs:
             
             if test ! -x /usr/local/git/bin/git ; then
                 cd /tmp
-                wget https://mirrors.edge.kernel.org/pub/software/scm/git/git-2.25.0.tar.gz
-                tar xzf git-2.25.0.tar.gz
-                cd git-2.25.0
+                wget https://github.com/git/git/archive/v2.26.2.tar.gz
+                tar xzf git-2.26.2.tar.gz
+                cd git-2.26.2
                 make prefix=/usr/local/git install
             fi
             

--- a/.github/workflows/gen_debian9.12.yml
+++ b/.github/workflows/gen_debian9.12.yml
@@ -37,7 +37,7 @@ jobs:
             if test ! -x /usr/local/git/bin/git ; then
                 cd /tmp
                 wget https://github.com/git/git/archive/v2.26.2.tar.gz
-                tar xzf git-2.26.2.tar.gz
+                tar xzf v2.26.2.tar.gz
                 cd git-2.26.2
                 make prefix=/usr/local/git install
             fi

--- a/.github/workflows/gen_debian9.12_continuous.yml
+++ b/.github/workflows/gen_debian9.12_continuous.yml
@@ -42,7 +42,7 @@ jobs:
             if test ! -x /usr/local/git/bin/git ; then
                 cd /tmp
                 wget https://github.com/git/git/archive/v2.26.2.tar.gz
-                tar xzf git-2.26.2.tar.gz
+                tar xzf v2.26.2.tar.gz
                 cd git-2.26.2
                 make prefix=/usr/local/git install
             fi

--- a/.github/workflows/gen_debian9.12_continuous.yml
+++ b/.github/workflows/gen_debian9.12_continuous.yml
@@ -31,7 +31,7 @@ jobs:
       uses: actions/cache@v1
       with:
          path: "/usr/local/git"
-         key: "debian9.12-git-2.25.0"
+         key: "debian9.12-git-2.26.2"
     - name: "Install Git from source"
       shell: bash
       run: |
@@ -41,9 +41,9 @@ jobs:
             
             if test ! -x /usr/local/git/bin/git ; then
                 cd /tmp
-                wget https://mirrors.edge.kernel.org/pub/software/scm/git/git-2.25.0.tar.gz
-                tar xzf git-2.25.0.tar.gz
-                cd git-2.25.0
+                wget https://github.com/git/git/archive/v2.26.2.tar.gz
+                tar xzf git-2.26.2.tar.gz
+                cd git-2.26.2
                 make prefix=/usr/local/git install
             fi
             

--- a/.github/workflows/gen_debian9.12_tag.yml
+++ b/.github/workflows/gen_debian9.12_tag.yml
@@ -34,7 +34,7 @@ jobs:
             if test ! -x /usr/local/git/bin/git ; then
                 cd /tmp
                 wget https://github.com/git/git/archive/v2.26.2.tar.gz
-                tar xzf git-2.26.2.tar.gz
+                tar xzf v2.26.2.tar.gz
                 cd git-2.26.2
                 make prefix=/usr/local/git install
             fi

--- a/.github/workflows/gen_debian9.12_tag.yml
+++ b/.github/workflows/gen_debian9.12_tag.yml
@@ -24,7 +24,7 @@ jobs:
       uses: actions/cache@v1
       with:
          path: "/usr/local/git"
-         key: "debian9.12-git-2.25.0"
+         key: "debian9.12-git-2.26.2"
     - name: "Install Git from source"
       shell: bash
       run: |
@@ -33,9 +33,9 @@ jobs:
             
             if test ! -x /usr/local/git/bin/git ; then
                 cd /tmp
-                wget https://mirrors.edge.kernel.org/pub/software/scm/git/git-2.25.0.tar.gz
-                tar xzf git-2.25.0.tar.gz
-                cd git-2.25.0
+                wget https://github.com/git/git/archive/v2.26.2.tar.gz
+                tar xzf git-2.26.2.tar.gz
+                cd git-2.26.2
                 make prefix=/usr/local/git install
             fi
             

--- a/ci/generate-workflows.py
+++ b/ci/generate-workflows.py
@@ -155,7 +155,7 @@ class Target(object):
     def install_git(self):
         steps = []
         if self.bootstrap_git:
-            GIT_VERS = "2.25.0"
+            GIT_VERS = "2.26.2"
             steps.append(
                 CacheStep(
                     "Cache Git installation",
@@ -177,7 +177,7 @@ class Target(object):
 
 if test ! -x /usr/local/git/bin/git ; then
     cd /tmp
-    wget https://mirrors.edge.kernel.org/pub/software/scm/git/git-{GIT_VERS}.tar.gz
+    wget https://github.com/git/git/archive/v{GIT_VERS}.tar.gz
     tar xzf git-{GIT_VERS}.tar.gz
     cd git-{GIT_VERS}
     make prefix=/usr/local/git install

--- a/ci/generate-workflows.py
+++ b/ci/generate-workflows.py
@@ -178,7 +178,7 @@ class Target(object):
 if test ! -x /usr/local/git/bin/git ; then
     cd /tmp
     wget https://github.com/git/git/archive/v{GIT_VERS}.tar.gz
-    tar xzf git-{GIT_VERS}.tar.gz
+    tar xzf v{GIT_VERS}.tar.gz
     cd git-{GIT_VERS}
     make prefix=/usr/local/git install
 fi


### PR DESCRIPTION
looks like the SSL cert for kernel.org expired today, breaking some
of our CI flows.

Let's try switching to github's mirror for git.