### PR TITLE
Support unicode charaters in `selection_word_boundary`

### DIFF
--- a/wezterm-gui/src/selection.rs
+++ b/wezterm-gui/src/selection.rs
@@ -52,7 +52,7 @@ pub struct SelectionRange {
 }
 
 fn is_double_click_word(s: &str) -> bool {
-    match s.len() {
+    match s.chars().count() {
         1 => !config::configuration().selection_word_boundary.contains(s),
         0 => false,
         _ => true,


### PR DESCRIPTION
I want to support https://unicodelookup.com/#%E2%94%82/1 (this is used as the tmux pane separator)
This is marginally slower, and it only supports "Unicode Scalar Value"s (rust char) and not graphemes, but it should be a start!