### PR TITLE
DECSTR should reset DECLRMM

### DIFF
--- a/term/src/terminalstate/mod.rs
+++ b/term/src/terminalstate/mod.rs
@@ -1039,6 +1039,7 @@ impl TerminalState {
                 self.application_keypad = false;
                 self.top_and_bottom_margins = 0..self.screen().physical_rows as i64;
                 self.left_and_right_margins = 0..self.screen().physical_cols;
+                self.left_and_right_margin_mode = false;
                 self.screen.activate_alt_screen(self.seqno);
                 self.screen.saved_cursor().take();
                 self.screen.activate_primary_screen(self.seqno);


### PR DESCRIPTION
While the description at DEC STD-070 04-31 does not mention Left Right
Margin Mode (it does mention the left and right margins), the code at
04-34 sets it to FIXED (the reset state, the set state is SETABLE).

From esctest:
DECSETTests.test_DECSET_DECLRMM_ModeResetByDECSTR