### PR TITLE
[sextants] fix copy-and-paste error on U+1FB06

### DIFF
--- a/wezterm-gui/src/glyphcache.rs
+++ b/wezterm-gui/src/glyphcache.rs
@@ -237,7 +237,7 @@ impl BlockKey {
             0x1fb03 => Self::Sextants(Sextant::THREE),
             0x1fb04 => Self::Sextants(Sextant::ONE | Sextant::THREE),
             0x1fb05 => Self::Sextants(Sextant::TWO | Sextant::THREE),
-            0x1fb06 => Self::Sextants(Sextant::TWO | Sextant::TWO | Sextant::THREE),
+            0x1fb06 => Self::Sextants(Sextant::ONE | Sextant::TWO | Sextant::THREE),
             0x1fb07 => Self::Sextants(Sextant::FOUR),
             0x1fb08 => Self::Sextants(Sextant::ONE | Sextant::FOUR),
             0x1fb09 => Self::Sextants(Sextant::TWO | Sextant::FOUR),


### PR DESCRIPTION
As noted in https://github.com/dankamongmen/notcurses/issues/1715, there was a bad glyph definition among your sextants. This fixes it up.