### PR TITLE
Do not run upload action on forks

### DIFF
--- a/.github/workflows/gen_centos7_continuous.yml
+++ b/.github/workflows/gen_centos7_continuous.yml
@@ -143,6 +143,7 @@ jobs:
 
     - name: "Upload to Nightly Release"
       uses: wez/upload-release-assets@releases/v1
+      if: github.event.repository.fork == false
       with:
          files: "wezterm-*.rpm"
          release-tag: "nightly"

--- a/.github/workflows/gen_centos7_tag.yml
+++ b/.github/workflows/gen_centos7_tag.yml
@@ -90,6 +90,7 @@ jobs:
       run: "mv ~/rpmbuild/RPMS/*/*.rpm ."
     - name: "Upload to Tagged Release"
       uses: softprops/action-gh-release@v1
+      if: github.event.repository.fork == false
       with:
          files: "wezterm-*.rpm"
          prerelease: true

--- a/.github/workflows/gen_centos8_continuous.yml
+++ b/.github/workflows/gen_centos8_continuous.yml
@@ -126,6 +126,7 @@ jobs:
 
     - name: "Upload to Nightly Release"
       uses: wez/upload-release-assets@releases/v1
+      if: github.event.repository.fork == false
       with:
          files: "wezterm-*.rpm"
          release-tag: "nightly"

--- a/.github/workflows/gen_centos8_tag.yml
+++ b/.github/workflows/gen_centos8_tag.yml
@@ -71,6 +71,7 @@ jobs:
       run: "mv ~/rpmbuild/RPMS/*/*.rpm ."
     - name: "Upload to Tagged Release"
       uses: softprops/action-gh-release@v1
+      if: github.event.repository.fork == false
       with:
          files: "wezterm-*.rpm"
          prerelease: true

--- a/.github/workflows/gen_debian10.3_continuous.yml
+++ b/.github/workflows/gen_debian10.3_continuous.yml
@@ -119,6 +119,7 @@ jobs:
 
     - name: "Upload to Nightly Release"
       uses: wez/upload-release-assets@releases/v1
+      if: github.event.repository.fork == false
       with:
          files: "wezterm-*.deb;wezterm-*.xz;wezterm-*.tar.gz"
          release-tag: "nightly"

--- a/.github/workflows/gen_debian10.3_tag.yml
+++ b/.github/workflows/gen_debian10.3_tag.yml
@@ -68,6 +68,7 @@ jobs:
       run: "bash ci/deploy.sh"
     - name: "Upload to Tagged Release"
       uses: softprops/action-gh-release@v1
+      if: github.event.repository.fork == false
       with:
          files: |
             wezterm-*.deb

--- a/.github/workflows/gen_debian11_continuous.yml
+++ b/.github/workflows/gen_debian11_continuous.yml
@@ -119,6 +119,7 @@ jobs:
 
     - name: "Upload to Nightly Release"
       uses: wez/upload-release-assets@releases/v1
+      if: github.event.repository.fork == false
       with:
          files: "wezterm-*.deb;wezterm-*.xz;wezterm-*.tar.gz"
          release-tag: "nightly"

--- a/.github/workflows/gen_debian11_tag.yml
+++ b/.github/workflows/gen_debian11_tag.yml
@@ -68,6 +68,7 @@ jobs:
       run: "bash ci/deploy.sh"
     - name: "Upload to Tagged Release"
       uses: softprops/action-gh-release@v1
+      if: github.event.repository.fork == false
       with:
          files: |
             wezterm-*.deb

--- a/.github/workflows/gen_debian9.12_continuous.yml
+++ b/.github/workflows/gen_debian9.12_continuous.yml
@@ -136,6 +136,7 @@ jobs:
 
     - name: "Upload to Nightly Release"
       uses: wez/upload-release-assets@releases/v1
+      if: github.event.repository.fork == false
       with:
          files: "wezterm-*.deb;wezterm-*.xz;wezterm-*.tar.gz"
          release-tag: "nightly"

--- a/.github/workflows/gen_debian9.12_tag.yml
+++ b/.github/workflows/gen_debian9.12_tag.yml
@@ -87,6 +87,7 @@ jobs:
       run: "bash ci/deploy.sh"
     - name: "Upload to Tagged Release"
       uses: softprops/action-gh-release@v1
+      if: github.event.repository.fork == false
       with:
          files: |
             wezterm-*.deb

--- a/.github/workflows/gen_fedora31_continuous.yml
+++ b/.github/workflows/gen_fedora31_continuous.yml
@@ -112,6 +112,7 @@ jobs:
 
     - name: "Upload to Nightly Release"
       uses: wez/upload-release-assets@releases/v1
