### PR TITLE
add WezTerm-macos-* to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@
 /AppDir
 /WezTerm*.AppImage
 /WezTerm*.AppImage.zsync
+/WezTerm-macos-*
 /wezterm*-src.tar.gz
 /wezterm-linuxbrew.rb
 /wezterm.rb


### PR DESCRIPTION
Ignore the `WezTerm-macos-*` folders being created on **build**.