### PR TITLE
ci: generate universal binaries for macOS

### DIFF
--- a/.github/workflows/gen_macos.yml
+++ b/.github/workflows/gen_macos.yml
@@ -83,7 +83,7 @@ jobs:
       shell: bash
       run: |
             export MACOSX_DEPLOYMENT_TARGET=10.9
-            cargo --target x86_64-apple-darwin test --all --release
+            cargo test --target x86_64-apple-darwin --all --release
             
 
     - name: "Package"

--- a/.github/workflows/gen_macos.yml
+++ b/.github/workflows/gen_macos.yml
@@ -14,7 +14,7 @@ jobs:
   build:
     strategy:
       fail-fast: false
-    runs-on: "macos-latest"
+    runs-on: "macos-11.0"
     
     steps:
     - name: "checkout repo"
@@ -44,6 +44,13 @@ jobs:
          components: "rustfmt"
       env:
          ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
+    - name: "Install Rust (ARM)"
+      shell: bash
+      run: |
+            export MACOSX_DEPLOYMENT_TARGET=10.9
+            rustup target add aarch64-apple-darwin
+            
+
     - name: "Install System Deps"
       shell: bash
       run: |
@@ -58,18 +65,25 @@ jobs:
             cargo fmt --all -- --check
             
 
-    - name: "Build (Release mode)"
+    - name: "Build (Release mode Intel)"
       shell: bash
       run: |
             export MACOSX_DEPLOYMENT_TARGET=10.9
-            cargo build --all --release
+            cargo build --target x86_64-apple-darwin --all --release
+            
+
+    - name: "Build (Release mode ARM)"
+      shell: bash
+      run: |
+            export MACOSX_DEPLOYMENT_TARGET=10.9
+            cargo build --target aarch64-apple-darwin --all --release
             
 
     - name: "Test (Release mode)"
       shell: bash
       run: |
             export MACOSX_DEPLOYMENT_TARGET=10.9
-            cargo test --all --release
+            cargo --target x86_64-apple-darwin test --all --release
             
 
     - name: "Package"

--- a/.github/workflows/gen_macos_continuous.yml
+++ b/.github/workflows/gen_macos_continuous.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     strategy:
       fail-fast: false
-    runs-on: "macos-latest"
+    runs-on: "macos-11.0"
     
     steps:
     - name: "checkout repo"
@@ -44,6 +44,15 @@ jobs:
          components: "rustfmt"
       env:
          ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
+    - name: "Install Rust (ARM)"
+      shell: bash
+      run: |
+            export BUILD_REASON=Schedule
+            export MACOSX_DEPLOYMENT_TARGET=10.9
+            rustup target add aarch64-apple-darwin
+            
+            
+
     - name: "Install System Deps"
       shell: bash
       run: |
@@ -53,12 +62,21 @@ jobs:
             
             
 
-    - name: "Build (Release mode)"
+    - name: "Build (Release mode Intel)"
       shell: bash
       run: |
             export BUILD_REASON=Schedule
             export MACOSX_DEPLOYMENT_TARGET=10.9
-            cargo build --all --release
+            cargo build --target x86_64-apple-darwin --all --release
+            
+            
+
+    - name: "Build (Release mode ARM)"
+      shell: bash
+      run: |
+            export BUILD_REASON=Schedule
+            export MACOSX_DEPLOYMENT_TARGET=10.9
+            cargo build --target aarch64-apple-darwin --all --release
             
             
 
@@ -67,7 +85,7 @@ jobs:
       run: |
             export BUILD_REASON=Schedule
             export MACOSX_DEPLOYMENT_TARGET=10.9
-            cargo test --all --release
+            cargo --target x86_64-apple-darwin test --all --release
             
             
 

--- a/.github/workflows/gen_macos_continuous.yml
+++ b/.github/workflows/gen_macos_continuous.yml
@@ -85,7 +85,7 @@ jobs:
       run: |
             export BUILD_REASON=Schedule
             export MACOSX_DEPLOYMENT_TARGET=10.9
-            cargo --target x86_64-apple-darwin test --all --release
+            cargo test --target x86_64-apple-darwin --all --release
             
             
 

--- a/.github/workflows/gen_macos_tag.yml
+++ b/.github/workflows/gen_macos_tag.yml
@@ -73,7 +73,7 @@ jobs:
       shell: bash
       run: |
             export MACOSX_DEPLOYMENT_TARGET=10.9
-            cargo --target x86_64-apple-darwin test --all --release
+            cargo test --target x86_64-apple-darwin --all --release
             
 
     - name: "Package"

--- a/.github/workflows/gen_macos_tag.yml
+++ b/.github/workflows/gen_macos_tag.yml
@@ -11,7 +11,7 @@ jobs:
   build:
     strategy:
       fail-fast: false
-    runs-on: "macos-latest"
+    runs-on: "macos-11.0"
     
     steps:
     - name: "checkout repo"
@@ -41,6 +41,13 @@ jobs:
          components: "rustfmt"
       env:
          ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
+    - name: "Install Rust (ARM)"
+      shell: bash
+      run: |
+            export MACOSX_DEPLOYMENT_TARGET=10.9
+            rustup target add aarch64-apple-darwin
+            
+
     - name: "Install System Deps"
       shell: bash
       run: |
@@ -48,18 +55,25 @@ jobs:
             ./get-deps
             
 
-    - name: "Build (Release mode)"
+    - name: "Build (Release mode Intel)"
       shell: bash
       run: |
             export MACOSX_DEPLOYMENT_TARGET=10.9
