### PR TITLE
docs: Ensure Ctrl-Shift-Space binding is readable

### DIFF
--- a/docs/config/keys.md
+++ b/docs/config/keys.md
@@ -185,7 +185,7 @@ The default key bindings are:
 | `SUPER`          | `f`    | `Search={CaseSensitiveString=""}` |
 | `CTRL+SHIFT`     | `F`    | `Search={CaseSensitiveString=""}` |
 | `CTRL+SHIFT`     | `X`    | `ActivateCopyMode` |
-| `CTRL+SHIFT`     | ` `    | `QuickSelect` (*since: 20210502-130208-bff6815d*) |
+| `CTRL+SHIFT`     | ` ` (`Space`)   | `QuickSelect` (*since: 20210502-130208-bff6815d*) |
 | `CTRL+SHIFT+ALT` | `"`    | `SplitVertical={domain="CurrentPaneDomain"}` |
 | `CTRL+SHIFT+ALT` | `%`    | `SplitHorizontal={domain="CurrentPaneDomain"}` |
 | `CTRL+SHIFT+ALT` | `LeftArrow`    | `AdjustPaneSize={"Left", 1}` |


### PR DESCRIPTION
Necessary, because with the default dark background, the space is invisible:
![invisible-space](https://user-images.githubusercontent.com/9730330/133510773-835b411d-7f7d-44b2-9fe6-80c89b3a5ebf.png)
