### PR TITLE
Better function for undercurl

### DIFF
--- a/wezterm-gui/src/glyphcache.rs
+++ b/wezterm-gui/src/glyphcache.rs
@@ -899,7 +899,7 @@ impl<T: Texture2d> GlyphCache<T> {
 
                 for row in 0..self.metrics.underline_height as usize {
                     let value = (255. * (vertical - v).abs()) as u8;
-                    add(x, row + y + v as usize, 0x10, max_y, buffer);
+                    add(x, row + y + v as usize, 0x88, max_y, buffer);
                 }
             }
             println!("{:?}", *buffer);

--- a/wezterm-gui/src/glyphcache.rs
+++ b/wezterm-gui/src/glyphcache.rs
@@ -889,7 +889,7 @@ impl<T: Texture2d> GlyphCache<T> {
                 let pixel = buffer.pixel_mut(x, y);
                 let (current, _, _, _) = SrgbaPixel::with_srgba_u32(*pixel).as_rgba();
                 let value = current.saturating_add(val);
-                *pixel = SrgbaPixel::rgba(value, value, value, value).as_srgba32();
+                *pixel = SrgbaPixel::rgba(0xFF, 0xFF, 0xFF, val).as_srgba32();
             }
 
             for x in 0..self.metrics.cell_size.width as usize {

--- a/wezterm-gui/src/glyphcache.rs
+++ b/wezterm-gui/src/glyphcache.rs
@@ -893,14 +893,13 @@ impl<T: Texture2d> GlyphCache<T> {
             }
 
             for x in 0..self.metrics.cell_size.width as usize {
-                let vertical = wave_height as f32 * (x as f32 * x_factor).cos();
-                let v1 = vertical.floor();
-                let v2 = vertical.ceil();
+                let vertical = wave_height as f32 / -3. * (x as f32 * x_factor).sin()
+                    + wave_height as f32 / 2.;
+                let v = vertical.round();
 
                 for row in 0..self.metrics.underline_height as usize {
-                    let value = (255. * (vertical - v1).abs()) as u8;
-                    add(x, row + y + v1 as usize, 255 - value, max_y, buffer);
-                    add(x, row + y + v2 as usize, value, max_y, buffer);
+                    let value = (255. * (vertical - v).abs()) as u8;
+                    add(x, row + y + v as usize, 255 - value, max_y, buffer);
                 }
             }
         };

--- a/wezterm-gui/src/glyphcache.rs
+++ b/wezterm-gui/src/glyphcache.rs
@@ -880,7 +880,7 @@ impl<T: Texture2d> GlyphCache<T> {
             let wave_height =
                 self.metrics.cell_size.height - (cell_rect.origin.y + self.metrics.descender_row);
 
-            let half_height = (wave_height as f32 / 2.).max(1.);
+            let half_height = (wave_height as f32 / 4.).max(1.);
             let y =
                 (cell_rect.origin.y + self.metrics.descender_row) as usize - half_height as usize;
 
@@ -889,21 +889,20 @@ impl<T: Texture2d> GlyphCache<T> {
                 let pixel = buffer.pixel_mut(x, y);
                 let (current, _, _, _) = SrgbaPixel::with_srgba_u32(*pixel).as_rgba();
                 let value = current.saturating_add(val);
-                *pixel = SrgbaPixel::rgba(0xFF, 0xFF, 0xFF, val).as_srgba32();
+                *pixel = SrgbaPixel::rgba(value, value, value, value).as_srgba32();
             }
 
             for x in 0..self.metrics.cell_size.width as usize {
-                let vertical = wave_height as f32 / -3. * (x as f32 * x_factor).sin()
-                    + wave_height as f32 / 2.;
-                let v = vertical.round();
+                let vertical = -half_height * (x as f32 * x_factor).sin() + half_height;
+                let v1 = vertical.floor();
+                let v2 = vertical.ceil();
 
                 for row in 0..self.metrics.underline_height as usize {
-                    let value = (255. * (vertical - v).abs()) as u8;
-                    add(x, row + y + v as usize, 0x88, max_y, buffer);
+                    let value = (255. * (vertical - v1).abs()) as u8;
+                    add(x, row + y + v1 as usize, 255 - value, max_y, buffer);
+                    add(x, row + y + v2 as usize, value, max_y, buffer);
                 }
             }
-            println!("{:?}", *buffer);
-            buffer.log_bits();
         };
 
         let draw_double = |buffer: &mut Image| {

--- a/wezterm-gui/src/glyphcache.rs
+++ b/wezterm-gui/src/glyphcache.rs
@@ -889,7 +889,7 @@ impl<T: Texture2d> GlyphCache<T> {
                 let pixel = buffer.pixel_mut(x, y);
                 let (current, _, _, _) = SrgbaPixel::with_srgba_u32(*pixel).as_rgba();
                 let value = current.saturating_add(val);
-                *pixel = SrgbaPixel::rgba(value, value, value, 0xff).as_srgba32();
+                *pixel = SrgbaPixel::rgba(value, value, value, value).as_srgba32();
             }
 
             for x in 0..self.metrics.cell_size.width as usize {
@@ -899,9 +899,11 @@ impl<T: Texture2d> GlyphCache<T> {
 
                 for row in 0..self.metrics.underline_height as usize {
                     let value = (255. * (vertical - v).abs()) as u8;
-                    add(x, row + y + v as usize, 255 - value, max_y, buffer);
+                    add(x, row + y + v as usize, 0x10, max_y, buffer);
                 }
             }
+            println!("{:?}", *buffer);
+            buffer.log_bits();
         };
 
         let draw_double = |buffer: &mut Image| {

--- a/wezterm-gui/src/line-frag.glsl
+++ b/wezterm-gui/src/line-frag.glsl
@@ -25,7 +25,7 @@ void main() {
     // if the underline glyph isn't transparent in this position then
     // we take the underline color, otherwise we'll leave the color
     // at the background color.
-    color = o_underline_color;
+    color = under_color * o_underline_color;
   }
 
   // Similar to the above: if the cursor texture isn't transparent

--- a/wezterm-gui/src/line-frag.glsl
+++ b/wezterm-gui/src/line-frag.glsl
@@ -23,9 +23,9 @@ void main() {
   vec4 under_color = sample_texture(atlas_nearest_sampler, o_underline);
   if (under_color.a != 0.0) {
     // if the underline glyph isn't transparent in this position then
-    // we take the underline color, otherwise we'll leave the color
+    // we overlay the underline color, otherwise we'll leave the color
     // at the background color.
-    color = under_color * o_underline_color;
+    color = color * (1.0 - under_color) + under_color * o_underline_color;
   }
 
   // Similar to the above: if the cursor texture isn't transparent


### PR DESCRIPTION
This improves the rendering of the undercurl.

Before:
![image](https://user-images.githubusercontent.com/11978847/116011975-06ec8a80-a628-11eb-8b49-fcde12a00b87.png)

After:
![image](https://user-images.githubusercontent.com/11978847/116011981-0c49d500-a628-11eb-925b-98fe379af122.png)

All that is changed is the wave generation function.

What I noticed is, that the antialiasing is broken, therefor I removed
the second pixel draw, as that made the curl twice as thick as the
other lines.
