### PR TITLE
docs: make 'borderless' searchable

### DIFF
--- a/docs/config/lua/config/window_decorations.md
+++ b/docs/config/lua/config/window_decorations.md
@@ -6,7 +6,7 @@ Configures whether the window has a title bar and/or resizable border.
 
 The value is a set of of flags:
 
-* `window_decorations = "NONE"` - disables titlebar and border
+* `window_decorations = "NONE"` - disables titlebar and border (borderless mode)
 * `window_decorations = "TITLE"` - disable the resizable border and enable only the title bar
 * `window_decorations = "RESIZE"` - disable the title bar but enable the resizable border
 * `window_decorations = "TITLE | RESIZE"` - Enable titlebar and border.  This is the default.


### PR DESCRIPTION
Tiny edit in the docs to help future users avoid my mistake
(would've prevented https://github.com/wez/wezterm/issues/1397)