### PR TITLE
Remove TryExec to fix desktop file on Debian Bookworm

### DIFF
--- a/assets/wezterm.desktop
+++ b/assets/wezterm.desktop
@@ -3,7 +3,6 @@ Name=WezTerm
 Comment=Wez's Terminal Emulator
 Keywords=shell;prompt;command;commandline;cmd;
 Icon=org.wezfurlong.wezterm
-TryExec=wezterm
 Exec=wezterm
 Type=Application
 Categories=System;TerminalEmulator;Utility;


### PR DESCRIPTION
My Debian Bookworm with Plasma KDE is really really unhappy about this line and refuses to do open wezterm at all. When I remove it everything works.

![image](https://user-images.githubusercontent.com/7258858/130828828-e8aa8863-d5cb-463c-8167-f96e0aa7594e.png)
