### PR TITLE
Update matrix room url

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ This is a spare time project, so please bear with me.  There are a couple of cha
 * You can use the GitHub issue tracker to see if someone else has a similar issue, or to file a new one: <https://github.com/wez/wezterm/issues>
 * Start or join a thread in our [GitHub Discussions](https://github.com/wez/wezterm/discussions); if you have general
   questions or want to chat with other wezterm users, you're welcome here!
-* There is an [Element.io](https://app.element.io/#/room/#gitter_wezterm=2Flobby:matrix.org)
-  room for (potentially!) real time discussions; that is bridged from the
+* There is an [Matrix room via Element.io](https://app.element.io/#/room/#wezterm_lobby:gitter.im)
+  for (potentially!) real time discussions; that is bridged from the
   original [Gitter room](https://gitter.im/wezterm/Lobby) that has some longer
   term users and older discussions.
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This is a spare time project, so please bear with me.  There are a couple of cha
 * You can use the GitHub issue tracker to see if someone else has a similar issue, or to file a new one: <https://github.com/wez/wezterm/issues>
 * Start or join a thread in our [GitHub Discussions](https://github.com/wez/wezterm/discussions); if you have general
   questions or want to chat with other wezterm users, you're welcome here!
-* There is an [Matrix room via Element.io](https://app.element.io/#/room/#wezterm_lobby:gitter.im)
+* There is a [Matrix room via Element.io](https://app.element.io/#/room/#wezterm_lobby:gitter.im)
   for (potentially!) real time discussions; that is bridged from the
   original [Gitter room](https://gitter.im/wezterm/Lobby) that has some longer
   term users and older discussions.

--- a/docs/help.markdown
+++ b/docs/help.markdown
@@ -5,8 +5,8 @@ This is a spare time project, so please bear with me.  There are a couple of cha
 * You can use the GitHub issue tracker to see if someone else has a similar issue, or to file a new one: <https://github.com/wez/wezterm/issues>
 * Start or join a thread in our [GitHub Discussions](https://github.com/wez/wezterm/discussions); if you have general
   questions or want to chat with other wezterm users, you're welcome here!
-* There is an [Element.io](https://app.element.io/#/room/#gitter_wezterm=2Flobby:matrix.org)
-  room for (potentially!) real time discussions; that is bridged from the
+* There is a [Matrix room via Element.io](https://app.element.io/#/room/#wezterm_lobby:gitter.im)
+  for (potentially!) real time discussions; that is bridged from the
   original [Gitter room](https://gitter.im/wezterm/Lobby) that has some longer
   term users and older discussions.
 


### PR DESCRIPTION
It is using the new room name integration between matrix & gitter since they merged (see: https://matrix.org/blog/2020/09/30/welcoming-gitter-to-matrix)