-            cargo build --all --release
+            cargo build --target x86_64-apple-darwin --all --release
+            
+
+    - name: "Build (Release mode ARM)"
+      shell: bash
+      run: |
+            export MACOSX_DEPLOYMENT_TARGET=10.9
+            cargo build --target aarch64-apple-darwin --all --release
             
 
     - name: "Test (Release mode)"
       shell: bash
       run: |
             export MACOSX_DEPLOYMENT_TARGET=10.9
-            cargo test --all --release
+            cargo --target x86_64-apple-darwin test --all --release
             
 
     - name: "Package"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2073,8 +2073,7 @@ dependencies = [
 [[package]]
 name = "mlua"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a12dc3300f9cb6d319059a5e94f9fcde2ee8dd803f225b92bed17b0c6fb15154"
+source = "git+https://github.com/wez/mlua.git?branch=cross#24d9099ef70619c08099157b63812b33af16426d"
 dependencies = [
  "bstr 0.2.14",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,3 +4,6 @@ members = ["wezterm-mux-server", "wezterm", "wezterm-gui", "strip-ansi-escapes"]
 [profile.release]
 opt-level = 3
 # debug = 1
+
+[patch.crates-io]
+mlua = { git = "https://github.com/wez/mlua.git", branch="cross" }

--- a/ci/generate-workflows.py
+++ b/ci/generate-workflows.py
@@ -262,7 +262,7 @@ cargo build --all --release""",
 
     def test_all_release(self):
         if "macos" in self.name:
-            return [RunStep(name="Test (Release mode)", run="cargo --target x86_64-apple-darwin test --all --release")]
+            return [RunStep(name="Test (Release mode)", run="cargo test --target x86_64-apple-darwin --all --release")]
         return [RunStep(name="Test (Release mode)", run="cargo test --all --release")]
 
     def package(self):

--- a/ci/generate-workflows.py
+++ b/ci/generate-workflows.py
@@ -214,11 +214,16 @@ ln -s /usr/local/git/bin/git /usr/local/bin/git
                 env={"ACTIONS_ALLOW_UNSECURE_COMMANDS": "true"},
             ),
         ]
+        if "macos" in self.name:
+            steps += [
+                RunStep(name="Install Rust (ARM)", run="rustup target add aarch64-apple-darwin")
+            ]
         if cache:
+            cache_paths = ["~/.cargo/registry", "~/.cargo/git", "target"]
             steps += [
                 CacheStep(
                     name="Cache cargo",
-                    path="~/.cargo/registry\n~/.cargo/git\ntarget",
+                    path="\n".join(cache_paths),
                     key=f"{key_prefix}-cargo",
                 ),
             ]
@@ -244,9 +249,20 @@ PATH C:\\Strawberry\\perl\\bin;%PATH%
 cargo build --all --release""",
                 )
             ]
+        if "macos" in self.name:
+            return [
+                RunStep(
+                    name="Build (Release mode Intel)",
+                    run="cargo build --target x86_64-apple-darwin --all --release"),
+                RunStep(
+                    name="Build (Release mode ARM)",
+                    run="cargo build --target aarch64-apple-darwin --all --release"),
+            ]
         return [RunStep(name="Build (Release mode)", run="cargo build --all --release")]
 
     def test_all_release(self):
+        if "macos" in self.name:
+            return [RunStep(name="Test (Release mode)", run="cargo --target x86_64-apple-darwin test --all --release")]
         return [RunStep(name="Test (Release mode)", run="cargo test --all --release")]
 
     def package(self):
@@ -516,7 +532,7 @@ TARGETS = [
     # Target(container="debian:8.11", continuous_only=True, bootstrap_git=True),
     Target(container="debian:9.12", continuous_only=True, bootstrap_git=True),
     Target(container="debian:10.3", continuous_only=True),
-    Target(name="macos", os="macos-latest"),
+    Target(name="macos", os="macos-11.0"),
     Target(container="fedora:31"),
     Target(container="fedora:32"),
     Target(container="fedora:33"),

--- a/docs/changelog.markdown
+++ b/docs/changelog.markdown
@@ -39,6 +39,7 @@ brief notes about them may accumulate here.
 * Added `selection_word_boundary` option to control double-click word selection boundaries. The default is ` \t\n{[}]()\"'\``. [#405](https://github.com/wez/wezterm/issues/405)
 * Added support for Curly, Dotted and Dashed underlines.  Vim users can set `let &t_Cs = "\e[4:3m"` in their `.vimrc` to enable undercurl support in wezterm. See [#415](https://github.com/wez/wezterm/issues/415) for more details on the escape sequences and configuration for this.
 * Fixed an issue where wezterm would spawn processes with `umask 077` on unix systems, rather than the more commonly expected `umask 022`. [#416](https://github.com/wez/wezterm/issues/416)
+* macOS: We now ship a Universal binary containing both Intel and "Apple Silicon" architectures
 
 ### 20201101-103216-403d002d
 

--- a/docs/install/macos.markdown
+++ b/docs/install/macos.markdown
@@ -3,6 +3,10 @@
 The CI system builds the package on macOS Mojave (10.14).  It may run on earlier
 versions of macOS, but that has not been tested.
 
+If you have an M1-based mac then it is recommended that you download the
+Nightly build which is a Universal binary with support for both Apple Silicon
+and Intel hardware.
+
 <a href="{{ macos_zip_stable }}" class="btn">Download for macOS</a>
 <a href="{{ macos_zip_nightly }}" class="btn">Nightly for macOS</a>
 1. Download <a href="{{ macos_zip_stable }}">Release</a>


### PR DESCRIPTION
This should persuade the CI to install both the arm and intel flavors
of the rust toolchain on macOS, and the deploy script to generate
a universal binary.