### PR TITLE
Remove unused Error import

### DIFF
--- a/termwiz/src/widgets/mod.rs
+++ b/termwiz/src/widgets/mod.rs
@@ -4,7 +4,7 @@
 use crate::color::ColorAttribute;
 use crate::input::InputEvent;
 use crate::surface::{Change, CursorShape, Position, SequenceNo, Surface};
-use crate::{Error, Result};
+use crate::Result;
 use fnv::FnvHasher;
 use std::collections::{HashMap, VecDeque};
 use std::hash::BuildHasherDefault;


### PR DESCRIPTION
Hello, I noticed while installing WezTerm that there was a warning about an unused import.
I have removed this Error import in TermWiz.
I ran `cargo check` and `cargo test --all` with no errors.