### PR TITLE
fix: do not propagate $APPIMAGE and $APPDIR env vars to child processes

### DIFF
--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -1839,12 +1839,12 @@ impl Config {
         // across the win32/wsl boundary
         let mut wsl_env = std::env::var("WSLENV").ok();
 
-        // Since we are running inside the appimage, we have "$APPIMAGE"
-        // and "$APPDIR" set inside the wezterm appimage. This gets
+        // If we are running as an appimage, we will have "$APPIMAGE"
+        // and "$APPDIR" set in the wezterm process. These will be
         // propagated to the child processes. Since some apps (including
         // wezterm) use these variables to detect if they are running in
-        // an appimage, the child processes get misconfigured
-        // We should just unset them too.
+        // an appimage, those child processes will be misconfigured.
+        // Ensure that they are unset.
         // https://docs.appimage.org/packaging-guide/environment-variables.html#id2
         cmd.env_remove("APPIMAGE");
         cmd.env_remove("APPDIR");

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -1839,6 +1839,17 @@ impl Config {
         // across the win32/wsl boundary
         let mut wsl_env = std::env::var("WSLENV").ok();
 
+        // Since we are running inside the appimage, we have "$APPIMAGE"
+        // and "$APPDIR" set inside the wezterm appimage. This gets
+        // propagated to the child processes. Since some apps (including
+        // wezterm) use these variables to detect if they are running in
+        // an appimage, the child processes get misconfigured
+        // We should just unset them too.
+        // https://docs.appimage.org/packaging-guide/environment-variables.html#id2
+        cmd.env_remove("APPIMAGE");
+        cmd.env_remove("APPDIR");
+        cmd.env_remove("OWD");
+
         for (k, v) in &self.set_environment_variables {
             if k == "WSLENV" {
                 wsl_env.replace(v.clone());


### PR DESCRIPTION
Some apps use `$APPIMAGE` and `$APPDIR` environment variables to figure out if they are running as an AppImage. When apps (which are not appimages) were launched from Wezterm AppImage, it tried to get resources from Wezterm's mount (since they tried to get the path relative to the $APPDIR`)