### PR TITLE
[cargo] add cargo-features = ["resolver"] where needed

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,5 @@
+cargo-features = ["resolver"]
+
 [workspace]
 members = ["wezterm-mux-server", "wezterm", "wezterm-gui", "strip-ansi-escapes", "wezterm-ssh"]
 resolver = "2"

--- a/async_ossl/Cargo.toml
+++ b/async_ossl/Cargo.toml
@@ -1,3 +1,5 @@
+cargo-features = ["resolver"]
+
 [package]
 name = "async_ossl"
 version = "0.1.0"

--- a/wezterm-gui/Cargo.toml
+++ b/wezterm-gui/Cargo.toml
@@ -1,3 +1,5 @@
+cargo-features = ["resolver"]
+
 [package]
 name = "wezterm-gui"
 version = "0.1.0"

--- a/wezterm-mux-server/Cargo.toml
+++ b/wezterm-mux-server/Cargo.toml
@@ -1,3 +1,5 @@
+cargo-features = ["resolver"]
+
 [package]
 name = "wezterm-mux-server"
 version = "0.1.0"


### PR DESCRIPTION
Needed to build wezterm on Debian Unstable's cargo 1.46.0.