### PR TITLE
conditionally include process divination for quit-confirm check on an…

### DIFF
--- a/mux/Cargo.toml
+++ b/mux/Cargo.toml
@@ -36,7 +36,7 @@ url = "2"
 wezterm-ssh = { path = "../wezterm-ssh" }
 wezterm-term = { path = "../term", features=["use_serde"] }
 
-[target.'cfg(all(windows, target_os="linux", target_os="macos"))'.dependencies]
+[target.'cfg(any(windows, target_os="linux", target_os="macos"))'.dependencies]
 sysinfo = "0.16"
 
 [dev-dependencies]

--- a/mux/src/localpane.rs
+++ b/mux/src/localpane.rs
@@ -598,7 +598,7 @@ impl LocalPane {
         #[allow(unused_mut)]
         let mut proc_names = vec![];
 
-        #[cfg(all(windows, target_os = "linux", target_os = "macos"))]
+        #[cfg(any(windows, target_os = "linux", target_os = "macos"))]
         if let ProcessState::Running { child, .. } = &*self.process.borrow() {
             if let Some(pid) = child.process_id() {
                 use sysinfo::{Pid, ProcessExt, RefreshKind, System, SystemExt};


### PR DESCRIPTION
…y win/linux/osx instead of all

I've always gotten the "Really kill this window...?" confirmation even with nothing open, and on looking in the docs and finding `skip_close_confirmation_for_processes_named` nothing I tried worked. I think it's just using the wrong predicate in `divine_process_list`; this behaves as expected on Linux.