### PR TITLE
X11: Composite isn't required anymore

### DIFF
--- a/window/src/os/x11/connection.rs
+++ b/window/src/os/x11/connection.rs
@@ -407,7 +407,7 @@ impl XConnection {
             if depth_bpp == 24 || depth_bpp == 32 {
                 for vis in depth.visuals() {
                     if vis.class() == xcb::xproto::VISUAL_CLASS_TRUE_COLOR as u8
-                        && vis.bits_per_rgb_value() == 8
+                        && vis.bits_per_rgb_value() >= 8
                     {
                         visuals.push((depth_bpp, vis));
                     }


### PR DESCRIPTION
on X11 bits_per_value() reports 11 when Composite is disabled and 8 otherwise, so let's make both acceptable, shall we?