### PR TITLE
windows: Add option to treat left ctrl-alt as altgr

### DIFF
--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -843,6 +843,9 @@ pub struct Config {
     #[serde(default = "default_true")]
     pub send_composed_key_when_right_alt_is_pressed: bool,
 
+    #[serde(default)]
+    pub treat_left_ctrlalt_as_altgr: bool,
+
     /// If true, the `Backspace` and `Delete` keys generate `Delete` and `Backspace`
     /// keypresses, respectively, rather than their normal keycodes.
     /// On macOS the default for this is true because its Backspace key

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -42,6 +42,7 @@ brief notes about them may accumulate here.
 * New: holding SUPER+Drag (or CTRL+SHIFT+Drag) will drag the wezterm window.  Use [StartWindowDrag](config/lua/keyassignment/StartWindowDrag.md) to configure your own binding.
 * New: configure [window_decorations](config/lua/config/window_decorations.md) to remove the title bar and/or window border
 * New: we now bundle [PowerlineExtraSymbols](https://github.com/ryanoasis/powerline-extra-symbols) as a built-in fallback font, so that you can use powerline glyphs with any font without patching the font.
+* Windows: fix the unexpected default behavior of Ctrl-Alt being converted to AltGr for layouts supporting this key, the previous behavior is still possible by enabling the option [`treat_left_ctrlalt_as_altgr`](config/lua/config/treat_left_ctrlalt_as_altgr.md) (to solve [#392](https://github.com/wez/wezterm/issues/392)). Thanks to [@bew](https://github.com/bew)! [#512](https://github.com/wez/wezterm/pull/512)
 
 ### 20210203-095643-70a364eb
 

--- a/docs/config/keys.md
+++ b/docs/config/keys.md
@@ -100,6 +100,24 @@ return {
 }
 ```
 
+### Microsoft Windows and Ctrl-Alt <-> AltGr
+
+*since: nightly*
+
+If you are using a layout with an *AltGr* key, you may experience issues
+when running inside a VNC session, because VNC emulates the AltGr keypresses
+by sending plain *Ctrl-Alt* keys, which won't be understood as AltGr.
+
+To fix this behavior you can tell WezTerm to treat left *Ctrl-Alt* keys as
+*AltGr* with the option `treat_left_ctrlalt_as_altgr`. Note that the key bindings using separate Ctrl and Alt won't be triggered anymore.
+
+```lua
+return {
+  treat_left_ctrlalt_as_altgr = true
+}
+```
+
+
 ### Defining Assignments for key combinations that may be composed
 
 When a key combination produces a composed key result, wezterm will look up

--- a/docs/config/keys.md
+++ b/docs/config/keys.md
@@ -102,20 +102,7 @@ return {
 
 ### Microsoft Windows and Ctrl-Alt <-> AltGr
 
-*since: nightly*
-
-If you are using a layout with an *AltGr* key, you may experience issues
-when running inside a VNC session, because VNC emulates the AltGr keypresses
-by sending plain *Ctrl-Alt* keys, which won't be understood as AltGr.
-
-To fix this behavior you can tell WezTerm to treat left *Ctrl-Alt* keys as
-*AltGr* with the option `treat_left_ctrlalt_as_altgr`. Note that the key bindings using separate Ctrl and Alt won't be triggered anymore.
-
-```lua
-return {
-  treat_left_ctrlalt_as_altgr = true
-}
-```
+If you are using VNC and a keyboard layout with dead keys, then you may wish to enable [treat_left_ctrlalt_as_altgr](lua/config/treat_left_ctrlalt_as_altgr.md).
 
 
 ### Defining Assignments for key combinations that may be composed

--- a/docs/config/lua/config/treat_left_ctrlalt_as_altgr.md
+++ b/docs/config/lua/config/treat_left_ctrlalt_as_altgr.md
@@ -1,0 +1,17 @@
+# `treat_left_ctrlalt_as_altgr = false`
+
+*since: nightly*
+
+If you are using a layout with an *AltGr* key, you may experience issues
+when running inside a VNC session, because VNC emulates the AltGr keypresses
+by sending plain *Ctrl-Alt* keys, which won't be understood as AltGr.
+
+To fix this behavior you can tell WezTerm to treat left *Ctrl-Alt* keys as
+*AltGr* with the option `treat_left_ctrlalt_as_altgr`. Note that the key
+bindings using separate Ctrl and Alt won't be triggered anymore.
+
+```lua
+return {
+  treat_left_ctrlalt_as_altgr = true
+}
+```

--- a/wezterm-gui/src/window_config.rs
+++ b/wezterm-gui/src/window_config.rs
@@ -32,6 +32,10 @@ impl WindowConfiguration for ConfigInstance {
         self.0.send_composed_key_when_right_alt_is_pressed
     }
 
+    fn treat_left_ctrlalt_as_altgr(&self) -> bool {
+        self.0.treat_left_ctrlalt_as_altgr
+    }
+
     fn enable_wayland(&self) -> bool {
         self.0.enable_wayland
     }
@@ -85,6 +89,10 @@ impl WindowConfiguration for ConfigBridge {
 
     fn send_composed_key_when_right_alt_is_pressed(&self) -> bool {
         global().send_composed_key_when_right_alt_is_pressed()
+    }
+
+    fn treat_left_ctrlalt_as_altgr(&self) -> bool {
+        global().treat_left_ctrlalt_as_altgr()
     }
 
     fn enable_wayland(&self) -> bool {

--- a/window/src/configuration.rs
+++ b/window/src/configuration.rs
@@ -14,6 +14,10 @@ pub trait WindowConfiguration {
         true
     }
 
+    fn treat_left_ctrlalt_as_altgr(&self) -> bool {
+        false
+    }
+
     // Applies to Windows only.
     // For macos, see send_composed_key_when_XXX_alt_is_pressed
     fn use_dead_keys(&self) -> bool {

--- a/window/src/os/windows/window.rs
+++ b/window/src/os/windows/window.rs
@@ -1568,7 +1568,7 @@ unsafe fn key(hwnd: HWND, msg: UINT, wparam: WPARAM, lparam: LPARAM) -> Option<L
         }
 
         if inner.keyboard_info.has_alt_gr()
-            && ((keys[VK_RMENU as usize] & 0x80 != 0) || (keys[VK_MENU as usize] & 0x80 != 0))
+            && (keys[VK_RMENU as usize] & 0x80 != 0)
             && (keys[VK_CONTROL as usize] & 0x80 != 0)
         {
             // AltGr is pressed; while AltGr is on the RHS of the keyboard
@@ -1579,14 +1579,21 @@ unsafe fn key(hwnd: HWND, msg: UINT, wparam: WPARAM, lparam: LPARAM) -> Option<L
             // We set RIGHT_ALT as a hint to ourselves that AltGr is in
             // use (we use regular ALT otherwise) so that our dead key
             // resolution can do the right thing.
-            //
+            modifiers |= Modifiers::RIGHT_ALT;
+        } else if inner.keyboard_info.has_alt_gr()
+            && config().treat_left_ctrlalt_as_altgr()
+            && (keys[VK_MENU as usize] & 0x80 != 0)
+            && (keys[VK_CONTROL as usize] & 0x80 != 0)
+        {
             // When running inside a VNC session, VNC emulates the AltGr keypresses
-            // by sending plain VK_MENU (rather than RMENU) + VK_CONTROL.
-            // For compatibility with that we also treat MENU+CONTROL as equivalent
-            // to RMENU+CONTROL even though it is technically a lossy transformation.
-            // We only do that when the keyboard layout has AltGr so that we don't
-            // screw things up for other keyboard layouts.
-            // See issue #392 for some more context.
+            // by sending plain VK_MENU (rather than VK_RMENU) + VK_CONTROL.
+            // For compatibility with that the option `treat_left_ctrlalt_as_altgr` allows
+            // to treat MENU+CONTROL as equivalent to RMENU+CONTROL (AltGr) even though it is
+            // technically a lossy transformation.
+            //
+            // We only do that when the keyboard layout has AltGr and the option is enabled,
+            // so that we don't screw things up by default or for other keyboard layouts.
+            // See issue #392 & #472 for some more context.
             modifiers |= Modifiers::RIGHT_ALT;
         } else {
             if keys[VK_CONTROL as usize] & 0x80 != 0 {


### PR DESCRIPTION
The previous behavior was to always treat ctrl-alt as altgr on Windows,
this has been done to better support altgr through a VNC session,
but this is very unintuitive when you don't need this behavior.

Closes #472