### PR TITLE
tmux-cc: force DcsPassThrough in tmux-cc mode

### DIFF
--- a/vtparse/src/lib.rs
+++ b/vtparse/src/lib.rs
@@ -679,6 +679,14 @@ impl VTParser {
             self.parse_byte(*b, actor);
         }
     }
+
+    /// Force DCS pass through for tmux cc
+    pub fn force_dcs_passthrough(&mut self, bytes: &[u8], actor: &mut dyn VTActor) {
+        for b in bytes {
+            let action = Action::Put;
+            self.action(action, *b, actor);
+        }
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
The thing about tmux-cc is that the pane-output actually contains escape sequences.

> The output has any characters less than ASCII 32 and the \ character replaced with their octal equivalent, so \ becomes \134. Otherwise, it is exactly what the application running in the pane sent to tmux. It may not be valid UTF-8 and may contain escape sequences which will be as expected by tmux

See: https://github.com/tmux/tmux/wiki/Control-Mode#pane-output

When the app is in tmux-cc mode, all characters received must be passed through the the DCS handler. The tmux-cc mode can only be terminated by "a %exit line and a corresponding ST (\033\) sequence"