### PR TITLE
Unzoom when switching panes

### DIFF
--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -1232,6 +1232,9 @@ pub struct Config {
     #[serde(default)]
     pub pane_focus_follows_mouse: bool,
 
+    #[serde(default = "default_true")]
+    pub unzoom_on_switch_pane: bool,
+
     #[serde(default = "default_max_fps")]
     pub max_fps: u8,
 

--- a/docs/config/lua/config/unzoom_on_switch_pane.md
+++ b/docs/config/lua/config/unzoom_on_switch_pane.md
@@ -1,0 +1,9 @@
+# `unzoom_on_switch_pane = true`
+
+If set to `false`, the 
+[`ActivatePaneDirection`](../keyassignment/ActivatePaneDirection.md) command
+will have no effect if the active pane is zoomed. 
+
+If `true`, the active pane will be unzoomed first and then switched.
+
+See also: [`TogglePaneZoomState`](../keyassignment/TogglePaneZoomState.md)

--- a/docs/config/lua/config/unzoom_on_switch_pane.md
+++ b/docs/config/lua/config/unzoom_on_switch_pane.md
@@ -1,5 +1,7 @@
 # `unzoom_on_switch_pane = true`
 
+*Since: nightly builds only*
+
 If set to `false`, the 
 [`ActivatePaneDirection`](../keyassignment/ActivatePaneDirection.md) command
 will have no effect if the active pane is zoomed. 

--- a/docs/config/lua/keyassignment/ActivatePaneDirection.md
+++ b/docs/config/lua/keyassignment/ActivatePaneDirection.md
@@ -6,6 +6,9 @@
 In cases where there are multiple adjacent panes in the intended direction,
 wezterm will choose the pane that has the largest edge intersection.
 
+If the active pane is [zoomed](TogglePaneZoomState.md), behavior is determined
+by the [`unzoom_on_switch_pane`](../config/unzoom_on_switch_pane.md) flag. 
+
 ```lua
 local wezterm = require 'wezterm';
 

--- a/docs/config/lua/keyassignment/TogglePaneZoomState.md
+++ b/docs/config/lua/keyassignment/TogglePaneZoomState.md
@@ -13,3 +13,5 @@ return {
   }
 }
 ```
+
+See also: [`unzoom_on_switch_pane`](../config/unzoom_on_switch_pane.md)

--- a/mux/src/tab.rs
+++ b/mux/src/tab.rs
@@ -1039,11 +1039,10 @@ impl Tab {
     /// edge intersection.
     pub fn activate_pane_direction(&self, direction: PaneDirection) {
         if self.zoomed.borrow().is_some() {
-            if configuration().unzoom_on_switch_pane {
-                self.toggle_zoom();
-            } else {
+            if !configuration().unzoom_on_switch_pane {
                 return;
             }
+            self.toggle_zoom();
         }
         let panes = self.iter_panes();
 

--- a/mux/src/tab.rs
+++ b/mux/src/tab.rs
@@ -2,6 +2,7 @@ use crate::domain::DomainId;
 use crate::pane::*;
 use crate::{Mux, WindowId};
 use bintree::PathBranch;
+use config::configuration;
 use config::keyassignment::PaneDirection;
 use portable_pty::PtySize;
 use rangeset::range_intersection;
@@ -1038,7 +1039,11 @@ impl Tab {
     /// edge intersection.
     pub fn activate_pane_direction(&self, direction: PaneDirection) {
         if self.zoomed.borrow().is_some() {
-            return;
+            if configuration().unzoom_on_switch_pane {
+                self.toggle_zoom();
+            } else {
+                return;
+            }
         }
         let panes = self.iter_panes();
 


### PR DESCRIPTION
Add the `unzoom_on_switch_pane` config flag, which determines whether switching panes with `ActivatePaneDirection` while the active pane is zoomed in should first unzoom and then switch (similar to tmux' behavior), or keep the pane zoomed and do nothing.

I set it to true by default, it may be desirable to keep it false to keep current behavior.