### PR TITLE
fonts: use FcFontMatch to resolve fontconfig aliases like 'monospace' (fixes #1249)

### DIFF
--- a/wezterm-font/src/ftwrap.rs
+++ b/wezterm-font/src/ftwrap.rs
@@ -167,7 +167,7 @@ impl Face {
                     source: self.source.source.clone(),
                     index: self.source.index,
                     variation: i,
-                    origin: self.source.origin,
+                    origin: self.source.origin.clone(),
                     coverage: self.source.coverage.clone(),
                 };
                 res.push(ParsedFont::from_face(&self, source)?);

--- a/wezterm-font/src/locator/mod.rs
+++ b/wezterm-font/src/locator/mod.rs
@@ -13,14 +13,23 @@ pub mod core_text;
 pub mod font_config;
 pub mod gdi;
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Ord, PartialOrd, Display)]
+#[derive(Clone, Debug, PartialEq, Eq, Ord, PartialOrd)]
 pub enum FontOrigin {
     FontConfig,
+    FontConfigMatch(String),
     CoreText,
     DirectWrite,
     Gdi,
     FontDirs,
     BuiltIn,
+}
+
+// derived impl would just use the inner string instead of
+// 'FontConfigMatch("..")', so use Debug
+impl Display for FontOrigin {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:?}", self)
+    }
 }
 
 #[derive(Clone)]

