### PR TITLE
fix use_ime=true swallows keys with LEADER modifier in macOS

### DIFF
--- a/wezterm-input-types/src/lib.rs
+++ b/wezterm-input-types/src/lib.rs
@@ -205,7 +205,23 @@ fn normalize_shift(key: KeyCode, modifiers: Modifiers) -> (KeyCode, Modifiers) {
             _ => (key, modifiers),
         }
     } else {
-        (key, modifiers)
+        match key {
+            // when use_ime=true, destructuring composed key to get the string and return the first character when
+            // it's one character long for searching in key map.
+            KeyCode::Composed(s) => {
+                let mut char_iter = s.chars();
+                if let Some(first_char) = char_iter.next() {
+                    if char_iter.next().is_none() {
+                        (KeyCode::Char(first_char), modifiers - Modifiers::SHIFT)
+                    } else {
+                        (KeyCode::Composed(s.clone()), modifiers)
+                    }
+                } else {
+                    (KeyCode::Composed(s.clone()), modifiers)
+                }
+            }
+            _ => (key, modifiers),
+        }
     }
 }
 

--- a/window/src/os/macos/window.rs
+++ b/window/src/os/macos/window.rs
@@ -1791,7 +1791,8 @@ impl WindowView {
                 "\x08"
             } else if virtual_key == super::keycodes::kVK_Tab {
                 "\t"
-            } else if !use_ime && virtual_key == super::keycodes::kVK_Delete {
+            } else if virtual_key == super::keycodes::kVK_Delete {
+                // When using IME in macOS, delete applied in candidate window.
                 "\x08"
             } else if virtual_key == super::keycodes::kVK_ANSI_KeypadEnter {
                 // https://github.com/wez/wezterm/issues/739


### PR DESCRIPTION
close #1409