### PR TITLE
Quickselect: allow limiting number of lines before/after viewport to consider

### DIFF
--- a/codec/src/lib.rs
+++ b/codec/src/lib.rs
@@ -405,7 +405,7 @@ macro_rules! pdu {
 /// The overall version of the codec.
 /// This must be bumped when backwards incompatible changes
 /// are made to the types and protocol.
-pub const CODEC_VERSION: usize = 17;
+pub const CODEC_VERSION: usize = 18;
 
 // Defines the Pdu enum.
 // Each struct has an explicit identifying number.
@@ -906,6 +906,7 @@ pub struct GetLinesResponse {
 pub struct SearchScrollbackRequest {
     pub pane_id: PaneId,
     pub pattern: mux::pane::Pattern,
+    pub range: Option<Range<StableRowIndex>>,
 }
 
 #[derive(Deserialize, Serialize, PartialEq, Debug)]

--- a/config/src/keyassignment.rs
+++ b/config/src/keyassignment.rs
@@ -268,6 +268,12 @@ pub struct QuickSelectArguments {
     /// Label to use in place of "copy" when `action` is set
     #[serde(default)]
     pub label: String,
+    /// How many lines before the viewport are considered, None for everything
+    #[serde(default)]
+    pub lines_before_viewport: Option<usize>,
+    /// How many lines after the viewport are considered, None for everything
+    #[serde(default)]
+    pub lines_after_viewport: Option<usize>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]

--- a/mux/src/localpane.rs
+++ b/mux/src/localpane.rs
@@ -447,10 +447,10 @@ impl Pane for LocalPane {
         term.get_semantic_zones()
     }
 
-    async fn search_range(
+    async fn search(
         &self,
         mut pattern: Pattern,
-        range: Range<StableRowIndex>,
+        range: Option<Range<StableRowIndex>>,
     ) -> anyhow::Result<Vec<SearchResult>> {
         let term = self.terminal.borrow();
         let screen = term.screen();
@@ -464,6 +464,13 @@ impl Pane for LocalPane {
         let mut haystack = String::new();
         let mut coords = vec![];
         let mut uniq_matches: HashMap<String, usize> = HashMap::new();
+        let range = range.unwrap_or_else(|| {
+            let dim = self.get_dimensions();
+            dim.scrollback_top
+                ..dim
+                    .scrollback_top
+                    .saturating_add(dim.scrollback_rows as isize)
+        });
 
         #[derive(Copy, Clone)]
         struct Coord {

--- a/mux/src/localpane.rs
+++ b/mux/src/localpane.rs
@@ -447,7 +447,11 @@ impl Pane for LocalPane {
         term.get_semantic_zones()
     }
 
-    async fn search(&self, mut pattern: Pattern) -> anyhow::Result<Vec<SearchResult>> {
+    async fn search_range(
+        &self,
+        mut pattern: Pattern,
+        range: Range<StableRowIndex>,
+    ) -> anyhow::Result<Vec<SearchResult>> {
         let term = self.terminal.borrow();
         let screen = term.screen();
 
@@ -550,9 +554,9 @@ impl Pane for LocalPane {
             }
         }
 
-        for (idx, line) in screen.lines.iter().enumerate() {
-            let stable_row = screen.phys_to_stable_row_index(idx);
+        let phys_range = screen.stable_range_to_phys(&range);
 
+        for (stable_row, line) in range.zip(screen.lines.range(phys_range)) {
             let mut wrapped = false;
             for (grapheme_idx, cell) in line.visible_cells() {
                 coords.push(Coord {

--- a/mux/src/localpane.rs
+++ b/mux/src/localpane.rs
@@ -554,7 +554,7 @@ impl Pane for LocalPane {
             }
         }
 
-        let phys_range = screen.stable_range_to_phys(&range);
+        let phys_range = screen.stable_range(&range);
 
         for (stable_row, line) in range.zip(screen.lines.range(phys_range)) {
             let mut wrapped = false;

--- a/mux/src/pane.rs
+++ b/mux/src/pane.rs
@@ -353,27 +353,13 @@ pub trait Pane: Downcast {
     }
 
     /// Performs a search.
+    /// If the range argument is supplied, only the specified line range is considered.
     /// If the result is empty then there are no matches.
     /// Otherwise, the result shall contain all possible matches.
-    async fn search(&self, pattern: Pattern) -> anyhow::Result<Vec<SearchResult>> {
-        let dim = self.get_dimensions();
-        self.search_range(
-            pattern,
-            dim.scrollback_top
-                ..dim
-                    .scrollback_top
-                    .saturating_add(dim.scrollback_rows as isize),
-        )
-        .await
-    }
-
-    /// Performs a search in the specified line range.
-    /// If the result is empty then there are no matches.
-    /// Otherwise, the result shall contain all possible matches.
-    async fn search_range(
+    async fn search(
         &self,
         _pattern: Pattern,
-        _range: Range<StableRowIndex>,
+        _range: Option<Range<StableRowIndex>>,
     ) -> anyhow::Result<Vec<SearchResult>> {
         Ok(vec![])
     }

--- a/mux/src/pane.rs
+++ b/mux/src/pane.rs
@@ -355,7 +355,26 @@ pub trait Pane: Downcast {
     /// Performs a search.
     /// If the result is empty then there are no matches.
     /// Otherwise, the result shall contain all possible matches.
-    async fn search(&self, _pattern: Pattern) -> anyhow::Result<Vec<SearchResult>> {
+    async fn search(&self, pattern: Pattern) -> anyhow::Result<Vec<SearchResult>> {
+        let dim = self.get_dimensions();
+        self.search_range(
+            pattern,
+            dim.physical_top
+                ..dim
+                    .physical_top
+                    .saturating_add(dim.scrollback_rows as isize),
+        )
+        .await
+    }
+
+    /// Performs a search in the specified line range.
+    /// If the result is empty then there are no matches.
+    /// Otherwise, the result shall contain all possible matches.
+    async fn search_range(
+        &self,
+        _pattern: Pattern,
+        _range: Range<StableRowIndex>,
+    ) -> anyhow::Result<Vec<SearchResult>> {
         Ok(vec![])
     }
 

--- a/mux/src/pane.rs
+++ b/mux/src/pane.rs
@@ -359,9 +359,9 @@ pub trait Pane: Downcast {
         let dim = self.get_dimensions();
         self.search_range(
             pattern,
-            dim.physical_top
+            dim.scrollback_top
                 ..dim
-                    .physical_top
+                    .scrollback_top
                     .saturating_add(dim.scrollback_rows as isize),
         )
         .await

--- a/term/src/screen.rs
+++ b/term/src/screen.rs
@@ -432,6 +432,14 @@ impl Screen {
     }
 
     #[inline]
+    pub fn stable_range_to_phys(&self, range: &Range<StableRowIndex>) -> Range<PhysRowIndex> {
+        self.stable_row_to_phys(range.start).unwrap_or(0)
+            ..self
+                .stable_row_to_phys(range.end)
+                .unwrap_or(self.lines.len())
+    }
+
+    #[inline]
     pub fn stable_row_to_phys(&self, stable: StableRowIndex) -> Option<PhysRowIndex> {
         let idx = stable - self.stable_row_index_offset as isize;
         if idx < 0 || idx >= self.lines.len() as isize {

--- a/term/src/screen.rs
+++ b/term/src/screen.rs
@@ -432,14 +432,6 @@ impl Screen {
     }
 
     #[inline]
-    pub fn stable_range_to_phys(&self, range: &Range<StableRowIndex>) -> Range<PhysRowIndex> {
-        self.stable_row_to_phys(range.start).unwrap_or(0)
-            ..self
-                .stable_row_to_phys(range.end)
-                .unwrap_or(self.lines.len())
-    }
-
-    #[inline]
     pub fn stable_row_to_phys(&self, stable: StableRowIndex) -> Option<PhysRowIndex> {
         let idx = stable - self.stable_row_index_offset as isize;
         if idx < 0 || idx >= self.lines.len() as isize {

--- a/wezterm-client/src/pane/clientpane.rs
+++ b/wezterm-client/src/pane/clientpane.rs
@@ -321,6 +321,21 @@ impl Pane for ClientPane {
         }
     }
 
+    // TODO: implement range search for remote panes
+    async fn search_range(
+        &self,
+        pattern: Pattern,
+        range: Range<StableRowIndex>,
+    ) -> anyhow::Result<Vec<SearchResult>> {
+        let result = self.search(pattern).await;
+        result.map(|results| {
+            results
+                .into_iter()
+                .filter(|res| range.start <= res.start_y && range.end >= res.end_y)
+                .collect()
+        })
+    }
+
     fn key_down(&self, key: KeyCode, mods: KeyModifiers) -> anyhow::Result<()> {
         let input_serial;
         {

--- a/wezterm-client/src/pane/clientpane.rs
+++ b/wezterm-client/src/pane/clientpane.rs
@@ -306,29 +306,20 @@ impl Pane for ClientPane {
         Ok(())
     }
 
-    // TODO: implement range search for remote panes
     async fn search(
         &self,
         pattern: Pattern,
         range: Option<Range<StableRowIndex>>,
     ) -> anyhow::Result<Vec<SearchResult>> {
-        let results = self
-            .client
+        self.client
             .client
             .search_scrollback(SearchScrollbackRequest {
                 pane_id: self.remote_pane_id,
                 pattern,
+                range,
             })
-            .await?
-            .results
-            .into_iter();
-        Ok(if let Some(range) = range {
-            results
-                .filter(|res| range.start <= res.start_y && range.end >= res.end_y)
-                .collect()
-        } else {
-            results.collect()
-        })
+            .await
+            .map(|res| res.results)
     }
 
     fn key_down(&self, key: KeyCode, mods: KeyModifiers) -> anyhow::Result<()> {

--- a/wezterm-gui/src/overlay/quickselect.rs
+++ b/wezterm-gui/src/overlay/quickselect.rs
@@ -523,8 +523,7 @@ impl QuickSelectRenderable {
 
     fn compute_range(&self) -> Range<StableRowIndex> {
         let dims = self.delegate.get_dimensions();
-        let top = self.viewport.unwrap_or(dims.physical_top);
-        let bottom = (top + dims.viewport_rows as StableRowIndex).saturating_sub(1);
+                .saturating_sub(lines_before as isize)
         top..bottom
     }
 

--- a/wezterm-gui/src/overlay/search.rs
+++ b/wezterm-gui/src/overlay/search.rs
@@ -453,7 +453,7 @@ impl SearchRenderable {
             let window = self.window.clone();
             let pattern = self.pattern.clone();
             promise::spawn::spawn(async move {
-                let mut results = pane.search(pattern).await?;
+                let mut results = pane.search(pattern, None).await?;
                 results.sort();
 
                 let pane_id = pane.pane_id();

--- a/wezterm-mux-server-impl/src/sessionhandler.rs
+++ b/wezterm-mux-server-impl/src/sessionhandler.rs
@@ -411,7 +411,7 @@ impl SessionHandler {
                         .get_pane(pane_id)
                         .ok_or_else(|| anyhow!("no such pane {}", pane_id))?;
 
-                    pane.search(pattern).await.map(|results| {
+                    pane.search(pattern, None).await.map(|results| {
                         Pdu::SearchScrollbackResponse(SearchScrollbackResponse { results })
                     })
                 }


### PR DESCRIPTION
Add `lines_{before,after}_viewport` option to `QuickSelectArgs`, which controls the search scope around the viewport. When unspecified, the entire scrollback is considered.

Quickselect can take a while to run when the scrollback is full. Scoping makes it run faster and consider less matches so that shorter prefixes are used more often. When the viewport is changed (on scroll/resize), quickselect will update the available matches and shortcuts.

