### PR TITLE
Fix DECRPTUI response

### DIFF
--- a/term/src/terminalstate/mod.rs
+++ b/term/src/terminalstate/mod.rs
@@ -1049,7 +1049,7 @@ impl TerminalState {
                 self.writer.flush().ok();
             }
             Device::RequestTertiaryDeviceAttributes => {
-                self.writer.write(b"\x1b[=00000000").ok();
+                self.writer.write(b"\x1bP!|00000000").ok();
                 self.writer.write(ST.as_bytes()).ok();
                 self.writer.flush().ok();
             }


### PR DESCRIPTION
DECRPTUI, the response to DA3, should be:
 DCS ! | D...D ST
not
 CSI = D...D ST


Can be tested with:
 - vttest (https://invisible-island.net/vttest/vttest.html) 6. Test of terminal reports → 6. Tertiary Device Attributes (DA)
 - the esctest fork at https://invent.kde.org/ninjalj/esctest, tests DA3Tests.test_DA3_0 and DA3Tests.test_DA3_NoParameter originally by Christian Persch.