### PR TITLE
Document workaround for get_appearance on GNOME Wayland

### DIFF
--- a/docs/config/lua/window/get_appearance.md
+++ b/docs/config/lua/window/get_appearance.md
@@ -45,40 +45,40 @@ end)
 return {
 }
 ```
-### Wayland GNOME Workaround
 
-If you happen to be running a Wayland session through GNOME desktop,
-a workaround exists in which you can query the `gsettings` command
-for the theme name. While GNOME does not specifically support
-appearance, it is common for themes to provide a dark variant (and
-this is the case for the default "Adwaita" theme), which are typically
-named with "-dark" appended to the theme name. With this heuristic,
-we can determine if GNOME is in dark mode or not, and abuse the
-[update-right-status](../window-events/update-right-status.md)
-event to poll for changes. When coupled with the [Night
-Theme](https://nightthemeswitcher.romainvigier.fr/) extension or
-similar, you can enjoy a Wezterm that changes theme based on day night
-cycle with the rest of your system.
+### Wayland GNOME Appearance
+
+The GNOME desktop environment provides the `gsettings` tool that can
+inform us of the selected appearance even in a Wayland session. We can
+substitute the call to `window:get_appearance` above with a call to the
+following function, which takes advantage of this.
 
 ```lua
-function·compute_scheme_gnome_wayland()¬
-··local·success,·stdout·=·wezterm.run_child_process(¬
-····{"gsettings",·"get",·"org.gnome.desktop.interface",·"gtk-theme"}¬
-··)¬
-··if·stdout:match("-dark")·then¬
-····return·"Builtin Solarized Dark"¬
-··else¬
-····return·"Builtin Solarized Light"¬
-··end¬
-end¬
-¬
-wezterm.on("update-right-status",·function(window,·pane)¬
-··local·overrides·=·window:get_config_overrides()·or·{}¬
-··local·scheme·=·compute_scheme_gnome_wayland()¬
-··if·overrides.color_scheme·~=·scheme·then¬
-····overrides.color_scheme·=·scheme¬
-····window:set_config_overrides(overrides)¬
-··end¬
-end)¬
+function query_appearance_gnome()
+  local success, stdout = wezterm.run_child_process(
+    {"gsettings", "get", "org.gnome.desktop.interface", "gtk-theme"}
+  )
+  -- lowercase and remove whitespace
+  stdout = stdout:lower():gsub("%s+", "")
+  local mapping = {
+     highcontrast = "LightHighContrast",
+     highcontrastinverse = "DarkHighContrast",
+     adwaita = "Light",
+     ["adwaita-dark"] = "Dark"
+  }
+  local appearance = mapping[stdout]
+  if appearance then
+     return appearance
+  end
+  if stdout:find("dark") then
+     return "Dark"
+  end
+  return "Light"
+end
 ```
+
+Since Wezterm will not fire a `window-config-reloaded`
+event on Wayland, you will instead need to listen on the
+[update-right-status](../window-events/update-right-status.md) event,
+which will essentially poll for the appearance continuously.
 

--- a/docs/config/lua/window/get_appearance.md
+++ b/docs/config/lua/window/get_appearance.md
@@ -45,4 +45,40 @@ end)
 return {
 }
 ```
+### Wayland GNOME Workaround
+
+If you happen to be running a Wayland session through GNOME desktop,
+a workaround exists in which you can query the `gsettings` command
+for the theme name. While GNOME does not specifically support
+appearance, it is common for themes to provide a dark variant (and
+this is the case for the default "Adwaita" theme), which are typically
+named with "-dark" appended to the theme name. With this heuristic,
+we can determine if GNOME is in dark mode or not, and abuse the
+[update-right-status](../window-events/update-right-status.md)
+event to poll for changes. When coupled with the [Night
+Theme](https://nightthemeswitcher.romainvigier.fr/) extension or
+similar, you can enjoy a Wezterm that changes theme based on day night
+cycle with the rest of your system.
+
+```lua
+function·compute_scheme_gnome_wayland()¬
+··local·success,·stdout·=·wezterm.run_child_process(¬
+····{"gsettings",·"get",·"org.gnome.desktop.interface",·"gtk-theme"}¬
+··)¬
+··if·stdout:match("-dark")·then¬
+····return·"Builtin Solarized Dark"¬
+··else¬
+····return·"Builtin Solarized Light"¬
+··end¬
+end¬
+¬
+wezterm.on("update-right-status",·function(window,·pane)¬
+··local·overrides·=·window:get_config_overrides()·or·{}¬
+··local·scheme·=·compute_scheme_gnome_wayland()¬
+··if·overrides.color_scheme·~=·scheme·then¬
+····overrides.color_scheme·=·scheme¬
+····window:set_config_overrides(overrides)¬
+··end¬
+end)¬
+```
 


### PR DESCRIPTION
This adds a note about how to acheive dark mode detection on GNOME Wayland systems, for future generations. Follows up on #1098 