### PR TITLE
portable_pty - support for x86_64-unknown-freebsd target

### DIFF
--- a/pty/src/unix.rs
+++ b/pty/src/unix.rs
@@ -107,7 +107,14 @@ impl PtyFd {
             ws_ypixel: size.pixel_height,
         };
 
-        if unsafe { libc::ioctl(self.0.as_raw_fd(), libc::TIOCSWINSZ, &ws_size as *const _) } != 0 {
+        if unsafe {
+            libc::ioctl(
+                self.0.as_raw_fd(),
+                libc::TIOCSWINSZ as _,
+                &ws_size as *const _,
+            )
+        } != 0
+        {
             bail!(
                 "failed to ioctl(TIOCSWINSZ): {:?}",
                 io::Error::last_os_error()
@@ -122,7 +129,7 @@ impl PtyFd {
         if unsafe {
             libc::ioctl(
                 self.0.as_raw_fd(),
-                libc::TIOCGWINSZ.into(),
+                libc::TIOCGWINSZ as _,
                 &mut size as *mut _,
             )
         } != 0

--- a/pty/src/unix.rs
+++ b/pty/src/unix.rs
@@ -119,7 +119,14 @@ impl PtyFd {
 
     fn get_size(&self) -> Result<PtySize, Error> {
         let mut size: winsize = unsafe { mem::zeroed() };
-        if unsafe { libc::ioctl(self.0.as_raw_fd(), libc::TIOCGWINSZ, &mut size as *mut _) } != 0 {
+        if unsafe {
+            libc::ioctl(
+                self.0.as_raw_fd(),
+                libc::TIOCGWINSZ.into(),
+                &mut size as *mut _,
+            )
+        } != 0
+        {
             bail!(
                 "failed to ioctl(TIOCGWINSZ): {:?}",
                 io::Error::last_os_error()


### PR DESCRIPTION
Compiling the portable-pty crate for `x86_64-unknown-freebsd` currently generates a build error:

```
error[E0308]: mismatched types
   --> /home/runner/.cargo/registry/src/github.com-1ecc6299db9ec823/portable-pty-0.3.0/src/unix.rs:122:53
    |
122 |         if unsafe { libc::ioctl(self.0.as_raw_fd(), libc::TIOCGWINSZ, &mut size as *mut _) } != 0 {
    |                                                     ^^^^^^^^^^^^^^^^
    |                                                     |
    |                                                     expected `u64`, found `u32`
    |                                                     help: you can convert an `u32` to `u64`: `libc::TIOCGWINSZ.into()`
```

Seems `libc::TIOCGWINSZ` is defined as u32 on some targets.