### PR TITLE
Build fix for `no implementation for `&[u8] == std::vec::Vec<u8>`

### DIFF
--- a/wezterm-gui/src/gui/termwindow.rs
+++ b/wezterm-gui/src/gui/termwindow.rs
@@ -814,7 +814,7 @@ fn reload_background_image(
         Some(p) => match std::fs::read(p) {
             Ok(data) => {
                 if let Some(existing) = image {
-                    if existing.data() == data {
+                    if existing.data() == &*data {
                         return Some(Arc::clone(existing));
                     }
                 }


### PR DESCRIPTION
Full error
```
error[E0277]: can't compare `&[u8]` with `std::vec::Vec<u8>`
   --> wezterm-gui/src/gui/termwindow.rs:817:40
    |
817 |                     if existing.data() == data {
    |                                        ^^ no implementation for `&[u8] == std::vec::Vec<u8>`
    |
    = help: the trait `std::cmp::PartialEq<std::vec::Vec<u8>>` is not implemented for `&[u8]`

error: aborting due to previous error
```