### PR TITLE
Add cli option --config-file

### DIFF
--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -1034,8 +1034,8 @@ impl Config {
         let lua = make_lua_context(path)?;
         let config: mlua::Value = smol::block_on(
             lua.load(&s)
-            .set_name(path.to_string_lossy().as_bytes())?
-            .eval_async(),
+                .set_name(path.to_string_lossy().as_bytes())?
+                .eval_async(),
         )?;
         cfg = luahelper::from_lua_value(config).with_context(|| {
             format!(

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -974,6 +974,19 @@ pub struct LoadedConfig {
     lua: Option<mlua::Lua>,
 }
 
+struct PathPossibility {
+    path: PathBuf,
+    is_required: bool,
+}
+impl PathPossibility {
+    pub fn required(path: PathBuf) -> PathPossibility {
+        PathPossibility { path, is_required: true }
+    }
+    pub fn optional(path: PathBuf) -> PathPossibility {
+        PathPossibility { path, is_required: false }
+    }
+}
+
 impl Config {
     pub fn load() -> Result<LoadedConfig, Error> {
         // Note that the directories crate has methods for locating project
@@ -982,8 +995,8 @@ impl Config {
         // so we do this bit "by-hand"
 
         let mut paths = vec![
-            CONFIG_DIR.join("wezterm.lua"),
-            HOME_DIR.join(".wezterm.lua"),
+            PathPossibility::optional(CONFIG_DIR.join("wezterm.lua")),
+            PathPossibility::optional(HOME_DIR.join(".wezterm.lua")),
         ];
         if cfg!(windows) {
             // On Windows, a common use case is to maintain a thumb drive
@@ -996,26 +1009,27 @@ impl Config {
             // dir as the executable that will take precedence.
             if let Ok(exe_name) = std::env::current_exe() {
                 if let Some(exe_dir) = exe_name.parent() {
-                    paths.insert(0, exe_dir.join("wezterm.lua"));
+                    paths.insert(0, PathPossibility::optional(exe_dir.join("wezterm.lua")));
                 }
             }
         }
         if let Some(path) = std::env::var_os("WEZTERM_CONFIG_FILE") {
             log::trace!("Note: WEZTERM_CONFIG_FILE is set in the environment");
-            paths.insert(0, path.into());
+            paths.insert(0, PathPossibility::required(path.into()));
         }
 
         if let Some(path) = CONFIG_FILE_OVERRIDE.lock().unwrap().as_ref() {
             log::trace!("Note: config file override is set");
-            paths.insert(0, path.clone());
+            paths.insert(0, PathPossibility::required(path.clone()));
         }
 
-        for p in &paths {
+        for path_item in &paths {
+            let p = path_item.path.as_path();
             log::trace!("consider config: {}", p.display());
             let mut file = match fs::File::open(p) {
                 Ok(file) => file,
                 Err(err) => match err.kind() {
-                    std::io::ErrorKind::NotFound => continue,
+                    std::io::ErrorKind::NotFound if !path_item.is_required => continue,
                     _ => bail!("Error opening {}: {}", p.display(), err),
                 },
             };

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -980,10 +980,16 @@ struct PathPossibility {
 }
 impl PathPossibility {
     pub fn required(path: PathBuf) -> PathPossibility {
-        PathPossibility { path, is_required: true }
+        PathPossibility {
+            path,
+            is_required: true,
+        }
     }
     pub fn optional(path: PathBuf) -> PathPossibility {
-        PathPossibility { path, is_required: false }
+        PathPossibility {
+            path,
+            is_required: false,
+        }
     }
 }
 

--- a/wezterm-gui/src/gui/termwindow.rs
+++ b/wezterm-gui/src/gui/termwindow.rs
@@ -28,7 +28,7 @@ use config::keyassignment::{
     ClipboardCopyDestination, ClipboardPasteSource, InputMap, KeyAssignment, MouseEventTrigger,
     SpawnCommand, SpawnTabDomain,
 };
-use config::{configuration, ConfigHandle, WindowCloseConfirmation};
+use config::{configuration, ConfigFileSelection, ConfigHandle, WindowCloseConfirmation};
 use lru::LruCache;
 use mux::activity::Activity;
 use mux::domain::{DomainId, DomainState};
@@ -1980,7 +1980,7 @@ impl TermWindow {
             CloseCurrentTab { confirm } => self.close_current_tab(*confirm),
             CloseCurrentPane { confirm } => self.close_current_pane(*confirm),
             Nop | DisableDefaultAssignment => {}
-            ReloadConfiguration => config::reload(),
+            ReloadConfiguration => config::reload(ConfigFileSelection::Search),
             MoveTab(n) => self.move_tab(*n)?,
             MoveTabRelative(n) => self.move_tab_relative(*n)?,
             ScrollByPage(n) => self.scroll_by_page(*n)?,

--- a/wezterm-gui/src/gui/termwindow.rs
+++ b/wezterm-gui/src/gui/termwindow.rs
@@ -28,7 +28,7 @@ use config::keyassignment::{
     ClipboardCopyDestination, ClipboardPasteSource, InputMap, KeyAssignment, MouseEventTrigger,
     SpawnCommand, SpawnTabDomain,
 };
-use config::{configuration, ConfigFileSelection, ConfigHandle, WindowCloseConfirmation};
+use config::{configuration, ConfigHandle, WindowCloseConfirmation};
 use lru::LruCache;
 use mux::activity::Activity;
 use mux::domain::{DomainId, DomainState};
@@ -1980,7 +1980,7 @@ impl TermWindow {
             CloseCurrentTab { confirm } => self.close_current_tab(*confirm),
             CloseCurrentPane { confirm } => self.close_current_pane(*confirm),
             Nop | DisableDefaultAssignment => {}
-            ReloadConfiguration => config::reload(ConfigFileSelection::Search),
+            ReloadConfiguration => config::reload(),
             MoveTab(n) => self.move_tab(*n)?,
             MoveTabRelative(n) => self.move_tab_relative(*n)?,
             ScrollByPage(n) => self.scroll_by_page(*n)?,

--- a/wezterm-gui/src/main.rs
+++ b/wezterm-gui/src/main.rs
@@ -31,7 +31,7 @@ mod window_config;
 )]
 struct Opt {
     /// Skip loading wezterm.lua
-    #[structopt(short = "n")]
+    #[structopt(name = "skip-config", short = "n")]
     skip_config: bool,
 
     /// Specify the configuration file to use, overrides the normal

--- a/wezterm-gui/src/main.rs
+++ b/wezterm-gui/src/main.rs
@@ -3,7 +3,6 @@
 
 use crate::gui::front_end;
 use anyhow::anyhow;
-use config::ConfigFileSelection;
 use mux::activity::Activity;
 use mux::domain::{Domain, LocalDomain};
 use mux::Mux;
@@ -419,13 +418,11 @@ fn run() -> anyhow::Result<()> {
     let _saver = umask::UmaskSaver::new();
 
     let opts = Opt::from_args();
+    if let Some(config_file) = opts.config_file.as_ref() {
+        config::set_config_file_override(std::path::Path::new(config_file));
+    }
     if !opts.skip_config {
-        if let Some(ref config_file) = opts.config_file {
-            let path = std::path::PathBuf::from(config_file);
-            config::reload(ConfigFileSelection::FromPath(path.as_path()));
-        } else {
-            config::reload(ConfigFileSelection::Search);
-        }
+        config::reload();
     }
     let config = config::configuration();
     window::configuration::set_configuration(crate::window_config::ConfigBridge);

--- a/wezterm-gui/src/main.rs
+++ b/wezterm-gui/src/main.rs
@@ -419,7 +419,7 @@ fn run() -> anyhow::Result<()> {
 
     let opts = Opt::from_args();
     if let Some(config_file) = opts.config_file.as_ref() {
-        config::set_config_file_override(config_file.into());
+        config::set_config_file_override(std::path::Path::new(config_file));
     }
     if !opts.skip_config {
         config::reload();

--- a/wezterm-gui/src/main.rs
+++ b/wezterm-gui/src/main.rs
@@ -39,7 +39,7 @@ struct Opt {
     #[structopt(
         long = "config-file",
         parse(from_os_str),
-        conflicts_with = "skip_config"
+        conflicts_with = "skip-config"
     )]
     config_file: Option<OsString>,
 
@@ -419,7 +419,7 @@ fn run() -> anyhow::Result<()> {
 
     let opts = Opt::from_args();
     if let Some(config_file) = opts.config_file.as_ref() {
-        config::set_config_file_override(std::path::Path::new(config_file));
+        config::set_config_file_override(config_file.into());
     }
     if !opts.skip_config {
         config::reload();

--- a/wezterm-gui/src/main.rs
+++ b/wezterm-gui/src/main.rs
@@ -35,8 +35,13 @@ struct Opt {
     #[structopt(short = "n")]
     skip_config: bool,
 
-    /// Specify the configuration file to use, overrides WEZTERM_CONFIG_FILE
-    #[structopt(long = "config-file", parse(from_os_str))]
+    /// Specify the configuration file to use, overrides the normal
+    /// configuration file resolution
+    #[structopt(
+        long = "config-file",
+        parse(from_os_str),
+        conflicts_with = "skip_config"
+    )]
     config_file: Option<OsString>,
 
     #[structopt(subcommand)]

--- a/wezterm-mux-server/src/main.rs
+++ b/wezterm-mux-server/src/main.rs
@@ -64,7 +64,7 @@ fn run() -> anyhow::Result<()> {
 
     let opts = Opt::from_args();
     if let Some(config_file) = opts.config_file.as_ref() {
-        config::set_config_file_override(config_file.into());
+        config::set_config_file_override(std::path::Path::new(config_file));
     }
     if !opts.skip_config {
         config::reload();

--- a/wezterm-mux-server/src/main.rs
+++ b/wezterm-mux-server/src/main.rs
@@ -23,8 +23,13 @@ struct Opt {
     #[structopt(short = "n")]
     skip_config: bool,
 
-    /// Specify the configuration file to use, overrides WEZTERM_CONFIG_FILE
-    #[structopt(long = "config-file", parse(from_os_str))]
+    /// Specify the configuration file to use, overrides the normal
+    /// configuration file resolution
+    #[structopt(
+        long = "config-file",
+        parse(from_os_str),
+        conflicts_with = "skip_config"
+    )]
     config_file: Option<OsString>,
 
     /// Detach from the foreground and become a background process

--- a/wezterm-mux-server/src/main.rs
+++ b/wezterm-mux-server/src/main.rs
@@ -28,7 +28,7 @@ struct Opt {
     #[structopt(
         long = "config-file",
         parse(from_os_str),
-        conflicts_with = "skip_config"
+        conflicts_with = "skip-config"
     )]
     config_file: Option<OsString>,
 
@@ -64,7 +64,7 @@ fn run() -> anyhow::Result<()> {
 
     let opts = Opt::from_args();
     if let Some(config_file) = opts.config_file.as_ref() {
-        config::set_config_file_override(std::path::Path::new(config_file));
+        config::set_config_file_override(config_file.into());
     }
     if !opts.skip_config {
         config::reload();

--- a/wezterm-mux-server/src/main.rs
+++ b/wezterm-mux-server/src/main.rs
@@ -20,7 +20,7 @@ mod daemonize;
 )]
 struct Opt {
     /// Skip loading wezterm.lua
-    #[structopt(short = "n")]
+    #[structopt(name = "skip-config", short = "n")]
     skip_config: bool,
 
     /// Specify the configuration file to use, overrides the normal

--- a/wezterm-mux-server/src/main.rs
+++ b/wezterm-mux-server/src/main.rs
@@ -1,4 +1,4 @@
-use config::{configuration, ConfigFileSelection};
+use config::configuration;
 use mux::activity::Activity;
 use mux::domain::{Domain, LocalDomain};
 use mux::Mux;
@@ -63,13 +63,11 @@ fn run() -> anyhow::Result<()> {
     let _saver = umask::UmaskSaver::new();
 
     let opts = Opt::from_args();
+    if let Some(config_file) = opts.config_file.as_ref() {
+        config::set_config_file_override(std::path::Path::new(config_file));
+    }
     if !opts.skip_config {
-        if let Some(ref config_file) = opts.config_file {
-            let path = std::path::PathBuf::from(config_file);
-            config::reload(ConfigFileSelection::FromPath(path.as_path()));
-        } else {
-            config::reload(ConfigFileSelection::Search);
-        }
+        config::reload();
     }
 
     #[cfg(unix)]

--- a/wezterm/src/main.rs
+++ b/wezterm/src/main.rs
@@ -1,5 +1,5 @@
 use anyhow::{anyhow, Context};
-use config::{wezterm_version, ConfigFileSelection};
+use config::wezterm_version;
 use mux::activity::Activity;
 use mux::pane::PaneId;
 use mux::tab::SplitDirection;
@@ -236,13 +236,11 @@ fn run() -> anyhow::Result<()> {
     let saver = UmaskSaver::new();
 
     let opts = Opt::from_args();
+    if let Some(config_file) = opts.config_file.as_ref() {
+        config::set_config_file_override(std::path::Path::new(config_file));
+    }
     if !opts.skip_config {
-        if let Some(ref config_file) = opts.config_file {
-            let path = std::path::PathBuf::from(config_file);
-            config::reload(ConfigFileSelection::FromPath(path.as_path()));
-        } else {
-            config::reload(ConfigFileSelection::Search);
-        }
+        config::reload();
     }
     let config = config::configuration();
 

--- a/wezterm/src/main.rs
+++ b/wezterm/src/main.rs
@@ -1,5 +1,5 @@
 use anyhow::{anyhow, Context};
-use config::{ConfigFileSelection, wezterm_version};
+use config::{wezterm_version, ConfigFileSelection};
 use mux::activity::Activity;
 use mux::pane::PaneId;
 use mux::tab::SplitDirection;

--- a/wezterm/src/main.rs
+++ b/wezterm/src/main.rs
@@ -29,8 +29,13 @@ struct Opt {
     #[structopt(short = "n")]
     skip_config: bool,
 
-    /// Specify the configuration file to use, overrides WEZTERM_CONFIG_FILE
-    #[structopt(long = "config-file", parse(from_os_str))]
+    /// Specify the configuration file to use, overrides the normal
+    /// configuration file resolution
+    #[structopt(
+        long = "config-file",
+        parse(from_os_str),
+        conflicts_with = "skip_config"
+    )]
     config_file: Option<OsString>,
 
     #[structopt(subcommand)]

--- a/wezterm/src/main.rs
+++ b/wezterm/src/main.rs
@@ -26,7 +26,7 @@ use wezterm_gui_subcommands::*;
 )]
 struct Opt {
     /// Skip loading wezterm.lua
-    #[structopt(short = "n")]
+    #[structopt(name = "skip-config", short = "n")]
     skip_config: bool,
 
     /// Specify the configuration file to use, overrides the normal

--- a/wezterm/src/main.rs
+++ b/wezterm/src/main.rs
@@ -237,7 +237,7 @@ fn run() -> anyhow::Result<()> {
 
     let opts = Opt::from_args();
     if let Some(config_file) = opts.config_file.as_ref() {
-        config::set_config_file_override(config_file.into());
+        config::set_config_file_override(std::path::Path::new(config_file));
     }
     if !opts.skip_config {
         config::reload();

--- a/wezterm/src/main.rs
+++ b/wezterm/src/main.rs
@@ -34,7 +34,7 @@ struct Opt {
     #[structopt(
         long = "config-file",
         parse(from_os_str),
-        conflicts_with = "skip_config"
+        conflicts_with = "skip-config"
     )]
     config_file: Option<OsString>,
 
@@ -237,7 +237,7 @@ fn run() -> anyhow::Result<()> {
 
     let opts = Opt::from_args();
     if let Some(config_file) = opts.config_file.as_ref() {
-        config::set_config_file_override(std::path::Path::new(config_file));
+        config::set_config_file_override(config_file.into());
     }
     if !opts.skip_config {
         config::reload();


### PR DESCRIPTION
It works! :tada: 

I didn't find a documentation for global flags/options, is it currently missing?

I'm not fond of the duplication between wezterm/wezterm-gui/wezterm-mux-server.. But this is a larger problem I think, it shouldn't be solved in this PR.

For the implementation
- I extracted the existing config load logic to a function that takes a Path, and make it used when the flag is given.

- I changed the signature of `reload` (to avoid having `reload()` and `reload_from_path(path)` functions), to take a `ConfigFileSelection` (not sure about the naming), to choose between searching the config file or using a given one.