### PR TITLE
move sudo into script to not use sudo for rust checking

### DIFF
--- a/docs/install/source.markdown
+++ b/docs/install/source.markdown
@@ -22,7 +22,7 @@ curl https://sh.rustup.rs -sSf | sh -s
 curl -LO {{ src_stable }}
 tar -xzf {{ src_stable_asset }}
 cd {{ src_stable_dir }}
-sudo ./get-deps
+./get-deps
 cargo build --release
 cargo run --release --bin wezterm -- start
 ```
@@ -34,7 +34,7 @@ curl https://sh.rustup.rs -sSf | sh -s
 git clone --depth=1 --branch=main --recursive https://github.com/wez/wezterm.git
 cd wezterm
 git submodule update --init --recursive
-sudo ./get-deps
+./get-deps
 cargo build --release
 cargo run --release --bin wezterm -- start
 ```

--- a/get-deps
+++ b/get-deps
@@ -51,12 +51,16 @@ if ! check_rust_version ; then
   exit 1
 fi
 
+if test -z "${SUDO+x}" && hash sudo 2>/dev/null; then
+  SUDO="sudo"
+fi
+
 # Centos may not have lsb_release installed
 if test -e /etc/centos-release || test -e /etc/fedora-release; then
   if test -x /bin/dnf ; then
-    YUM=dnf
+    YUM="$SUDO dnf"
   else
-    YUM=yum
+    YUM="$SUDO yum"
   fi
   # Fedora 33 moved some perl bits around
   $YUM install -y perl-FindBin perl-File-Compare || true
@@ -82,8 +86,9 @@ if test -e /etc/centos-release || test -e /etc/fedora-release; then
 fi
 
 if test -x /usr/bin/lsb_release && test `lsb_release -si` = "openSUSE"; then
-  zypper install -y perl-FindBin perl-File-Compare || true
-  zypper install -y \
+  ZYPPER="$SUDO zypper"
+  $ZYPPER install -y perl-FindBin perl-File-Compare || true
+  $ZYPPER install -y \
     make \
     gcc \
     gcc-c++ \
@@ -104,7 +109,8 @@ if test -x /usr/bin/lsb_release && test `lsb_release -si` = "openSUSE"; then
 fi
 
 if test -e /etc/debian_version ; then
-  apt-get install -y \
+  APT="$SUDO apt-get"
+  $APT install -y \
     bsdutils \
     cmake \
     dpkg-dev \
@@ -132,7 +138,8 @@ if test -e /etc/debian_version ; then
 fi
 
 if test -e /etc/arch-release ; then
-  pacman -S --noconfirm --needed \
+  PACMAN="$SUDO pacman"
+  $PACMAN -S --noconfirm --needed \
     'cargo' \
     'cmake' \
     'fontconfig' \
@@ -155,7 +162,8 @@ case $OSTYPE in
     exit 0
   ;;
   freebsd*)
-    pkg install -y \
+    PKG="$SUDO pkg"
+    $PKG install -y \
       cmake \
       curl \
       egl-wayland \


### PR DESCRIPTION
Rust is typically installed per user rather than globally and hence when sudo is used typically either the executable is not found or a wrong version is used instead.

Update the docs

Test:
Ran `./get-deps` and verified rust version check passed and the package manager was executed with sudo privilige