+      if: github.event.repository.fork == false
       with:
          files: "wezterm-*.rpm"
          release-tag: "nightly"

--- a/.github/workflows/gen_fedora31_tag.yml
+++ b/.github/workflows/gen_fedora31_tag.yml
@@ -65,6 +65,7 @@ jobs:
       run: "mv ~/rpmbuild/RPMS/*/*.rpm ."
     - name: "Upload to Tagged Release"
       uses: softprops/action-gh-release@v1
+      if: github.event.repository.fork == false
       with:
          files: "wezterm-*.rpm"
          prerelease: true

--- a/.github/workflows/gen_fedora32_continuous.yml
+++ b/.github/workflows/gen_fedora32_continuous.yml
@@ -112,6 +112,7 @@ jobs:
 
     - name: "Upload to Nightly Release"
       uses: wez/upload-release-assets@releases/v1
+      if: github.event.repository.fork == false
       with:
          files: "wezterm-*.rpm"
          release-tag: "nightly"

--- a/.github/workflows/gen_fedora32_tag.yml
+++ b/.github/workflows/gen_fedora32_tag.yml
@@ -65,6 +65,7 @@ jobs:
       run: "mv ~/rpmbuild/RPMS/*/*.rpm ."
     - name: "Upload to Tagged Release"
       uses: softprops/action-gh-release@v1
+      if: github.event.repository.fork == false
       with:
          files: "wezterm-*.rpm"
          prerelease: true

--- a/.github/workflows/gen_fedora33_continuous.yml
+++ b/.github/workflows/gen_fedora33_continuous.yml
@@ -112,6 +112,7 @@ jobs:
 
     - name: "Upload to Nightly Release"
       uses: wez/upload-release-assets@releases/v1
+      if: github.event.repository.fork == false
       with:
          files: "wezterm-*.rpm"
          release-tag: "nightly"

--- a/.github/workflows/gen_fedora33_tag.yml
+++ b/.github/workflows/gen_fedora33_tag.yml
@@ -65,6 +65,7 @@ jobs:
       run: "mv ~/rpmbuild/RPMS/*/*.rpm ."
     - name: "Upload to Tagged Release"
       uses: softprops/action-gh-release@v1
+      if: github.event.repository.fork == false
       with:
          files: "wezterm-*.rpm"
          prerelease: true

--- a/.github/workflows/gen_fedora34_continuous.yml
+++ b/.github/workflows/gen_fedora34_continuous.yml
@@ -112,6 +112,7 @@ jobs:
 
     - name: "Upload to Nightly Release"
       uses: wez/upload-release-assets@releases/v1
+      if: github.event.repository.fork == false
       with:
          files: "wezterm-*.rpm"
          release-tag: "nightly"

--- a/.github/workflows/gen_fedora34_tag.yml
+++ b/.github/workflows/gen_fedora34_tag.yml
@@ -65,6 +65,7 @@ jobs:
       run: "mv ~/rpmbuild/RPMS/*/*.rpm ."
     - name: "Upload to Tagged Release"
       uses: softprops/action-gh-release@v1
+      if: github.event.repository.fork == false
       with:
          files: "wezterm-*.rpm"
          prerelease: true

--- a/.github/workflows/gen_macos_continuous.yml
+++ b/.github/workflows/gen_macos_continuous.yml
@@ -112,6 +112,7 @@ jobs:
 
     - name: "Upload to Nightly Release"
       uses: wez/upload-release-assets@releases/v1
+      if: github.event.repository.fork == false
       with:
          files: "WezTerm-*.zip"
          release-tag: "nightly"

--- a/.github/workflows/gen_macos_tag.yml
+++ b/.github/workflows/gen_macos_tag.yml
@@ -85,6 +85,7 @@ jobs:
 
     - name: "Upload to Tagged Release"
       uses: softprops/action-gh-release@v1
+      if: github.event.repository.fork == false
       with:
          files: "WezTerm-*.zip"
          prerelease: true

--- a/.github/workflows/gen_ubuntu16_continuous.yml
+++ b/.github/workflows/gen_ubuntu16_continuous.yml
@@ -119,6 +119,7 @@ jobs:
 
     - name: "Upload to Nightly Release"
       uses: wez/upload-release-assets@releases/v1
+      if: github.event.repository.fork == false
       with:
          files: "wezterm-*.deb;wezterm-*.xz;wezterm-*.tar.gz;*.AppImage;*.zsync"
          release-tag: "nightly"

--- a/.github/workflows/gen_ubuntu16_tag.yml
+++ b/.github/workflows/gen_ubuntu16_tag.yml
@@ -68,6 +68,7 @@ jobs:
       run: "bash ci/appimage.sh"
     - name: "Upload to Tagged Release"
       uses: softprops/action-gh-release@v1
