### PR TITLE
lua: Add `wezterm.action_callback` to help define key callbacks

### DIFF
--- a/docs/config/lua/wezterm/action_callback.md
+++ b/docs/config/lua/wezterm/action_callback.md
@@ -1,0 +1,39 @@
+# `wezterm.action_callback(callback)`
+
+*Since: nightly*
+
+This function is a helper to register a custom event and return an action triggering it.
+
+It is helpful to write custom key bindings directly, without having to declare
+the event and use it in a different place.
+
+The implementation is essentially the same as:
+```lua
+function wezterm.action_callback(callback)
+  local event_id = "..." -- the function generates a unique event id
+  wezterm.on(event_id, callback)
+  return wezterm.action{EmitEvent=event_id}
+end
+```
+
+See [wezterm.on](./on.md) and [wezterm.action](./action.md) for more info on what you can do with these.
+
+
+## Usage
+
+```lua
+local wezterm = require 'wezterm';
+
+return {
+  keys = {
+    {
+      mods = "CTRL|SHIFT",
+      key = "i",
+      action = wezterm.action_callback(function(win, pane)
+        wezterm.log_info("Hello from callback!")
+        wezterm.log_info("WindowID:", win:window_id(), "PaneID:", pane:pane_id())
+      end)
+    },
+  }
+}
+```

--- a/docs/config/lua/wezterm/action_callback.md
+++ b/docs/config/lua/wezterm/action_callback.md
@@ -1,6 +1,6 @@
 # `wezterm.action_callback(callback)`
 
-*Since: nightly*
+*Since: nightly builds only*
 
 This function is a helper to register a custom event and return an action triggering it.
 

--- a/docs/config/lua/wezterm/on.md
+++ b/docs/config/lua/wezterm/on.md
@@ -22,6 +22,8 @@ There is no way to de-register an event handler.  However, since the Lua
 state is built from scratch when the configuration is reloaded, simply
 reloading the configuration will clear any existing event handlers.
 
+See [wezterm.action_callback](./action_callback.md) for a helper to define a custom action callback.
+
 ## Predefined Events
 
 See [Window Events](../window-events/index.md) for a list of pre-defined


### PR DESCRIPTION
Following up on https://matrix.to/#/!PirwUBcuIlTXwNveYz:matrix.org/$ets1eEk2ixZ3MgxHLrrpOoo2Rg3VI6Cg4z82IYxsOqA?via=matrix.org

I couldn't find a way to get the filename/linenumber of the call to use it for the event name without trying to use unsafe code.
It's actually not that bad, because as error in the callback will show a traceback with correct filename/linenumber.

:upside_down_face: 