### PR TITLE
termwiz: add CursorVisibility

### DIFF
--- a/termwiz/src/render/terminfo.rs
+++ b/termwiz/src/render/terminfo.rs
@@ -7,7 +7,7 @@ use crate::escape::osc::{ITermDimension, ITermFileData, ITermProprietary, Operat
 use crate::escape::OneBased;
 use crate::image::TextureCoordinate;
 use crate::render::RenderTty;
-use crate::surface::{Change, CursorShape, Position};
+use crate::surface::{Change, CursorShape, CursorVisibility, Position};
 use std::io::Write;
 use terminfo::{capability as cap, Capability as TermInfoCapability};
 
@@ -553,6 +553,18 @@ impl TerminfoRenderer {
                         };
                         if let Some(set) = self.get_capability::<cap::SetCursorStyle>() {
                             set.expand().kind(param).to(out.by_ref())?;
+                        }
+                    }
+                },
+                Change::CursorVisibility(visibility) => match visibility {
+                    CursorVisibility::Visible => {
+                        if let Some(show) = self.get_capability::<cap::CursorVisible>() {
+                            show.expand().to(out.by_ref())?;
+                        }
+                    }
+                    CursorVisibility::Hidden => {
+                        if let Some(hide) = self.get_capability::<cap::CursorInvisible>() {
+                            hide.expand().to(out.by_ref())?;
                         }
                     }
                 },

--- a/termwiz/src/render/windows.rs
+++ b/termwiz/src/render/windows.rs
@@ -408,6 +408,7 @@ impl WindowsConsoleRenderer {
                 }
                 Change::CursorColor(_color) => {}
                 Change::CursorShape(_shape) => {}
+                Change::CursorVisibility(_visibility) => {}
                 Change::Image(image) => {
                     // Images are not supported, so just blank out the cells and
                     // move the cursor to the right spot

--- a/termwiz/src/surface/change.rs
+++ b/termwiz/src/surface/change.rs
@@ -1,7 +1,7 @@
 use crate::cell::{unicode_column_width, AttributeChange, CellAttributes};
 use crate::color::ColorAttribute;
 pub use crate::image::{ImageData, TextureCoordinate};
-use crate::surface::{CursorShape, Position};
+use crate::surface::{CursorShape, CursorVisibility, Position};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use unicode_segmentation::UnicodeSegmentation;
@@ -43,6 +43,8 @@ pub enum Change {
     CursorColor(ColorAttribute),
     /// Change the cursor shape
     CursorShape(CursorShape),
+    /// Change the cursor visibility
+    CursorVisibility(CursorVisibility),
     /// Place an image at the current cursor position.
     /// The image defines the dimensions in cells.
     /// TODO: check iterm rendering behavior when the image is larger than the width of the screen.
@@ -184,6 +186,7 @@ impl ChangeSequence {
             | Change::Attribute(_)
             | Change::CursorColor(_)
             | Change::CursorShape(_)
+            | Change::CursorVisibility(_)
             | Change::ClearToEndOfLine(_)
             | Change::Title(_)
             | Change::ClearToEndOfScreen(_) => {}

--- a/termwiz/src/surface/mod.rs
+++ b/termwiz/src/surface/mod.rs
@@ -29,6 +29,18 @@ pub enum Position {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum CursorVisibility {
+    Hidden,
+    Visible,
+}
+
+impl Default for CursorVisibility {
+    fn default() -> CursorVisibility {
+        CursorVisibility::Visible
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum CursorShape {
     Hidden,
     Default,
@@ -43,6 +55,15 @@ pub enum CursorShape {
 impl Default for CursorShape {
     fn default() -> CursorShape {
         CursorShape::Default
+    }
+}
+
+impl From<CursorVisibility> for CursorShape {
+    fn from(visibility: CursorVisibility) -> CursorShape {
+        match visibility {
+            CursorVisibility::Hidden => CursorShape::Hidden,
+            CursorVisibility::Visible => CursorShape::Default,
+        }
     }
 }
 
@@ -268,6 +289,7 @@ impl Surface {
             Change::ClearToEndOfScreen(color) => self.clear_eos(*color),
             Change::CursorColor(color) => self.cursor_color = *color,
             Change::CursorShape(shape) => self.cursor_shape = *shape,
+            Change::CursorVisibility(visibility) => self.cursor_shape = (*visibility).into(),
             Change::Image(image) => self.add_image(image),
             Change::Title(text) => self.title = text.to_owned(),
             Change::ScrollRegionUp {

--- a/termwiz/src/terminal/unix.rs
+++ b/termwiz/src/terminal/unix.rs
@@ -492,8 +492,10 @@ impl Drop for UnixTerminal {
                 .unwrap();
             };
         }
-        self.render(&[Change::CursorShape(crate::surface::CursorShape::Default)])
-            .ok();
+        self.render(&[Change::CursorVisibility(
+            crate::surface::CursorVisibility::Visible,
+        )])
+        .ok();
         if self.caps.bracketed_paste() {
             decreset!(BracketedPaste);
         }


### PR DESCRIPTION
Some applications want to control the cursor visibility, without affecting
cursor shape.  Provide the `CursorVisibility` change type for this purpose.

Use this when dropping `UnixTerminal` to ensure the cursor is visible
without affecting the user's cursor shape.