### PR TITLE
Absolute working directory paths for CreateProcessW()

### DIFF
--- a/pty/src/cmdbuilder.rs
+++ b/pty/src/cmdbuilder.rs
@@ -243,7 +243,17 @@ impl CommandBuilder {
 
         dir.map(|dir| {
             let mut wide = vec![];
-            wide.extend(dir.encode_wide());
+
+            if Path::new(dir).is_relative() {
+                if let Ok(ccwd) = std::env::current_dir() {
+                    wide.extend(ccwd.join(dir).as_os_str().encode_wide());
+                } else {
+                    wide.extend(dir.encode_wide());
+                }
+            } else {
+                wide.extend(dir.encode_wide());
+            }
+
             wide.push(0);
             wide
         })


### PR DESCRIPTION
As mentioned in #900, CreateProcessW() expects a full path and behaves weirdly if the shell / parent process switched drives before with a relative path.