### PR TITLE
unix: Correctly signal child process on exit

### DIFF
--- a/pty/src/lib.rs
+++ b/pty/src/lib.rs
@@ -190,6 +190,11 @@ impl Child for std::process::Child {
     fn kill(&mut self) -> IoResult<()> {
         #[cfg(unix)]
         {
+            // On unix, we send the SIGHUP signal instead of trying to kill
+            // the process. The default behavior of a process receiving this
+            // signal is to be killed unless it configured a signal handler.
+            // In this case the process is responsible of itself, releasing
+            // resources and terminating itself, or become a daemon.
             unsafe { libc::kill(self.id() as i32, libc::SIGHUP) };
             Ok(())
         }

--- a/pty/src/lib.rs
+++ b/pty/src/lib.rs
@@ -44,10 +44,10 @@
 //! session with an implementation of `PtySystem`, allowing
 //! you to use the same pty interface with remote ptys.
 use anyhow::Error;
+use libc;
 #[cfg(feature = "serde_support")]
 use serde_derive::*;
 use std::io::Result as IoResult;
-use libc;
 
 pub mod cmdbuilder;
 pub use cmdbuilder::CommandBuilder;

--- a/pty/src/lib.rs
+++ b/pty/src/lib.rs
@@ -195,7 +195,12 @@ impl Child for std::process::Child {
             // signal is to be killed unless it configured a signal handler.
             // In this case the process is responsible of itself, releasing
             // resources and terminating itself, or become a daemon.
-            unsafe { libc::kill(self.id() as i32, libc::SIGHUP) };
+            let result = unsafe { libc::kill(self.id() as i32, libc::SIGHUP) };
+            if result == 0 {
+               Ok(())
+            } else {
+               Err(IoError::last_os_error())
+            }
             Ok(())
         }
         #[cfg(windows)]


### PR DESCRIPTION
@p00f reported on Matrix an issue where zsh would not save its ~/.zsh_history file when closing wezterm (which needs to 'close' the shell) but it works when closing the shell (which will then close wezterm).

The reason seems to be because currently wezterm tries to kill the child process when closing, instead of sending a signal to the process to tell it its terminal is closing.

NOTE: For some reason I couldn't reproduce the issue on my Linux, but @p00f confirmed that it worked.

---
On Matrix @wez, you suggested to implement it bit differently:
> I suppose that sending SIGHUP makes sense, however, **that isn't guaranteed to kill an arbitrary program** because it may be ignoring HUP (eg: nohup). The usual approach for gracefully killing things is first to deliver SIGTERM, give it a few moments to handle it and if it hasn't gone away, follow up with SIGKILL. I think in the context of a pty we can do SIGHUP, SIGTERM and then SIGKILL.

Highlighted:
> that isn't guaranteed to kill an arbitrary program

The thing is, from what I read the terminal should NOT kill the program (cf wikipedia extract on SIGUP below) but must simply send the SIGHUP signal to the process. By default that signal kills the process unless it configured a signal handler.

Extract from https://en.wikipedia.org/wiki/SIGHUP#Modern_usage:
> With the decline of access via serial line, the meaning of SIGHUP has changed somewhat on modern systems, often meaning a controlling pseudo or virtual terminal has been closed. If a command is executed inside a terminal window and the terminal window is closed while the command process is still running, it receives SIGHUP.
