### PR TITLE
Capture middle mouse events on macos

### DIFF
--- a/window/src/os/macos/window.rs
+++ b/window/src/os/macos/window.rs
@@ -1501,9 +1501,8 @@ impl WindowView {
         unsafe {
             let button_number = NSEvent::buttonNumber(nsevent);
             // Button 2 is the middle mouse button (scroll wheel)
-            // At least on the tested mouse, the dedicated middle mouse button
-            // is button 4. This should probably be made configurable at some point
-            if [2, 4].contains(&button_number) {
+            // but is the dedicated middle mouse button on 4 button mouses
+            if button_number == 2 {
                 Self::mouse_common(this, nsevent, MouseEventKind::Release(MousePress::Middle));
             }
         }
@@ -1581,7 +1580,7 @@ impl WindowView {
         unsafe {
             let button_number = NSEvent::buttonNumber(nsevent);
             // See `other_mouse_up`
-            if [2, 4].contains(&button_number) {
+            if button_number == 2 {
                 Self::mouse_common(this, nsevent, MouseEventKind::Press(MousePress::Middle));
             }
         }

--- a/window/src/os/macos/window.rs
+++ b/window/src/os/macos/window.rs
@@ -1577,7 +1577,14 @@ impl WindowView {
     }
 
     extern "C" fn other_mouse_down(this: &mut Object, _sel: Sel, nsevent: id) {
-        Self::mouse_common(this, nsevent, MouseEventKind::Press(MousePress::Middle));
+        // Safety: See `other_mouse_up`
+        unsafe {
+            let button_number = NSEvent::buttonNumber(nsevent);
+            // See `other_mouse_up`
+            if [2, 4].contains(&button_number) {
+                Self::mouse_common(this, nsevent, MouseEventKind::Press(MousePress::Middle));
+            }
+        }
     }
 
     extern "C" fn mouse_moved_or_dragged(this: &mut Object, _sel: Sel, nsevent: id) {

--- a/window/src/os/macos/window.rs
+++ b/window/src/os/macos/window.rs
@@ -1496,6 +1496,10 @@ impl WindowView {
         Self::mouse_common(this, nsevent, MouseEventKind::Release(MousePress::Right));
     }
 
+    extern "C" fn other_mouse_up(this: &mut Object, _sel: Sel, nsevent: id) {
+        Self::mouse_common(this, nsevent, MouseEventKind::Release(MousePress::Middle));
+    }
+
     extern "C" fn scroll_wheel(this: &mut Object, _sel: Sel, nsevent: id) {
         let precise = unsafe { nsevent.hasPreciseScrollingDeltas() } == YES;
         let scale = if precise {
@@ -1561,6 +1565,10 @@ impl WindowView {
 
     extern "C" fn right_mouse_down(this: &mut Object, _sel: Sel, nsevent: id) {
         Self::mouse_common(this, nsevent, MouseEventKind::Press(MousePress::Right));
+    }
+
+    extern "C" fn other_mouse_down(this: &mut Object, _sel: Sel, nsevent: id) {
+        Self::mouse_common(this, nsevent, MouseEventKind::Press(MousePress::Middle));
     }
 
     extern "C" fn mouse_moved_or_dragged(this: &mut Object, _sel: Sel, nsevent: id) {
@@ -1955,6 +1963,14 @@ impl WindowView {
             cls.add_method(
                 sel!(rightMouseUp:),
                 Self::right_mouse_up as extern "C" fn(&mut Object, Sel, id),
+            );
+            cls.add_method(
+                sel!(otherMouseDown:),
+                Self::other_mouse_down as extern "C" fn(&mut Object, Sel, id),
+            );
+            cls.add_method(
+                sel!(otherMouseUp:),
+                Self::other_mouse_up as extern "C" fn(&mut Object, Sel, id),
             );
             cls.add_method(
                 sel!(scrollWheel:),

--- a/window/src/os/macos/window.rs
+++ b/window/src/os/macos/window.rs
@@ -1497,7 +1497,16 @@ impl WindowView {
     }
 
     extern "C" fn other_mouse_up(this: &mut Object, _sel: Sel, nsevent: id) {
-        Self::mouse_common(this, nsevent, MouseEventKind::Release(MousePress::Middle));
+        // Safety: We know this is an button event
+        unsafe {
+            let button_number = NSEvent::buttonNumber(nsevent);
+            // Button 2 is the middle mouse button (scroll wheel)
+            // At least on the tested mouse, the dedicated middle mouse button
+            // is button 4. This should probably be made configurable at some point
+            if [2, 4].contains(&button_number) {
+                Self::mouse_common(this, nsevent, MouseEventKind::Release(MousePress::Middle));
+            }
+        }
     }
 
     extern "C" fn scroll_wheel(this: &mut Object, _sel: Sel, nsevent: id) {


### PR DESCRIPTION
I noticed that no matter what I did, even trying multiple mouses, I couldn't get middle-mouse-paste to work on my macos version of wezterm

Looking through the code, I found it was missing bindings to `otherMouse*` events. I added them, and lo and behold, it worked!

One question: I dont really understand the difference between the press type in `MouseEventKind` and the `buttons` in `MouseEvent`.
This code causes the middle mouse click to happen when I click ANY of the non left/right buttons on my mouse. I am not sure if thats what we want (until/if we add button bindings would change this), or if not, how I should structure the code to avoid that. I suppose we'd have to compare the decoded mouse_buttons with the MouseEventKind in `mouse_common`?