### PR TITLE
Update snapshot tests to use k9@0.10.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1786,9 +1786,9 @@ dependencies = [
 
 [[package]]
 name = "k9"
-version = "0.3.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ccd792b32bf0403a0970175152bc795f2bf7de13218e218a62f6b271aa2478e"
+checksum = "3288a4d64e83c532d6abf9bde7ee98a7841041aaa13dbcc5e2a432c381562987"
 dependencies = [
  "anyhow",
  "colored",

--- a/term/Cargo.toml
+++ b/term/Cargo.toml
@@ -32,7 +32,7 @@ url = "2"
 [dev-dependencies]
 pretty_assertions = "0.6"
 pretty_env_logger = "0.4"
-k9 = "0.3"
+k9 = "0.10.0"
 
 [dependencies.termwiz]
 version = "0.11"

--- a/term/src/test/mod.rs
+++ b/term/src/test/mod.rs
@@ -357,9 +357,10 @@ fn test_semantic() {
         ],
     );
 
-    k9::assert_matches_inline_snapshot!(
-        format!("{:#?}", term.get_semantic_zones().unwrap()),
-        r##"[
+    k9::snapshot!(
+        term.get_semantic_zones().unwrap(),
+        "
+[
     SemanticZone {
         start_y: 0,
         start_x: 0,
@@ -367,7 +368,8 @@ fn test_semantic() {
         end_x: 9,
         semantic_type: Output,
     },
-]"##
+]
+"
     );
 
     term.print(format!(
@@ -411,9 +413,10 @@ fn test_semantic() {
             .set_semantic_type(SemanticType::Input);
     }
 
-    k9::assert_matches_inline_snapshot!(
-        format!("{:#?}", term.get_semantic_zones().unwrap()),
-        r##"[
+    k9::snapshot!(
+        term.get_semantic_zones().unwrap(),
+        "
+[
     SemanticZone {
         start_y: 0,
         start_x: 0,
@@ -442,7 +445,8 @@ fn test_semantic() {
         end_x: 8,
         semantic_type: Output,
     },
-]"##
+]
+"
     );
 
     assert_lines_equal(


### PR DESCRIPTION
I'm gradually improving snapshot testing macro devx in k9 and preparing
to ship v1. Before i do this i'm changing the inline snapshot macro to be
just `snapshot!()` that takes `Debug` trait an an arg and figures out
serialization of it.

this project has just a few snapshot tests and is prefect to test the migration (if that's ok)