### PR TITLE
Only disable drop shadow on macOS when window background opacity is transparent

### DIFF
--- a/wezterm-gui/src/gui/termwindow.rs
+++ b/wezterm-gui/src/gui/termwindow.rs
@@ -1305,6 +1305,7 @@ impl TermWindow {
         self.apply_scale_change(&dimensions, self.fonts.get_font_scale());
         self.apply_dimensions(&dimensions, Some(cell_dims));
         if let Some(window) = self.window.as_ref() {
+            window.config_did_change();
             window.invalidate();
         }
     }

--- a/wezterm-gui/src/window_config.rs
+++ b/wezterm-gui/src/window_config.rs
@@ -23,4 +23,8 @@ impl WindowConfiguration for ConfigBridge {
     fn native_macos_fullscreen_mode(&self) -> bool {
         configuration().native_macos_fullscreen_mode
     }
+
+    fn window_background_opacity(&self) -> f32 {
+        configuration().window_background_opacity
+    }
 }

--- a/window/src/configuration.rs
+++ b/window/src/configuration.rs
@@ -20,6 +20,10 @@ pub trait WindowConfiguration {
     fn native_macos_fullscreen_mode(&self) -> bool {
         false
     }
+
+    fn window_background_opacity(&self) -> f32 {
+        1.0
+    }
 }
 
 lazy_static::lazy_static! {

--- a/window/src/lib.rs
+++ b/window/src/lib.rs
@@ -204,6 +204,10 @@ pub trait WindowOps {
     fn toggle_fullscreen(&self) -> Future<()> {
         Future::ok(())
     }
+
+    fn config_did_change(&self) -> Future<()> {
+        Future::ok(())
+    }
 }
 
 pub trait WindowOpsMut {
@@ -245,6 +249,8 @@ pub trait WindowOpsMut {
     fn set_icon(&mut self, _image: &dyn BitmapImage) {}
 
     fn toggle_fullscreen(&mut self) {}
+
+    fn config_did_change(&mut self) {}
 }
 
 static PREFER_SWRAST: AtomicBool = AtomicBool::new(false);

--- a/window/src/os/macos/window.rs
+++ b/window/src/os/macos/window.rs
@@ -704,7 +704,7 @@ impl WindowInner {
     fn update_window_shadow(&mut self) {
         if config().window_background_opacity() < 1.0 {
             unsafe {
-                self.window.setOpaque_(YES);
+                self.window.setOpaque_(NO);
                 // Turn off the window shadow, because when the background is transparent
                 // having the shadow enabled seems to correlate with ghostly remnants
                 // see: https://github.com/wez/wezterm/issues/310
@@ -712,7 +712,7 @@ impl WindowInner {
             }
         } else {
             unsafe {
-                self.window.setOpaque_(NO);
+                self.window.setOpaque_(YES);
                 self.window.setHasShadow_(YES);
             }
         }


### PR DESCRIPTION
as title.

see #310 

https://user-images.githubusercontent.com/409951/106346474-50694b80-626c-11eb-9614-fcdbf88bd9c3.mov

