### PR TITLE
docs: replace AltDrag with AltSnap

### DIFF
--- a/docs/config/lua/config/window_decorations.md
+++ b/docs/config/lua/config/window_decorations.md
@@ -26,5 +26,5 @@ mouse reporting you will need to hold down the `SHIFT` modifier in order for
 
 When the resizable border is disabled you will need to use features of your
 desktop environment to resize the window.  Windows users may wish to consider
-[AltDrag](https://stefansundin.github.io/altdrag/).
+[AltSnap](https://github.com/RamonUnch/AltSnap).
 


### PR DESCRIPTION
AltDrag is old (latest release in 2015) and unusable with WezTerm (too much lag), AltSnap is the maintained fork that works with only a little hiccup