### PR TITLE
lineedit: add a way to render previews

### DIFF
--- a/termwiz/src/lineedit/host.rs
+++ b/termwiz/src/lineedit/host.rs
@@ -49,6 +49,13 @@ pub trait LineEditorHost {
         vec![OutputElement::Text(prompt.to_owned())]
     }
 
+    /// Given a reference to the current line being edited, render a preview
+    /// of its outcome. The preview is cleared when the input is accepted,
+    /// or canceled.
+    fn render_preview(&self, _line: &str) -> Vec<OutputElement> {
+        Vec::new()
+    }
+
     /// Given a reference to the current line being edited and the position
     /// of the cursor, return the rendered form of the line as a sequence
     /// of `OutputElement` instances.


### PR DESCRIPTION
Make it possible to implement rendering previews in new lines, seen in
nodejs [1]. The preview is cleared when the line is accepted (Enter)
or canceled (Ctrl+C).

[1]: https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V12.md#repl-previews