### PR TITLE
Finish up DEC Special Graphics character set

### DIFF
--- a/term/src/terminalstate.rs
+++ b/term/src/terminalstate.rs
@@ -2965,9 +2965,7 @@ impl<'a> Performer<'a> {
         for g in unicode_segmentation::UnicodeSegmentation::graphemes(p.as_str(), true) {
             let g = if self.dec_line_drawing_mode {
                 match g {
-                    // AZL: I do not know why the diamond is red in vttest.
-                    "`" => "♦",
-
+                    "`" => "◆",
                     "a" => "▒",
 
                     // AZL: I do not know why the next four Unicode glyphs are

--- a/term/src/terminalstate.rs
+++ b/term/src/terminalstate.rs
@@ -35,6 +35,13 @@ struct TabStop {
     tab_width: usize,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CharSet {
+    Ascii,
+    Uk,
+    DecLineDrawing,
+}
+
 impl TabStop {
     fn new(screen_width: usize, tab_width: usize) -> Self {
         let mut tabs = Vec::with_capacity(screen_width);
@@ -103,7 +110,8 @@ struct SavedCursor {
     wrap_next: bool,
     pen: CellAttributes,
     dec_origin_mode: bool,
-    dec_line_drawing_mode: bool,
+    g0_charset: CharSet,
+    g1_charset: CharSet,
     // TODO: selective_erase when supported
 }
 
@@ -277,7 +285,11 @@ pub struct TerminalState {
     current_mouse_button: MouseButton,
     last_mouse_move: Option<MouseEvent>,
     cursor_visible: bool,
-    dec_line_drawing_mode: bool,
+
+    /// Support for US, UK, and DEC Special Graphics
+    g0_charset: CharSet,
+    g1_charset: CharSet,
+    shift_out: bool,
 
     tabs: TabStop,
 
@@ -478,7 +490,9 @@ impl TerminalState {
             mouse_tracking: false,
             last_mouse_move: None,
             cursor_visible: true,
-            dec_line_drawing_mode: false,
+            g0_charset: CharSet::Ascii,
+            g1_charset: CharSet::DecLineDrawing,
+            shift_out: false,
             current_mouse_button: MouseButton::None,
             tabs: TabStop::new(size.physical_cols, 8),
             title: "wezterm".to_string(),
@@ -2754,7 +2768,8 @@ impl TerminalState {
             wrap_next: self.wrap_next,
             pen: self.pen.clone(),
             dec_origin_mode: self.dec_origin_mode,
-            dec_line_drawing_mode: self.dec_line_drawing_mode,
+            g0_charset: self.g0_charset,
+            g1_charset: self.g1_charset,
         };
         debug!(
             "saving cursor {:?} is_alt={}",
@@ -2775,7 +2790,8 @@ impl TerminalState {
                 wrap_next: false,
                 pen: Default::default(),
                 dec_origin_mode: false,
-                dec_line_drawing_mode: false,
+                g0_charset: CharSet::Ascii,
+                g1_charset: CharSet::DecLineDrawing,
             });
         debug!(
             "restore cursor {:?} is_alt={}",
@@ -2791,7 +2807,9 @@ impl TerminalState {
         self.wrap_next = saved.wrap_next;
         self.pen = saved.pen;
         self.dec_origin_mode = saved.dec_origin_mode;
-        self.dec_line_drawing_mode = saved.dec_line_drawing_mode;
+        self.g0_charset = saved.g0_charset;
+        self.g1_charset = saved.g1_charset;
+        self.shift_out = false;
     }
 
     fn perform_csi_sgr(&mut self, sgr: Sgr) {
@@ -2963,26 +2981,20 @@ impl<'a> Performer<'a> {
         };
 
         for g in unicode_segmentation::UnicodeSegmentation::graphemes(p.as_str(), true) {
-            let g = if self.dec_line_drawing_mode {
+            let g = if (self.shift_out && self.g1_charset == CharSet::DecLineDrawing)
+                || (!self.shift_out && self.g0_charset == CharSet::DecLineDrawing)
+            {
                 match g {
                     "`" => "◆",
                     "a" => "▒",
-
-                    // AZL: I do not know why the next four Unicode glyphs are
-                    //      incorrect on the screen.
                     "b" => "␉",
                     "c" => "␌",
                     "d" => "␍",
                     "e" => "␊",
-
                     "f" => "°",
                     "g" => "±",
                     "h" => "␤",
-
-                    // AZL: I do not know with the next glyph is incorrect on
-                    //      the screen.
                     "i" => "␋",
-
                     "j" => "┘",
                     "k" => "┐",
                     "l" => "┌",
@@ -3004,6 +3016,13 @@ impl<'a> Performer<'a> {
                     "|" => "≠",
                     "}" => "£",
                     "~" => "·",
+                    _ => g,
+                }
+            } else if (self.shift_out && self.g1_charset == CharSet::Uk)
+                || (!self.shift_out && self.g0_charset == CharSet::Uk)
+            {
+                match g {
+                    "#" => "£",
                     _ => g,
                 }
             } else {
@@ -3212,9 +3231,18 @@ impl<'a> Performer<'a> {
                 }
             }
             ControlCode::RI => self.c1_reverse_index(),
-            ControlCode::ShiftIn | ControlCode::ShiftOut => {
-                // These sequences are used to switch between character sets.
-                // wezterm only supports UTF-8, so these do nothing.
+
+            // wezterm only supports UTF-8, so does not support the
+            // DEC National Replacement Character Sets.  However, it does
+            // support the DEC Special Graphics character set used by
+            // numerous ncurses applications.  DEC Special Graphics can be
+            // selected by ASCII Shift Out (0x0E, ^N) or by setting G0
+            // via ESC ( 0 .
+            ControlCode::ShiftIn => {
+                self.shift_out = false;
+            }
+            ControlCode::ShiftOut => {
+                self.shift_out = true;
             }
             _ => log::warn!("unhandled ControlCode {:?}", control),
         }
@@ -3255,11 +3283,23 @@ impl<'a> Performer<'a> {
             Esc::Code(EscCode::Index) => self.c1_index(),
             Esc::Code(EscCode::NextLine) => self.c1_nel(),
             Esc::Code(EscCode::HorizontalTabSet) => self.c1_hts(),
-            Esc::Code(EscCode::DecLineDrawing) => {
-                self.dec_line_drawing_mode = true;
+            Esc::Code(EscCode::DecLineDrawingG0) => {
+                self.g0_charset = CharSet::DecLineDrawing;
             }
-            Esc::Code(EscCode::AsciiCharacterSet) => {
-                self.dec_line_drawing_mode = false;
+            Esc::Code(EscCode::AsciiCharacterSetG0) => {
+                self.g0_charset = CharSet::Ascii;
+            }
+            Esc::Code(EscCode::UkCharacterSetG0) => {
+                self.g0_charset = CharSet::Uk;
+            }
+            Esc::Code(EscCode::DecLineDrawingG1) => {
+                self.g1_charset = CharSet::DecLineDrawing;
+            }
+            Esc::Code(EscCode::AsciiCharacterSetG1) => {
+                self.g1_charset = CharSet::Ascii;
+            }
+            Esc::Code(EscCode::UkCharacterSetG1) => {
+                self.g1_charset = CharSet::Uk;
             }
             Esc::Code(EscCode::DecSaveCursorPosition) => self.dec_save_cursor(),
             Esc::Code(EscCode::DecRestoreCursorPosition) => self.dec_restore_cursor(),
@@ -3311,7 +3351,9 @@ impl<'a> Performer<'a> {
                 self.button_event_mouse = false;
                 self.current_mouse_button = MouseButton::None;
                 self.cursor_visible = true;
-                self.dec_line_drawing_mode = false;
+                self.g0_charset = CharSet::Ascii;
+                self.g1_charset = CharSet::DecLineDrawing;
+                self.shift_out = false;
                 self.tabs = TabStop::new(self.screen().physical_cols, 8);
                 self.palette.take();
                 self.top_and_bottom_margins = 0..self.screen().physical_rows as VisibleRowIndex;

--- a/term/src/terminalstate.rs
+++ b/term/src/terminalstate.rs
@@ -103,7 +103,7 @@ struct SavedCursor {
     wrap_next: bool,
     pen: CellAttributes,
     dec_origin_mode: bool,
-    dec_line_drawing_mode : bool,
+    dec_line_drawing_mode: bool,
     // TODO: selective_erase when supported
 }
 

--- a/term/src/terminalstate.rs
+++ b/term/src/terminalstate.rs
@@ -103,6 +103,7 @@ struct SavedCursor {
     wrap_next: bool,
     pen: CellAttributes,
     dec_origin_mode: bool,
+    dec_line_drawing_mode : bool,
     // TODO: selective_erase when supported
 }
 
@@ -2753,6 +2754,7 @@ impl TerminalState {
             wrap_next: self.wrap_next,
             pen: self.pen.clone(),
             dec_origin_mode: self.dec_origin_mode,
+            dec_line_drawing_mode: self.dec_line_drawing_mode,
         };
         debug!(
             "saving cursor {:?} is_alt={}",
@@ -2773,6 +2775,7 @@ impl TerminalState {
                 wrap_next: false,
                 pen: Default::default(),
                 dec_origin_mode: false,
+                dec_line_drawing_mode: false,
             });
         debug!(
             "restore cursor {:?} is_alt={}",
@@ -2788,6 +2791,7 @@ impl TerminalState {
         self.wrap_next = saved.wrap_next;
         self.pen = saved.pen;
         self.dec_origin_mode = saved.dec_origin_mode;
+        self.dec_line_drawing_mode = saved.dec_line_drawing_mode;
     }
 
     fn perform_csi_sgr(&mut self, sgr: Sgr) {
@@ -2961,17 +2965,47 @@ impl<'a> Performer<'a> {
         for g in unicode_segmentation::UnicodeSegmentation::graphemes(p.as_str(), true) {
             let g = if self.dec_line_drawing_mode {
                 match g {
+                    // AZL: I do not know why the diamond is red in vttest.
+                    "`" => "♦",
+
+                    "a" => "▒",
+
+                    // AZL: I do not know why the next four Unicode glyphs are
+                    //      incorrect on the screen.
+                    "b" => "␉",
+                    "c" => "␌",
+                    "d" => "␍",
+                    "e" => "␊",
+
+                    "f" => "°",
+                    "g" => "±",
+                    "h" => "␤",
+
+                    // AZL: I do not know with the next glyph is incorrect on
+                    //      the screen.
+                    "i" => "␋",
+
                     "j" => "┘",
                     "k" => "┐",
                     "l" => "┌",
                     "m" => "└",
                     "n" => "┼",
+                    "o" => "⎺",
+                    "p" => "⎻",
                     "q" => "─",
+                    "r" => "⎼",
+                    "s" => "⎽",
                     "t" => "├",
                     "u" => "┤",
                     "v" => "┴",
                     "w" => "┬",
                     "x" => "│",
+                    "y" => "≤",
+                    "z" => "≥",
+                    "{" => "π",
+                    "|" => "≠",
+                    "}" => "£",
+                    "~" => "·",
                     _ => g,
                 }
             } else {

--- a/term/src/test/mod.rs
+++ b/term/src/test/mod.rs
@@ -680,6 +680,29 @@ fn test_delete_lines() {
     term.assert_dirty_lines(&[4], None);
 }
 
+/// Test DEC Special Graphics character set.
+#[test]
+fn test_dec_special_graphics() {
+    let mut term = TestTerm::new(2, 50, 0);
+
+    term.print("\u{1b}(0ABCabcdefghijklmnopqrstuvwxyzDEF\r\n\u{1b}(Bhello");
+    assert_visible_contents(
+        &term,
+        file!(),
+        line!(),
+        &["ABC▒␉␌␍␊°±␤␋┘┐┌└┼⎺⎻─⎼⎽├┤┴┬│≤≥DEF", "hello"],
+    );
+
+    term = TestTerm::new(2, 50, 0);
+    term.print("\u{0e}SO-ABCabcdefghijklmnopqrstuvwxyzDEF\r\n\u{0f}SI-hello");
+    assert_visible_contents(
+        &term,
+        file!(),
+        line!(),
+        &["SO-ABC▒␉␌␍␊°±␤␋┘┐┌└┼⎺⎻─⎼⎽├┤┴┬│≤≥DEF", "SI-hello"],
+    );
+}
+
 /// Test the behavior of wrapped lines when we resize the terminal
 /// wider and then narrower.
 #[test]

--- a/termwiz/src/escape/esc.rs
+++ b/termwiz/src/escape/esc.rs
@@ -179,7 +179,9 @@ mod test {
 
     #[test]
     fn test() {
-        assert_eq!(parse("(0"), Esc::Code(EscCode::DecLineDrawing));
-        assert_eq!(parse("(B"), Esc::Code(EscCode::AsciiCharacterSet));
+        assert_eq!(parse("(0"), Esc::Code(EscCode::DecLineDrawingG0));
+        assert_eq!(parse("(B"), Esc::Code(EscCode::AsciiCharacterSetG0));
+        assert_eq!(parse(")0"), Esc::Code(EscCode::DecLineDrawingG1));
+        assert_eq!(parse(")B"), Esc::Code(EscCode::AsciiCharacterSetG1));
     }
 }

--- a/termwiz/src/escape/esc.rs
+++ b/termwiz/src/escape/esc.rs
@@ -68,10 +68,19 @@ pub enum EscCode {
     /// DECPNM - Normal Keypad
     DecNormalKeyPad = esc!('>'),
 
-    /// Designate Character Set – DEC Line Drawing
-    DecLineDrawing = esc!('(', '0'),
-    /// Designate Character Set – US ASCII
-    AsciiCharacterSet = esc!('(', 'B'),
+    /// Designate G0 Character Set – DEC Line Drawing
+    DecLineDrawingG0 = esc!('(', '0'),
+    /// Designate G0 Character Set - UK
+    UkCharacterSetG0 = esc!('(', 'A'),
+    /// Designate G0 Character Set – US ASCII
+    AsciiCharacterSetG0 = esc!('(', 'B'),
+
+    /// Designate G1 Character Set – DEC Line Drawing
+    DecLineDrawingG1 = esc!(')', '0'),
+    /// Designate G1 Character Set - UK
+    UkCharacterSetG1 = esc!(')', 'A'),
+    /// Designate G1 Character Set – US ASCII
+    AsciiCharacterSetG1 = esc!(')', 'B'),
 
     /// https://vt100.net/docs/vt510-rm/DECALN.html
     DecScreenAlignmentDisplay = esc!('#', '8'),

--- a/termwiz/src/render/terminfo.rs
+++ b/termwiz/src/render/terminfo.rs
@@ -888,7 +888,7 @@ mod test {
                 Action::Print('o'),
                 Action::Print('t'),
                 Action::Print(' '),
-                Action::Esc(Esc::Code(EscCode::AsciiCharacterSet)),
+                Action::Esc(Esc::Code(EscCode::AsciiCharacterSetG0)),
                 Action::CSI(CSI::Sgr(Sgr::Reset)),
                 Action::CSI(CSI::Sgr(Sgr::Intensity(Intensity::Bold))),
                 Action::Print('f'),
@@ -1069,7 +1069,7 @@ mod test {
         assert_eq!(
             result,
             vec![
-                Action::Esc(Esc::Code(EscCode::AsciiCharacterSet)),
+                Action::Esc(Esc::Code(EscCode::AsciiCharacterSetG0)),
                 Action::CSI(CSI::Sgr(Sgr::Reset)),
                 // Note that the render code rearranges (red,bold) to (bold,red)
                 Action::CSI(CSI::Sgr(Sgr::Intensity(Intensity::Bold))),
@@ -1141,7 +1141,7 @@ mod test {
         assert_eq!(
             result,
             vec![
-                Action::Esc(Esc::Code(EscCode::AsciiCharacterSet)),
+                Action::Esc(Esc::Code(EscCode::AsciiCharacterSetG0)),
                 Action::CSI(CSI::Sgr(Sgr::Reset)),
                 // Note that the render code rearranges (red,bold) to (bold,red)
                 Action::CSI(CSI::Sgr(Sgr::Intensity(Intensity::Bold))),
@@ -1150,7 +1150,7 @@ mod test {
                 Action::Print('e'),
                 Action::Print('d'),
                 // Turning off bold is translated into reset and set red again
-                Action::Esc(Esc::Code(EscCode::AsciiCharacterSet)),
+                Action::Esc(Esc::Code(EscCode::AsciiCharacterSetG0)),
                 Action::CSI(CSI::Sgr(Sgr::Reset)),
                 Action::CSI(CSI::Sgr(Sgr::Foreground(AnsiColor::Maroon.into()))),
                 Action::Print('2'),


### PR DESCRIPTION
Hi!  This is my first PR ever in Rust, so it likely needs work.  But the point of it:

1. DEC Special Graphics is saved/restored by DECSC/DECRC.  (And it's actually not just one bool, it should be the selected character sets for G0, G1, G2, G3, and GR; and by default selectable via ASCII SO and SI.)
2. Added the remaining mappings.  I do not know why some of the glyphs aren't making it to the screen correctly.  These are all standard Unicode glyphs:  ◆▒␉␌␍␊°±␤␋┘┐┌└┼⎺⎻─⎼⎽├┤┴┬│≤≥π≠£·  Many of these are also accessible to ncurses applications via ACS_DIAMOND, ACS_CKBOARD, etc.

With these changes (and assuming you know how to fix the glyphs for ␉ ␌ ␍ ␊ ␋), this would finish out the screen features SAVE/RESTORE CURSOR screen, and get better on the VT100 character sets screen.
