### PR TITLE
Add full assignment example. Clarify Shift v SHIFT.

### DIFF
--- a/docs/config/keys.md
+++ b/docs/config/keys.md
@@ -264,6 +264,24 @@ Possible Modifier labels are:
 
 You can combine modifiers using the `|` symbol (eg: `"CMD|CTRL"`).
 
+> Note: To specify the shift key in `key` use the capitalization `Shift` but
+>       for use in `mods` use the capitalization `SHIFT`.
+
+A complete example to demonstrate use of `wezterm.action`, use of the shift key
+as a modifier key, and a key assignment which requires an argument:
+
+```lua
+local wezterm = require 'wezterm';
+
+return {
+  keys = {
+    -- Add Control+Shift+Left/Right Arrow tab navigation
+    {key="LeftArrow", mods="SHIFT|CTRL", action=wezterm.action{ActivateTabRelative=-1}},
+    {key="RightArrow", mods="SHIFT|CTRL", action=wezterm.action{ActivateTabRelative=1}},
+  }
+}
+```
+
 ### Leader Key
 
 *Since: 20201031-154415-9614e117*


### PR DESCRIPTION
Thanks for your work on `wezterm`, I've been trying it out off & on and this time I got as far as setting up key assignments! :)

### Context

Unfortunately setting up key assignments turned out to be more frustrating than it needed to be due to the order of the required information in the docs (and my lack of Lua knowledge).

So, this PR adds a complete example earlier in the documentation flow to hopefully prevent others to running into the same situation.

### Details

The existing example uses "Nop" which can be supplied as string but other key assignments require use of `wezterm.action`.

For people not familiar with Lua (like me :) ) a full example with correct syntax is helpful at this point in the documentation.

Additionally, it was not immediately obvious to me that the Shift key requires different capitalization in different contexts. The resulting error messages also don't mention the significance of the capitalization. So this commit adds a note about this detail.

Hopefully these additions will make the initial key assignment experience more approachable & less frustrating. :)

(The key combination used in this example matches that used by the elementary OS terminal.)

_[I'm not particular about the specific wording used so feel free to modify as desired--especially as (for expectation management purposes :) ) I tend not to be great at following up drive-by PRs.]_

Thanks!