--- a/wezterm-font/src/parser.rs
+++ b/wezterm-font/src/parser.rs
@@ -535,13 +535,13 @@ pub(crate) fn parse_and_collect_font_info(
         source: &FontDataSource,
         index: u32,
         font_info: &mut Vec<ParsedFont>,
-        origin: FontOrigin,
+        origin: &FontOrigin,
     ) -> anyhow::Result<()> {
         let locator = FontDataHandle {
             source: source.clone(),
             index,
             variation: 0,
-            origin,
+            origin: origin.clone(),
             coverage: None,
         };
 
@@ -558,7 +558,7 @@ pub(crate) fn parse_and_collect_font_info(
     }
 
     for index in 0..num_faces {
-        if let Err(err) = load_one(&lib, &source, index, font_info, origin) {
+        if let Err(err) = load_one(&lib, &source, index, font_info, &origin) {
             log::trace!("error while parsing {:?} index {}: {}", source, index, err);
         }
     }


### PR DESCRIPTION
This patch adds some very careful support for `get_best_match` (`FcFontMatch`) resolution with `config_substitute` on, i.e. allows users to rely on custom aliases set in `fonts.conf`.

Here's how `wezterm.font("monospace")` looks like with various values of `monospace` in fontconfig: 

<details>
<summary>JetBrains Mono</summary>


```
Primary font:
wezterm.font_with_fallback({
  -- /usr/local/share/fonts/jetbrains-mono/JetBrainsMono-Regular.ttf, FontConfig
  "JetBrains Mono",

  -- <built-in>, BuiltIn
  -- Assumed to have Emoji Presentation
  -- Pixel sizes: [128]
  "Noto Color Emoji",

  -- <built-in>, BuiltIn
  "Last Resort High-Efficiency",

})


When Intensity=Half Italic=true:
wezterm.font_with_fallback({
  -- /usr/local/share/fonts/jetbrains-mono/JetBrainsMono-ExtraLightItalic.ttf, FontConfig
  {family="JetBrains Mono", weight="ExtraLight", italic=true},

  -- /usr/local/share/fonts/jetbrains-mono/JetBrainsMono-Regular.ttf, FontConfig
  "JetBrains Mono",

  -- <built-in>, BuiltIn
  -- Assumed to have Emoji Presentation
  -- Pixel sizes: [128]
  "Noto Color Emoji",

  -- <built-in>, BuiltIn
  "Last Resort High-Efficiency",

})


When Intensity=Half Italic=false:
wezterm.font_with_fallback({
  -- /usr/local/share/fonts/jetbrains-mono/JetBrainsMono-ExtraLight.ttf, FontConfig
  {family="JetBrains Mono", weight="ExtraLight"},

  -- /usr/local/share/fonts/jetbrains-mono/JetBrainsMono-Regular.ttf, FontConfig
  "JetBrains Mono",

  -- <built-in>, BuiltIn
  -- Assumed to have Emoji Presentation
  -- Pixel sizes: [128]
  "Noto Color Emoji",

  -- <built-in>, BuiltIn
  "Last Resort High-Efficiency",

})


When Intensity=Bold Italic=false:
wezterm.font_with_fallback({
  -- /usr/local/share/fonts/jetbrains-mono/JetBrainsMono-Bold.ttf, FontConfig
  {family="JetBrains Mono", weight="Bold"},

  -- /usr/local/share/fonts/jetbrains-mono/JetBrainsMono-Regular.ttf, FontConfig
  "JetBrains Mono",

  -- <built-in>, BuiltIn
  -- Assumed to have Emoji Presentation
  -- Pixel sizes: [128]
  "Noto Color Emoji",

  -- <built-in>, BuiltIn
  "Last Resort High-Efficiency",

})


When Intensity=Bold Italic=true:
wezterm.font_with_fallback({
  -- /usr/local/share/fonts/jetbrains-mono/JetBrainsMono-BoldItalic.ttf, FontConfig
  {family="JetBrains Mono", weight="Bold", italic=true},

  -- /usr/local/share/fonts/jetbrains-mono/JetBrainsMono-Regular.ttf, FontConfig
  "JetBrains Mono",

  -- <built-in>, BuiltIn
  -- Assumed to have Emoji Presentation
  -- Pixel sizes: [128]
  "Noto Color Emoji",

  -- <built-in>, BuiltIn
  "Last Resort High-Efficiency",

})


When Intensity=Normal Italic=true:
wezterm.font_with_fallback({
  -- /usr/local/share/fonts/jetbrains-mono/JetBrainsMono-Italic.ttf, FontConfig
  {family="JetBrains Mono", italic=true},

  -- /usr/local/share/fonts/jetbrains-mono/JetBrainsMono-Regular.ttf, FontConfig
  "JetBrains Mono",

  -- <built-in>, BuiltIn
  -- Assumed to have Emoji Presentation
  -- Pixel sizes: [128]
  "Noto Color Emoji",

  -- <built-in>, BuiltIn
  "Last Resort High-Efficiency",

})
```

</details>

<details>
<summary>Source Code Pro</summary>

```
Primary font:
wezterm.font_with_fallback({
  -- /usr/local/share/fonts/SourceCodePro/SourceCodePro-Regular.ttf, FontConfig
  "Source Code Pro",

  -- /usr/local/share/fonts/jetbrains-mono/JetBrainsMono-Regular.ttf, FontConfig
  "JetBrains Mono",

  -- <built-in>, BuiltIn
  -- Assumed to have Emoji Presentation
  -- Pixel sizes: [128]
  "Noto Color Emoji",

  -- <built-in>, BuiltIn
  "Last Resort High-Efficiency",

})


When Intensity=Half Italic=true:
wezterm.font_with_fallback({
  -- /usr/local/share/fonts/SourceCodePro/SourceCodePro-ExtraLightIt.ttf, FontConfig
  {family="Source Code Pro", weight="ExtraLight", italic=true},

  -- /usr/local/share/fonts/jetbrains-mono/JetBrainsMono-Regular.ttf, FontConfig
  "JetBrains Mono",

  -- <built-in>, BuiltIn
  -- Assumed to have Emoji Presentation
  -- Pixel sizes: [128]
  "Noto Color Emoji",

  -- <built-in>, BuiltIn
  "Last Resort High-Efficiency",

})


When Intensity=Half Italic=false:
wezterm.font_with_fallback({
  -- /usr/local/share/fonts/SourceCodePro/SourceCodePro-ExtraLight.ttf, FontConfig
  {family="Source Code Pro", weight="ExtraLight"},

  -- /usr/local/share/fonts/jetbrains-mono/JetBrainsMono-Regular.ttf, FontConfig
  "JetBrains Mono",

  -- <built-in>, BuiltIn
  -- Assumed to have Emoji Presentation
  -- Pixel sizes: [128]
  "Noto Color Emoji",

  -- <built-in>, BuiltIn
  "Last Resort High-Efficiency",

})


When Intensity=Bold Italic=false:
wezterm.font_with_fallback({
  -- /usr/local/share/fonts/SourceCodePro/SourceCodePro-Semibold.ttf, FontConfig
  {family="Source Code Pro", weight="DemiBold"},

  -- /usr/local/share/fonts/jetbrains-mono/JetBrainsMono-Regular.ttf, FontConfig
  "JetBrains Mono",

  -- <built-in>, BuiltIn
  -- Assumed to have Emoji Presentation
  -- Pixel sizes: [128]
  "Noto Color Emoji",

  -- <built-in>, BuiltIn
  "Last Resort High-Efficiency",

})


When Intensity=Bold Italic=true:
wezterm.font_with_fallback({
  -- /usr/local/share/fonts/SourceCodePro/SourceCodePro-SemiboldIt.ttf, FontConfig
  {family="Source Code Pro", weight="DemiBold", italic=true},

  -- /usr/local/share/fonts/jetbrains-mono/JetBrainsMono-Regular.ttf, FontConfig
  "JetBrains Mono",

  -- <built-in>, BuiltIn
  -- Assumed to have Emoji Presentation
  -- Pixel sizes: [128]
  "Noto Color Emoji",

  -- <built-in>, BuiltIn
  "Last Resort High-Efficiency",

})


When Intensity=Normal Italic=true:
wezterm.font_with_fallback({
  -- /usr/local/share/fonts/SourceCodePro/SourceCodePro-It.ttf, FontConfig
  {family="Source Code Pro", italic=true},

  -- /usr/local/share/fonts/jetbrains-mono/JetBrainsMono-Regular.ttf, FontConfig
  "JetBrains Mono",

  -- <built-in>, BuiltIn
  -- Assumed to have Emoji Presentation
  -- Pixel sizes: [128]
  "Noto Color Emoji",

  -- <built-in>, BuiltIn
  "Last Resort High-Efficiency",

})

```

</details>


<details>
<summary>DejaVu Sans Mono (system default, no custom alias)</summary>

```
Primary font:
wezterm.font_with_fallback({
  -- /usr/local/share/fonts/DejaVuSansMono.ttf, FontConfig
  "DejaVu Sans Mono",

  -- /usr/local/share/fonts/jetbrains-mono/JetBrainsMono-Regular.ttf, FontConfig
  "JetBrains Mono",

  -- <built-in>, BuiltIn
  -- Assumed to have Emoji Presentation
  -- Pixel sizes: [128]
  "Noto Color Emoji",

  -- <built-in>, BuiltIn
  "Last Resort High-Efficiency",

})


When Intensity=Half Italic=true:
wezterm.font_with_fallback({
  -- /usr/local/share/fonts/DejaVuSansMono-Oblique.ttf, FontConfig
  -- Will synthesize dim
  {family="DejaVu Sans Mono", italic=true},

  -- /usr/local/share/fonts/jetbrains-mono/JetBrainsMono-Regular.ttf, FontConfig
  "JetBrains Mono",

  -- <built-in>, BuiltIn
  -- Assumed to have Emoji Presentation
  -- Pixel sizes: [128]
  "Noto Color Emoji",

  -- <built-in>, BuiltIn
  "Last Resort High-Efficiency",

})


When Intensity=Half Italic=false:
wezterm.font_with_fallback({
  -- /usr/local/share/fonts/DejaVuSansMono.ttf, FontConfig
  -- Will synthesize dim
  "DejaVu Sans Mono",

  -- /usr/local/share/fonts/jetbrains-mono/JetBrainsMono-Regular.ttf, FontConfig
  "JetBrains Mono",

  -- <built-in>, BuiltIn
  -- Assumed to have Emoji Presentation
  -- Pixel sizes: [128]
  "Noto Color Emoji",

  -- <built-in>, BuiltIn
  "Last Resort High-Efficiency",

})


When Intensity=Bold Italic=false:
wezterm.font_with_fallback({
  -- /usr/local/share/fonts/DejaVuSansMono-Bold.ttf, FontConfig
  {family="DejaVu Sans Mono", weight="Bold"},

  -- /usr/local/share/fonts/jetbrains-mono/JetBrainsMono-Regular.ttf, FontConfig
  "JetBrains Mono",

  -- <built-in>, BuiltIn
  -- Assumed to have Emoji Presentation
  -- Pixel sizes: [128]
  "Noto Color Emoji",

  -- <built-in>, BuiltIn
  "Last Resort High-Efficiency",

})


When Intensity=Bold Italic=true:
wezterm.font_with_fallback({
  -- /usr/local/share/fonts/DejaVuSansMono-BoldOblique.ttf, FontConfig
  {family="DejaVu Sans Mono", weight="Bold", italic=true},

  -- /usr/local/share/fonts/jetbrains-mono/JetBrainsMono-Regular.ttf, FontConfig
  "JetBrains Mono",

  -- <built-in>, BuiltIn
  -- Assumed to have Emoji Presentation
  -- Pixel sizes: [128]
  "Noto Color Emoji",

  -- <built-in>, BuiltIn
  "Last Resort High-Efficiency",

})


When Intensity=Normal Italic=true:
wezterm.font_with_fallback({
  -- /usr/local/share/fonts/DejaVuSansMono-Oblique.ttf, FontConfig
  {family="DejaVu Sans Mono", italic=true},

  -- /usr/local/share/fonts/jetbrains-mono/JetBrainsMono-Regular.ttf, FontConfig
  "JetBrains Mono",

  -- <built-in>, BuiltIn
  -- Assumed to have Emoji Presentation
  -- Pixel sizes: [128]
  "Noto Color Emoji",

  -- <built-in>, BuiltIn
  "Last Resort High-Efficiency",

})

```

</details>
