### PR TITLE
Better antialiasing for Undercurl

### DIFF
--- a/wezterm-gui/src/line-frag.glsl
+++ b/wezterm-gui/src/line-frag.glsl
@@ -23,9 +23,9 @@ void main() {
   vec4 under_color = sample_texture(atlas_nearest_sampler, o_underline);
   if (under_color.a != 0.0) {
     // if the underline glyph isn't transparent in this position then
-    // we take the underline color, otherwise we'll leave the color
+    // we overlay the underline color, otherwise we'll leave the color
     // at the background color.
-    color = under_color * o_underline_color;
+    color = color * (1.0 - under_color) + under_color * o_underline_color;
   }
 
   // Similar to the above: if the cursor texture isn't transparent


### PR DESCRIPTION
The reason I am making this request again, is that after using it for a while I noticed that the simpler calculation leaves artefacts:
Current (with dark pixels around undercurl):
![image](https://user-images.githubusercontent.com/11978847/120244990-1b95f100-c26c-11eb-94aa-7fd97baa8aa2.png)
With the more complex calculation:
![image](https://user-images.githubusercontent.com/11978847/120245002-251f5900-c26c-11eb-8d29-f68068885812.png)

old on the left, mine on the right:
![image](https://user-images.githubusercontent.com/11978847/120245271-fce42a00-c26c-11eb-91ca-882cad863ae2.png)
