### PR TITLE
wayland: Support disabled key repeat

### DIFF
--- a/window/src/os/wayland/window.rs
+++ b/window/src/os/wayland/window.rs
@@ -51,8 +51,12 @@ impl KeyRepeatState {
             let gap;
             {
                 let conn = WaylandConnection::get().unwrap().wayland();
+                let rate = *conn.key_repeat_rate.borrow() as u64;
+                if rate == 0 {
+                    return;
+                }
                 delay = Duration::from_millis(*conn.key_repeat_delay.borrow() as u64);
-                gap = Duration::from_millis(1000 / *conn.key_repeat_rate.borrow() as u64);
+                gap = Duration::from_millis(1000 / rate);
             }
 
             let mut initial = true;


### PR DESCRIPTION
Noticed by running in bare KWin (windowed mode, no other plasma stuff installed) and getting the "attempt to divide by zero" panic.