### PR TITLE
window: use system library for xcb-imdkit-rs

### DIFF
--- a/get-deps
+++ b/get-deps
@@ -77,6 +77,7 @@ if test -e /etc/centos-release || test -e /etc/fedora-release; then
     libxkbcommon-x11-devel \
     wayland-devel \
     mesa-libEGL-devel \
+    xcb-imdkit-devel \
     xcb-util-devel \
     xcb-util-keysyms-devel \
     xcb-util-image-devel \
@@ -102,6 +103,7 @@ if test -x /usr/bin/lsb_release && test `lsb_release -si` = "openSUSE"; then
     libxkbcommon-x11-devel \
     wayland-devel \
     Mesa-libEGL-devel \
+    xcb-imdkit-devel \
     xcb-util-devel \
     xcb-util-keysyms-devel \
     xcb-util-image-devel \
@@ -127,6 +129,7 @@ if test -e /etc/debian_version ; then
     libx11-xcb-dev \
     libxcb-ewmh-dev \
     libxcb-icccm4-dev \
+    libxcb-imdkit-dev \
     libxcb-image0-dev \
     libxcb-keysyms1-dev \
     libxcb-render0-dev \
@@ -155,6 +158,7 @@ if test -e /etc/arch-release ; then
     'python3' \
     'rust' \
     'wayland' \
+    'xcb-imdkit' \
     'xcb-util' \
     'xcb-util-image' \
     'xcb-util-keysyms' \
@@ -189,6 +193,7 @@ case $OSTYPE in
       rust \
       wayland \
       libxcb \
+      xcb-imdkit \
       xcb-util \
       xcb-util-image \
       xcb-util-keysyms \

--- a/window/Cargo.toml
+++ b/window/Cargo.toml
@@ -73,7 +73,7 @@ smithay-client-toolkit = {version = "0.14", default-features=false, optional=tru
 wayland-protocols = {version="0.28", optional=true}
 wayland-client = {version="0.28", optional=true}
 wayland-egl = {version="0.28", optional=true}
-xcb-imdkit = "0.1"
+xcb-imdkit = { version = "0.1", features = ["use-system-lib"] }
 
 [target.'cfg(target_os="macos")'.dependencies]
 cocoa = "0.20"


### PR DESCRIPTION
This is especially important if no network (and git repository)
is available at build time like it is when building wezterm in nixpkgs.