### PR TITLE
gui: cancel mouse click streak when the cursor has moved to a different cell (fixes #910)

### DIFF
--- a/term/src/input.rs
+++ b/term/src/input.rs
@@ -45,10 +45,12 @@ pub struct MouseEvent {
 /// which is the number of successive clicks of the same mouse button
 /// within the `CLICK_INTERVAL`.  The streak is reset to 1 each time
 /// the mouse button differs from the last click, or when the elapsed
-/// time exceeds `CLICK_INTERVAL`.
+/// time exceeds `CLICK_INTERVAL`, or when the cursor position
+/// changes to a different character cell.
 #[derive(Debug, Clone)]
 pub struct LastMouseClick {
     pub button: MouseButton,
+    position: (usize, i64),
     time: Instant,
     pub streak: usize,
 }
@@ -57,17 +59,19 @@ pub struct LastMouseClick {
 const CLICK_INTERVAL: u64 = 500;
 
 impl LastMouseClick {
-    pub fn new(button: MouseButton) -> Self {
+    pub fn new(button: MouseButton, position: (usize, i64)) -> Self {
         Self {
             button,
+            position,
             time: Instant::now(),
             streak: 1,
         }
     }
 
-    pub fn add(&self, button: MouseButton) -> Self {
+    pub fn add(&self, button: MouseButton, position: (usize, i64)) -> Self {
         let now = Instant::now();
         let streak = if button == self.button
+            && position == self.position
             && now.duration_since(self.time) <= Duration::from_millis(CLICK_INTERVAL)
         {
             self.streak + 1
@@ -76,6 +80,7 @@ impl LastMouseClick {
         };
         Self {
             button,
+            position,
             time: now,
             streak,
         }

--- a/wezterm-gui/src/termwindow/mouseevent.rs
+++ b/wezterm-gui/src/termwindow/mouseevent.rs
@@ -125,8 +125,8 @@ impl super::TermWindow {
                 let button = mouse_press_to_tmb(press);
 
                 let click = match self.last_mouse_click.take() {
-                    None => LastMouseClick::new(button),
-                    Some(click) => click.add(button),
+                    None => LastMouseClick::new(button, (x, y)),
+                    Some(click) => click.add(button, (x, y)),
                 };
                 self.last_mouse_click = Some(click);
                 self.current_mouse_buttons.retain(|p| p != press);


### PR DESCRIPTION
Fast-clicking users generally expect to be able to rapidly do regular selections or otherwise cancel double/triple/quad clicks, so significant mouse movement should end the streak.

Allowing tiny pixel movements to account for touchpads is necessary.
Fortunately, the position here is already in character grid cells, which provides enough margin for this.
Other code editors like gedit also seem to do this based on the character grid.

---

@zhou13 hopefully this solves #910