### PR TITLE
Add support for setting arbitrary colors ranging from 16 to 256.

### DIFF
--- a/config/src/color.rs
+++ b/config/src/color.rs
@@ -106,8 +106,8 @@ impl From<Palette> for wezterm_term::color::ColorPalette {
                 p.colors.0[idx + 8] = *col;
             }
         }
-        for (idx, col) in cfg.indexed.iter() {
-            p.colors.0[*idx as usize] = *col;
+        for (&idx, &col) in &cfg.indexed {
+            p.colors.0[idx as usize] = col;
         }
         p
     }

--- a/config/src/color.rs
+++ b/config/src/color.rs
@@ -42,6 +42,9 @@ pub struct Palette {
     /// A list of 8 colors corresponding to bright versions of the
     /// ANSI palette
     pub brights: Option<[RgbColor; 8]>,
+    /// A map for setting arbitrary colors ranging from 16 to 256 in the color
+    /// palette
+    pub indexed: Option<HashMap<String, RgbColor>>,
     /// Configure the colors and styling of the tab bar
     pub tab_bar: Option<TabBarColors>,
     /// The color of the "thumb" of the scrollbar; the segment that
@@ -80,6 +83,13 @@ impl From<Palette> for wezterm_term::color::ColorPalette {
         if let Some(brights) = cfg.brights {
             for (idx, col) in brights.iter().enumerate() {
                 p.colors.0[idx + 8] = *col;
+            }
+        }
+        if let Some(indexed) = cfg.indexed {
+            for (idx, col) in indexed.iter()
+                    .filter_map(|(k, v)| Some((k.parse::<usize>().ok()?, v)))
+                    .filter(|&(k, _)| 15 < k && k < 256) {
+                p.colors.0[idx] = *col;
             }
         }
         p

--- a/config/src/color.rs
+++ b/config/src/color.rs
@@ -86,9 +86,11 @@ impl From<Palette> for wezterm_term::color::ColorPalette {
             }
         }
         if let Some(indexed) = cfg.indexed {
-            for (idx, col) in indexed.iter()
-                    .filter_map(|(k, v)| Some((k.parse::<usize>().ok()?, v)))
-                    .filter(|&(k, _)| 15 < k && k < 256) {
+            for (idx, col) in indexed
+                .iter()
+                .filter_map(|(k, v)| Some((k.parse::<usize>().ok()?, v)))
+                .filter(|&(k, _)| 15 < k && k < 256)
+            {
                 p.colors.0[idx] = *col;
             }
         }

--- a/docs/config/appearance.md
+++ b/docs/config/appearance.md
@@ -57,6 +57,9 @@ return {
 
       ansi = {"black", "maroon", "green", "olive", "navy", "purple", "teal", "silver"},
       brights = {"grey", "red", "lime", "yellow", "blue", "fuchsia", "aqua", "white"},
+
+      -- Arbitrary colors of the palette in the range from 16 to 255
+      indexed = {[136] = "#af8700"},
   }
 }
 ```


### PR DESCRIPTION
Hello there, I absolutely love this terminal emulator, however for my usecase I'd need support for setting all colors in the 256 color table, do you have any interest in that? This would be useful for colorschemes like gruvbox which define a lot of colors outside the standard 4-bit color range. This pull request is my attempt to address this shortcoming. I followed the approach of [alacritty](https://github.com/alacritty/alacritty/blob/master/alacritty.yml#L275-L319) here which beside the `ansi` and `bright` tables allows to set arbitrary colors from 16 to 256 in an `indexed` table. This would for example make it possible to specify the whole gruvbox colorscheme like this:
```lua
local config = {
  color_scheme = "Gruvbox Dark Medium",
  color_schemes = {
    ["Gruvbox Dark Medium"] = {
      foreground = "#ebdbb2",
      background = "#282828",
      cursor_bg = "#ebdbb2",
      cursor_border = "#ebdbb2",
      cursor_fg = "#282828",
      selection_bg = "#ebdbb2",
      selection_fg = "#282828",

      ansi = {"#282828","#cc241d","#98971a","#d79921","#458588","#b16286","#689d6a","#a89984"},
      brights = {"#928374","#fb4934","#b8bb26","#fabd2f","#83a598","#d3869b","#8ec07c","#ebdbb2"},
      indexed = {
        [24]  = "#076678", [66]  = "#458588", [72]  = "#689d6a", [88]  = "#9d0006", [96]  = "#8f3f71",
        [100] = "#79740e", [106] = "#98971a", [108] = "#8ec07c", [109] = "#83a598", [124] = "#cc241d",
        [130] = "#af3a03", [132] = "#b16286", [136] = "#b57614", [142] = "#b8bb26", [166] = "#d65d0e",
        [167] = "#fb4934", [172] = "#d79921", [175] = "#d3869b", [208] = "#fe8019", [214] = "#fabd2f",
        [223] = "#ebdbb2", [228] = "#f2e5bc", [229] = "#fbf1c7", [230] = "#f9f5d7", [234] = "#1d2021",
        [235] = "#282828", [236] = "#32302f", [237] = "#3c3836", [239] = "#504945", [241] = "#665c54",
        [243] = "#7c6f64", [244] = "#928374", [245] = "#928374", [246] = "#a89984", [248] = "#bdae93",
        [250] = "#d5c4a1"
      }
    }
  }
}
```
This pull request would fix #841.