### PR TITLE
wayland: frame: remove scale handling code, rely on the terminal's scale instead

### DIFF
--- a/window/src/os/wayland/window.rs
+++ b/window/src/os/wayland/window.rs
@@ -333,9 +333,12 @@ impl WaylandWindow {
             Decorations::ClientSide
         });
 
+        let scale = get_surface_scale_factor(&surface);
+
         window.set_frame_config(ConceptConfig {
             font_config: Some(Rc::clone(&font_config)),
             config: config.cloned(),
+            scale,
             ..Default::default()
         });
 
@@ -650,7 +653,16 @@ impl WaylandWindowInner {
                 }
 
                 // Update the window decoration size
-                self.window.as_mut().unwrap().resize(w, h);
+                if let Some(window) = self.window.as_mut() {
+                    window.set_frame_config(ConceptConfig {
+                        font_config: Some(Rc::clone(&self.font_config)),
+                        config: self.config.as_ref().cloned(),
+                        scale: factor,
+                        ..Default::default()
+                    });
+
+                    window.resize(w, h);
+                }
 
                 // Compute the new pixel dimensions
                 let new_dimensions = Dimensions {
@@ -1180,6 +1192,7 @@ impl WaylandWindowInner {
             window.set_frame_config(ConceptConfig {
                 font_config: Some(Rc::clone(&self.font_config)),
                 config: Some(config.clone()),
+                scale: get_surface_scale_factor(&self.surface),
                 ..Default::default()
             });
             // I tried re-applying the config to window.set_decorate


### PR DESCRIPTION
This code was redundantly tracking the scale for each subsurface of the frame, which is completely unnecessary. This only existed in SCTK because it's a generic toolkit where the content might not be scale-aware at all.

---

Hopefully soon we'll have close-minimize-whatever buttons right in the fancy-tab-bar ;) but even then the ConceptFrame will probably still be used for the invisible resize handles I suppose? So it's still worth cleaning it up.

---

This is a bit more experimental than everything in #1246 (and surprisingly doesn't depend on it) but Works For Me™ so far (only tested on a single 2x output).

I thiiiiink not `clear()`ing the parts is safe, all config accesses seem to be in redraw anyway.