### PR TITLE
Manjaro requires additional base-devel package

### DIFF
--- a/get-deps
+++ b/get-deps
@@ -96,6 +96,11 @@ fi
 
 if test -e /etc/arch-release ; then
   PACMAN="$SUDO pacman"
+  
+  if test -e /etc/manjaro-release ; then
+    $PACMAN -S --noconfirm --needed base-devel
+  fi
+  
   $PACMAN -S --noconfirm --needed \
     'cargo' \
     'cmake' \

--- a/get-deps
+++ b/get-deps
@@ -96,12 +96,8 @@ fi
 
 if test -e /etc/arch-release ; then
   PACMAN="$SUDO pacman"
-  
-  if test -e /etc/manjaro-release ; then
-    $PACMAN -S --noconfirm --needed base-devel
-  fi
-  
   $PACMAN -S --noconfirm --needed \
+    'base-devel' \
     'cargo' \
     'cmake' \
     'fontconfig' \


### PR DESCRIPTION
When running `cargo build --release` on a fresh install of Manjaro 21.1.6, I got the following message:

```sh
   Compiling libc v0.2.107
   Compiling proc-macro2 v1.0.32
   Compiling unicode-xid v0.2.2
   Compiling autocfg v1.0.1
   Compiling cfg-if v1.0.0
   Compiling syn v1.0.81
   Compiling version_check v0.9.3
error: linker `cc` not found
  |
  = note: No such file or directory (os error 2)

error: could not compile `libc` due to previous error
warning: build failed, waiting for other jobs to finish...
error: build failed
```

I installed `base-devel` afterwards and was able to continue.