### PR TITLE
Add Sync marker to child process created through pty spawn

### DIFF
--- a/pty/src/lib.rs
+++ b/pty/src/lib.rs
@@ -129,7 +129,7 @@ pub trait Child: std::fmt::Debug {
 /// Can be used to spawn processes into the pty.
 pub trait SlavePty {
     /// Spawns the command specified by the provided CommandBuilder
-    fn spawn_command(&self, cmd: CommandBuilder) -> Result<Box<dyn Child + Send>, Error>;
+    fn spawn_command(&self, cmd: CommandBuilder) -> Result<Box<dyn Child + Send + Sync>, Error>;
 }
 
 /// Represents the exit status of a child process.

--- a/pty/src/serial.rs
+++ b/pty/src/serial.rs
@@ -99,7 +99,7 @@ struct Slave {
 }
 
 impl SlavePty for Slave {
-    fn spawn_command(&self, cmd: CommandBuilder) -> anyhow::Result<Box<dyn Child + Send>> {
+    fn spawn_command(&self, cmd: CommandBuilder) -> anyhow::Result<Box<dyn Child + Send + Sync>> {
         ensure!(
             cmd.is_default_prog(),
             "can only use default prog commands with serial tty implementations"

--- a/pty/src/ssh.rs
+++ b/pty/src/ssh.rs
@@ -195,7 +195,7 @@ struct SshSlave {
 }
 
 impl SlavePty for SshSlave {
-    fn spawn_command(&self, cmd: CommandBuilder) -> anyhow::Result<Box<dyn Child + Send>> {
+    fn spawn_command(&self, cmd: CommandBuilder) -> anyhow::Result<Box<dyn Child + Send + Sync>> {
         self.pty.with_channel(|channel| {
             for (key, val) in cmd.iter_env_as_str() {
                 if let Err(err) = channel.setenv(key, val) {
@@ -213,7 +213,7 @@ impl SlavePty for SshSlave {
                 channel.exec(&command)?;
             }
 
-            let child: Box<dyn Child + Send> = Box::new(SshChild {
+            let child: Box<dyn Child + Send + Sync> = Box::new(SshChild {
                 pty: self.pty.clone(),
             });
 

--- a/pty/src/unix.rs
+++ b/pty/src/unix.rs
@@ -292,7 +292,10 @@ fn cloexec(fd: RawFd) -> Result<(), Error> {
 }
 
 impl SlavePty for UnixSlavePty {
-    fn spawn_command(&self, builder: CommandBuilder) -> Result<Box<dyn Child + Send>, Error> {
+    fn spawn_command(
+        &self,
+        builder: CommandBuilder,
+    ) -> Result<Box<dyn Child + Send + Sync>, Error> {
         Ok(Box::new(self.fd.spawn_command(builder)?))
     }
 }

--- a/pty/src/win/conpty.rs
+++ b/pty/src/win/conpty.rs
@@ -112,7 +112,7 @@ impl io::Write for ConPtyMasterPty {
 }
 
 impl SlavePty for ConPtySlavePty {
-    fn spawn_command(&self, cmd: CommandBuilder) -> anyhow::Result<Box<dyn Child + Send>> {
+    fn spawn_command(&self, cmd: CommandBuilder) -> anyhow::Result<Box<dyn Child + Send + Sync>> {
         let inner = self.inner.lock().unwrap();
         let child = inner.con.spawn_command(cmd)?;
         Ok(Box::new(child))

--- a/pty/src/win/psuedocon.rs
+++ b/pty/src/win/psuedocon.rs
@@ -13,6 +13,7 @@ use std::os::windows::io::{AsRawHandle, FromRawHandle};
 use std::os::windows::raw::HANDLE;
 use std::path::Path;
 use std::ptr;
+use std::sync::Mutex;
 use winapi::shared::minwindef::DWORD;
 use winapi::shared::winerror::{HRESULT, S_OK};
 use winapi::um::handleapi::*;
@@ -150,6 +151,8 @@ impl PsuedoCon {
         let _main_thread = unsafe { OwnedHandle::from_raw_handle(pi.hThread) };
         let proc = unsafe { OwnedHandle::from_raw_handle(pi.hProcess) };
 
-        Ok(WinChild { proc })
+        Ok(WinChild {
+            proc: Mutex::new(proc),
+        })
     }
 }


### PR DESCRIPTION
This will also allow sharing references of the process across different threads. I need this to share state between different threads.

I don't think that this will break any existing behaviour, from what I've seen (and from what the compiler tells) every data structure in there is `Sync` compatible.