### PR TITLE
termwiz: do not use terminfo for unsupported 256-colors

### DIFF
--- a/termwiz/src/render/terminfo.rs
+++ b/termwiz/src/render/terminfo.rs
@@ -124,6 +124,10 @@ impl TerminfoRenderer {
             }
 
             let has_true_color = self.caps.color_level() == ColorLevel::TrueColor;
+            let terminfo_color: i32 = match self.get_capability::<cap::MaxColors>() {
+                Some(cap::MaxColors(n)) => n,
+                None => 0,
+            };
 
             if attr.foreground != current_foreground {
                 match (has_true_color, attr.foreground) {
@@ -143,14 +147,17 @@ impl TerminfoRenderer {
                     }
                     (false, ColorAttribute::TrueColorWithPaletteFallback(_, idx))
                     | (_, ColorAttribute::PaletteIndex(idx)) => {
-                        if let Some(set) = self.get_capability::<cap::SetAForeground>() {
-                            set.expand().color(idx).to(out.by_ref())?;
-                        } else {
-                            write!(
-                                out,
-                                "{}",
-                                CSI::Sgr(Sgr::Foreground(ColorSpec::PaletteIndex(idx)))
-                            )?;
+                        match self.get_capability::<cap::SetAForeground>() {
+                            Some(set) if (idx as i32) < terminfo_color => {
+                                set.expand().color(idx).to(out.by_ref())?;
+                            }
+                            _ => {
+                                write!(
+                                    out,
+                                    "{}",
+                                    CSI::Sgr(Sgr::Foreground(ColorSpec::PaletteIndex(idx)))
+                                )?;
+                            }
                         }
                     }
                 }
@@ -174,14 +181,17 @@ impl TerminfoRenderer {
                     }
                     (false, ColorAttribute::TrueColorWithPaletteFallback(_, idx))
                     | (_, ColorAttribute::PaletteIndex(idx)) => {
-                        if let Some(set) = self.get_capability::<cap::SetABackground>() {
-                            set.expand().color(idx).to(out.by_ref())?;
-                        } else {
-                            write!(
-                                out,
-                                "{}",
-                                CSI::Sgr(Sgr::Background(ColorSpec::PaletteIndex(idx)))
-                            )?;
+                        match self.get_capability::<cap::SetABackground>() {
+                            Some(set) if (idx as i32) < terminfo_color => {
+                                set.expand().color(idx).to(out.by_ref())?;
+                            }
+                            _ => {
+                                write!(
+                                    out,
+                                    "{}",
+                                    CSI::Sgr(Sgr::Background(ColorSpec::PaletteIndex(idx)))
+                                )?;
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
I noticed edenscm log -p (using streampager) cannot render 256 colors
if TERM is not "*-256color", despite forcing enabling true colors in
streampager (https://github.com/markbt/streampager/pull/28).

I tracked it down here. The problem is that we ask terminfo for colors
it does not claim to support. Fix it by using fallback CSI rendering
for colors exceeding the terminfo max color.