### PR TITLE
get-deps: Zypper needs -l (--auto-agree-with-licenses)

### DIFF
--- a/get-deps
+++ b/get-deps
@@ -88,8 +88,8 @@ fi
 
 if test -x /usr/bin/lsb_release && test `lsb_release -si` = "openSUSE"; then
   ZYPPER="$SUDO zypper"
-  $ZYPPER install -y perl-FindBin perl-File-Compare || true
-  $ZYPPER install -y \
+  $ZYPPER install -yl perl-FindBin perl-File-Compare || true
+  $ZYPPER install -yl \
     make \
     gcc \
     gcc-c++ \


### PR DESCRIPTION
Without this switch, zypper would automatically answer "no" to any license agreements, halting the update.