### PR TITLE
wezterm-gui: allow title prefixes to be hidden

### DIFF
--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -879,6 +879,10 @@ pub struct Config {
     #[serde(default)]
     pub hide_tab_bar_if_only_one_tab: bool,
 
+    /// If true, hide all prefixes in the window title.
+    #[serde(default)]
+    pub hide_window_title_prefixes: bool,
+
     #[serde(default)]
     pub enable_scroll_bar: bool,
 

--- a/docs/config/appearance.md
+++ b/docs/config/appearance.md
@@ -214,6 +214,17 @@ return {
 }
 ```
 
+### Window Titles
+
+By default, windows with multiple tabs will have their titles prefixed with the
+current tab and the total. This can be disabled:
+
+```lua
+return {
+  hide_window_title_prefixes = true,
+}
+```
+
 ## Styling Inactive Panes
 
 *since: 20201031-154415-9614e117*

--- a/wezterm-gui/src/termwindow/mod.rs
+++ b/wezterm-gui/src/termwindow/mod.rs
@@ -1030,15 +1030,21 @@ impl TermWindow {
             let title = pos.pane.get_title();
 
             if let Some(window) = self.window.as_ref() {
-                let show_tab_bar;
-                if num_tabs == 1 {
+                let show_tab_bar = self.config.enable_tab_bar
+                    && if num_tabs == 1 {
+                        !self.config.hide_tab_bar_if_only_one_tab
+                    } else {
+                        true
+                    };
+
+                if self.config.hide_window_title_prefixes {
+                    window.set_title(&title);
+                } else if num_tabs == 1 {
                     window.set_title(&format!(
                         "{}{}",
                         if pos.is_zoomed { "[Z] " } else { "" },
                         title
                     ));
-                    show_tab_bar =
-                        self.config.enable_tab_bar && !self.config.hide_tab_bar_if_only_one_tab;
                 } else {
                     window.set_title(&format!(
                         "{}[{}/{}] {}",
@@ -1047,7 +1053,6 @@ impl TermWindow {
                         num_tabs,
                         title
                     ));
-                    show_tab_bar = self.config.enable_tab_bar;
                 }
 
                 // If the number of tabs changed and caused the tab bar to


### PR DESCRIPTION
Another option here would be to implement a simple templating system for the window title, but selfishly, this does what I'm looking for in terms of just disabling the `[count/total]` prefix.