### PR TITLE
custom Unicode box drawing glyphs

### DIFF
--- a/test-data/box-drawings.py
+++ b/test-data/box-drawings.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+
+# Print out the unicde drawing box range
+
+s = ""
+for b in range(0x2500, 0x2504):
+    s += chr(b) + " "
+
+print(s)
+print(s)
+print(s)
+


### PR DESCRIPTION
This is an initial push towards solving #584.

It is unlikely we'll want to merge the PR as is, since it:

- misses a bunch of box drawing characters (currently only `light vertical` is implemented)
- duplicates a lot of "block drawing" logic that we should probably merge
- doesn't include any tests

I figured I'd push this up regardless, as it solved an immediate need for my usage, and I am running this fork for now, until there is more guidance on the preferred way forward with this feature.

Here's an example with custom `line_height` and the vertical line going all the way to the edges of the line:

<img width="115" alt="Screenshot 2021-03-30 at 10 25 24" src="https://user-images.githubusercontent.com/383250/112958045-57b0b680-9142-11eb-9964-65e2e16a395f.png">
