### PR TITLE
Add config option to specify default current working directory

### DIFF
--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -526,6 +526,10 @@ pub struct Config {
     /// as the positional arguments to that command.
     pub default_prog: Option<Vec<String>>,
 
+    /// Specifies the default current working directory for the initially
+    /// spawned program.
+    pub default_cwd: Option<PathBuf>,
+
     /// Specifies a map of environment variables that should be set
     /// when spawning commands in the local domain.
     /// This is not used when working with remote domains.
@@ -1241,6 +1245,10 @@ impl Config {
     }
 
     pub fn apply_cmd_defaults(&self, cmd: &mut CommandBuilder) {
+        if let Some(ref cwd) = self.default_cwd {
+            cmd.cwd(cwd);
+        }
+
         for (k, v) in &self.set_environment_variables {
             cmd.env(k, v);
         }

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -1245,7 +1245,9 @@ impl Config {
     }
 
     pub fn apply_cmd_defaults(&self, cmd: &mut CommandBuilder) {
-        if let Some(ref cwd) = self.default_cwd {
+        // Apply `default_cwd` only if `cwd` is not already set, allows `--cwd`
+        // option to take precedence
+        if let (None, Some(cwd)) = (cmd.get_cwd(), &self.default_cwd) {
             cmd.cwd(cwd);
         }
 

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -526,8 +526,9 @@ pub struct Config {
     /// as the positional arguments to that command.
     pub default_prog: Option<Vec<String>>,
 
-    /// Specifies the default current working directory for the initially
-    /// spawned program.
+    /// Specifies the default current working directory if none is specified
+    /// through configuration or OSC 7 (see docs for `default_cwd` for more
+    /// info!)
     pub default_cwd: Option<PathBuf>,
 
     /// Specifies a map of environment variables that should be set

--- a/docs/config/launch.markdown
+++ b/docs/config/launch.markdown
@@ -49,6 +49,48 @@ to edit your wezterm configuration:
 wezterm start -- vim ~/.wezterm.lua
 ```
 
+## Specifying the current working directory
+
+If you'd like `wezterm` to start running a program in a specific working
+directory you can do so via the config, CLI, and when using
+[`SpawnCommand`](lua/SpawnCommand.md):
+
+* Setting the [`default_cwd`](lua/config/default_cwd.md) via the config:
+
+  ```lua
+  return {
+    default_cwd = "/some/path",
+  }
+  ```
+
+* One off program in a specific working directory via the CLI:
+
+  ```bash
+  wezterm start --cwd /some/path
+  ```
+
+* The [`SpawnCommandInNewTab`](lua/keyassignment/SpawnCommandInNewTab.md),
+  [`SpawnCommandInNewWindow`](lua/keyassignment/SpawnCommandInNewWindow.md),
+  [`SpawnTab`](lua/keyassignment/SpawnTab.md) key assignments, and the
+  [Launcher Menu](#the-launcher-menu) described below all accept a
+  [`SpawnCommand`](lua/SpawnCommand.md) object that accepts an optional `cwd` field:
+
+  ```lua
+  {
+    label = "List files in /some/path",
+    args = {"ls", "-al"},
+    cwd = "/some/path",
+  }
+  ```
+
+Panes/Tabs/Windows created after the first will generally try to resolve the
+current working directory of the current Pane, preferring
+[a value set by OSC 7](../shell-integration.markdown) and falling back to
+attempting to lookup the `cwd` of the current process group leader attached to a
+local Pane. If no `cwd` can be resolved, then the `default_cwd` will be used.
+If `default_cwd` is not specified, then the home directory of the user will be
+used.
+
 ## Passing Environment variables to the spawned program
 
 The `set_environment_variables` configuration setting can be used to

--- a/docs/config/lua/config/default_cwd.md
+++ b/docs/config/lua/config/default_cwd.md
@@ -1,4 +1,56 @@
 # `default_cwd`
 
-Specifies the default current working directory for the initially spawned
-program.
+Sets the default current working directory used by the initial window. If
+`wezterm start --cwd /some/path` is used to specify the current working
+directory, that will take precedence.
+
+Commands launched using [`SpawnCommand`](../SpawnCommand.md) will use the
+`cwd` specified in the `SpawnCommand`, if any.
+
+Panes/Tabs/Windows created after the first will generally try to resolve the
+current working directory of the current Pane, preferring
+[a value set by OSC 7](../../../shell-integration.markdown) and falling back to
+attempting to lookup the `cwd` of the current process group leader attached to a
+local Pane. If no `cwd` can be resolved, then the `default_cwd` will be used.
+If `default_cwd` is not specified, then the home directory of the user will be
+used.
+
+```text
+                             Is initial window?
+               ______________________|______________________
+              |                                             |
+             Yes                                            No
+              |                                             |
+       Opened with CLI                  New pane, tab, or window. Opened with a
+      and `--cwd` flag?                   `SpawnCommand` that includes `cwd`?
+    __________|__________                         __________|__________
+   |                     |                       |                     |
+  Yes                    No                      No                   Yes
+   |                     |                       |                     |
+  Use                    |                Is there a value    Use `cwd` specified
+`--cwd`                  |                 set by OSC 7?       by `SpawnCommand`
+               __________|             __________|__________
+              |                       |                     |
+              |                       No                   Yes
+              |                       |                     |
+              |            Can `cwd` be resolved via    Use OSC 7
+              |            the process group leader?      value
+              |             __________|__________
+              |            |                     |
+              |            No                   Yes
+              |____________|                     |
+                    |                       Use resolved
+             Is `default_cwd`                  `cwd`
+                 defined?
+          __________|__________
+         |                     |
+        Yes                    No
+         |                     |
+        Use                 Use home
+   `default_cwd`            directory
+```
+
+On macOS and Linux, `wezterm` can attempt to resolve the process group leader
+and then attempt to resolve its current working directory. This is not
+guaranteed to succeed, and there are a number of potential edge cases (which is
+another reason for configuring your shell to use OSC 7 sequences).

--- a/docs/config/lua/config/default_cwd.md
+++ b/docs/config/lua/config/default_cwd.md
@@ -1,0 +1,4 @@
+# `default_cwd`
+
+Specifies the default current working directory for the initially spawned
+program.

--- a/pty/src/cmdbuilder.rs
+++ b/pty/src/cmdbuilder.rs
@@ -96,6 +96,10 @@ impl CommandBuilder {
         self.cwd = Some(dir.as_ref().to_owned());
     }
 
+    pub fn get_cwd(&self) -> Option<&OsString> {
+        self.cwd.as_ref()
+    }
+
     #[cfg(unix)]
     pub fn umask(&mut self, mask: Option<libc::mode_t>) {
         self.umask = mask;


### PR DESCRIPTION
Specifies the default current working directory for the initially spawned program.