### PR TITLE
Instruct docs.rs to build with widgets and serde features

### DIFF
--- a/termwiz/Cargo.toml
+++ b/termwiz/Cargo.toml
@@ -35,6 +35,7 @@ vtparse = { version="0.3", path="../vtparse" }
 [features]
 widgets = ["cassowary", "fnv"]
 use_serde = ["serde"]
+docs = ["widgets", "use_serde"]
 
 [dev-dependencies]
 varbincode = "0.1"
@@ -57,3 +58,7 @@ features = [
     "synchapi",
 ]
 version = "0.3"
+
+[package.metadata.docs.rs]
+features = ["docs"]
+rustdoc-args = ["--cfg", "feature=\"docs\""]

--- a/termwiz/src/lib.rs
+++ b/termwiz/src/lib.rs
@@ -1,7 +1,7 @@
 //! # Terminal Wizardry
 //!
 //! This is a rust crate that provides a number of support functions
-//! for applications interesting in either displaying data to a terminal
+//! for applications interested in either displaying data to a terminal
 //! or in building a terminal emulator.
 //!
 //! It is currently in active development and subject to fairly wild


### PR DESCRIPTION
As seen in https://github.com/async-rs/async-std/blob/master/Cargo.toml#L20-L22

That way, docs.rs will have the `Widget` struct documentation available.