### PR TITLE
wezterm: Use high precision floats in glsl.

### DIFF
--- a/wezterm/src/gui/fragment.glsl
+++ b/wezterm/src/gui/fragment.glsl
@@ -1,4 +1,4 @@
-precision mediump float;
+precision highp float;
 
 in vec2 o_tex;
 in vec4 o_fg_color;

--- a/wezterm/src/gui/vertex.glsl
+++ b/wezterm/src/gui/vertex.glsl
@@ -1,4 +1,4 @@
-precision mediump float;
+precision highp float;
 in vec2 position;
 in vec2 adjust;
 in vec2 tex;


### PR DESCRIPTION
Using mediump precision in fragment and vertex shaders resulted in rendering
artifacts for fonts when running on NVIDIA GeForce GTX 1650.

fixes #295