+      if: github.event.repository.fork == false
       with:
          files: |
             wezterm-*.deb

--- a/.github/workflows/gen_ubuntu18_continuous.yml
+++ b/.github/workflows/gen_ubuntu18_continuous.yml
@@ -105,6 +105,7 @@ jobs:
 
     - name: "Upload to Nightly Release"
       uses: wez/upload-release-assets@releases/v1
+      if: github.event.repository.fork == false
       with:
          files: "wezterm-*.deb;wezterm-*.xz;wezterm-*.tar.gz"
          release-tag: "nightly"

--- a/.github/workflows/gen_ubuntu18_tag.yml
+++ b/.github/workflows/gen_ubuntu18_tag.yml
@@ -62,6 +62,7 @@ jobs:
       run: "bash ci/deploy.sh"
     - name: "Upload to Tagged Release"
       uses: softprops/action-gh-release@v1
+      if: github.event.repository.fork == false
       with:
          files: |
             wezterm-*.deb

--- a/.github/workflows/gen_ubuntu20.04_continuous.yml
+++ b/.github/workflows/gen_ubuntu20.04_continuous.yml
@@ -119,6 +119,7 @@ jobs:
 
     - name: "Upload to Nightly Release"
       uses: wez/upload-release-assets@releases/v1
+      if: github.event.repository.fork == false
       with:
          files: "wezterm-*.deb;wezterm-*.xz;wezterm-*.tar.gz"
          release-tag: "nightly"

--- a/.github/workflows/gen_ubuntu20.04_tag.yml
+++ b/.github/workflows/gen_ubuntu20.04_tag.yml
@@ -68,6 +68,7 @@ jobs:
       run: "bash ci/deploy.sh"
     - name: "Upload to Tagged Release"
       uses: softprops/action-gh-release@v1
+      if: github.event.repository.fork == false
       with:
          files: |
             wezterm-*.deb

--- a/.github/workflows/gen_windows_continuous.yml
+++ b/.github/workflows/gen_windows_continuous.yml
@@ -85,6 +85,7 @@ jobs:
 
     - name: "Upload to Nightly Release"
       uses: wez/upload-release-assets@releases/v1
+      if: github.event.repository.fork == false
       with:
          files: "WezTerm-*.zip;WezTerm-*.exe"
          release-tag: "nightly"

--- a/.github/workflows/gen_windows_tag.yml
+++ b/.github/workflows/gen_windows_tag.yml
@@ -58,6 +58,7 @@ jobs:
       run: "bash ci/deploy.sh"
     - name: "Upload to Tagged Release"
       uses: softprops/action-gh-release@v1
+      if: github.event.repository.fork == false
       with:
          files: |
             WezTerm-*.zip

--- a/ci/generate-workflows.py
+++ b/ci/generate-workflows.py
@@ -47,15 +47,18 @@ class RunStep(Step):
 
 
 class ActionStep(Step):
-    def __init__(self, name, action, params=None, env=None):
+    def __init__(self, name, action, params=None, env=None, condition=None):
         self.name = name
         self.action = action
         self.params = params
         self.env = env
+        self.condition = condition
 
     def render(self, f, env):
         f.write(f"    - name: {yv(self.name)}\n")
         f.write(f"      uses: {self.action}\n")
+        if self.condition:
+            f.write(f"      if: {self.condition}\n")
         if self.params:
             f.write("      with:\n")
             for k, v in self.params.items():
@@ -372,6 +375,7 @@ cargo build --all --release""",
             ActionStep(
                 "Upload to Nightly Release",
                 action="wez/upload-release-assets@releases/v1",
+                condition="github.event.repository.fork == false",
                 params={
                     "files": ";".join(patterns),
                     "release-tag": "nightly",
@@ -392,6 +396,7 @@ cargo build --all --release""",
             ActionStep(
                 "Upload to Tagged Release",
                 action="softprops/action-gh-release@v1",
+                condition="github.event.repository.fork == false",
                 params={"files": "\n".join(patterns), "prerelease": True},
                 env={
                     "GITHUB_TOKEN": "${{ secrets.GITHUB_TOKEN }}",


### PR DESCRIPTION
A small update to the "continuous" GitHub Actions workflow files.

It adds a conditional to the `Upload to Nightly Release` step in order to prevent it from running on forks.

Right now, these workflows will fail in all forked repositories (e.g. https://github.com/friederbluemle/wezterm/runs/3658906316), as the required secrets are missing (and, of course, there is no point in releasing from forks anyway).