### PR TITLE
Add ActivateLastTab command

### DIFF
--- a/config/src/keyassignment.rs
+++ b/config/src/keyassignment.rs
@@ -164,6 +164,7 @@ pub enum KeyAssignment {
     ResetFontSize,
     ResetFontAndWindowSize,
     ActivateTab(isize),
+    ActivateLastTab,
     SendString(String),
     Nop,
     DisableDefaultAssignment,

--- a/docs/config/lua/keyassignment/ActivateLastTab.md
+++ b/docs/config/lua/keyassignment/ActivateLastTab.md
@@ -1,0 +1,14 @@
+# ActivateLastTab
+
+Activate the last active tab. If there is none, it will do nothing.
+
+
+```lua
+return {
+  keys = {
+    {key="o", mods="LEADER|CTRL", action="ActivateLastTab"},
+  }
+}
+```
+
+

--- a/mux/src/window.rs
+++ b/mux/src/window.rs
@@ -10,6 +10,7 @@ pub struct Window {
     id: WindowId,
     tabs: Vec<Rc<Tab>>,
     active: usize,
+    last_active: Option<TabId>,
     clipboard: Option<Arc<dyn Clipboard>>,
     invalidated: bool,
 }
@@ -20,6 +21,7 @@ impl Window {
             id: WIN_ID.fetch_add(1, ::std::sync::atomic::Ordering::Relaxed),
             tabs: vec![],
             active: 0,
+            last_active: None,
             clipboard: None,
             invalidated: false,
         }
@@ -122,6 +124,19 @@ impl Window {
     #[inline]
     pub fn get_active_idx(&self) -> usize {
         self.active
+    }
+
+    pub fn save_last_active(&mut self) {
+        self.last_active = self.get_by_idx(self.active).map(|tab| tab.tab_id());
+    }
+
+    #[inline]
+    pub fn get_last_active_idx(&self) -> Option<usize> {
+        if let Some(tab_id) = self.last_active {
+            self.idx_by_id(tab_id)
+        } else {
+            None
+        }
     }
 
     pub fn set_active(&mut self, idx: usize) {

--- a/wezterm-gui/src/termwindow/spawn.rs
+++ b/wezterm-gui/src/termwindow/spawn.rs
@@ -186,6 +186,7 @@ impl super::TermWindow {
                     let mut window = mux
                         .get_window_mut(target_window_id)
                         .ok_or_else(|| anyhow!("no such window!?"))?;
+                    window.save_last_active();
                     if let Some(idx) = window.idx_by_id(tab_id) {
                         window.set_active(idx);
                     }


### PR DESCRIPTION
This replicates `last-window` in tmux. To pull this off, I
deliberately store the last tab whenever I'm activating a new one or
spawning a new one. I had to do this explicitly rather than hooking
set_active, because we end up setting the active tab briefly for some
common operations like moving a tab.