### PR TITLE
window: unbreak bypass_mouse_reporting_modifiers on Wayland (fixes #1122)

### DIFF
--- a/window/src/os/wayland/window.rs
+++ b/window/src/os/wayland/window.rs
@@ -396,6 +396,7 @@ impl WaylandWindowInner {
                 ..
             } => {
                 mapper.update_modifier_state(mods_depressed, mods_latched, mods_locked, group);
+                self.modifiers = mapper.get_key_modifiers();
             }
             _ => {}
         }


### PR DESCRIPTION
Modifier state was not saved to the `modifiers` field that's read when converting mouse events, so these events always had no modifiers.