### PR TITLE
Support gating libssh-rs and ssh2 behind features of same name

### DIFF
--- a/wezterm-ssh/Cargo.toml
+++ b/wezterm-ssh/Cargo.toml
@@ -11,6 +11,7 @@ documentation = "https://docs.rs/wezterm-ssh"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
+default = ["libssh-rs", "ssh2"]
 vendored-openssl = ["ssh2/vendored-openssl", "libssh-rs/vendored-openssl"]
 
 [dependencies]
@@ -26,9 +27,9 @@ log = "0.4"
 portable-pty = { version="0.7", path = "../pty" }
 regex = "1"
 smol = "1.2"
-ssh2 = {version="0.9.3", features=["openssl-on-win32"]}
-libssh-rs = {version="0.1.2", features=["vendored"], git="https://github.com/wez/libssh-rs.git"}
-#libssh-rs = {path="../../libssh-rs/libssh-rs", features=["vendored"]}
+ssh2 = {version="0.9.3", features=["openssl-on-win32"], optional = true}
+libssh-rs = {version="0.1.2", features=["vendored"], git="https://github.com/wez/libssh-rs.git", optional = true}
+#libssh-rs = {path="../../libssh-rs/libssh-rs", features=["vendored"], optional = true}
 thiserror = "1.0"
 
 # Not used directly, but is used to centralize the openssl vendor feature selection

--- a/wezterm-ssh/Cargo.toml
+++ b/wezterm-ssh/Cargo.toml
@@ -13,6 +13,8 @@ documentation = "https://docs.rs/wezterm-ssh"
 [features]
 default = ["libssh-rs", "ssh2"]
 vendored-openssl = ["ssh2/vendored-openssl", "libssh-rs/vendored-openssl"]
+vendored-openssl-ssh2 = ["ssh2/vendored-openssl"]
+vendored-openssl-libssh-rs = ["libssh-rs/vendored-openssl"]
 
 [dependencies]
 anyhow = "1.0"

--- a/wezterm-ssh/src/channelwrap.rs
+++ b/wezterm-ssh/src/channelwrap.rs
@@ -1,12 +1,15 @@
 use crate::pty::{NewPty, ResizePty};
-use libssh_rs as libssh;
 use portable_pty::ExitStatus;
 
 pub(crate) enum ChannelWrap {
+    #[cfg(feature = "ssh2")]
     Ssh2(ssh2::Channel),
-    LibSsh(libssh::Channel),
+
+    #[cfg(feature = "libssh-rs")]
+    LibSsh(libssh_rs::Channel),
 }
 
+#[cfg(feature = "ssh2")]
 fn has_signal(chan: &ssh2::Channel) -> Option<ssh2::ExitSignal> {
     if let Ok(sig) = chan.exit_signal() {
         if sig.exit_signal.is_some() {
@@ -19,6 +22,7 @@ fn has_signal(chan: &ssh2::Channel) -> Option<ssh2::ExitSignal> {
 impl ChannelWrap {
     pub fn exit_status(&mut self) -> Option<ExitStatus> {
         match self {
+            #[cfg(feature = "ssh2")]
             Self::Ssh2(chan) => {
                 if chan.eof() && chan.wait_close().is_ok() {
                     if let Some(_sig) = has_signal(chan) {
@@ -32,6 +36,8 @@ impl ChannelWrap {
                     None
                 }
             }
+
+            #[cfg(feature = "libssh-rs")]
             Self::LibSsh(chan) => {
                 if chan.is_eof() {
                     if let Some(status) = chan.get_exit_status() {
@@ -45,7 +51,10 @@ impl ChannelWrap {
 
     pub fn reader(&mut self, idx: usize) -> Box<dyn std::io::Read + '_> {
         match self {
+            #[cfg(feature = "ssh2")]
             Self::Ssh2(chan) => Box::new(chan.stream(idx as i32)),
+
+            #[cfg(feature = "libssh-rs")]
             Self::LibSsh(chan) => match idx {
                 0 => Box::new(chan.stdout()),
                 1 => Box::new(chan.stderr()),
@@ -56,16 +65,22 @@ impl ChannelWrap {
 
     pub fn writer(&mut self) -> Box<dyn std::io::Write + '_> {
         match self {
+            #[cfg(feature = "ssh2")]
             Self::Ssh2(chan) => Box::new(chan),
+
+            #[cfg(feature = "libssh-rs")]
             Self::LibSsh(chan) => Box::new(chan.stdin()),
         }
     }
 
     pub fn close(&mut self) {
         match self {
+            #[cfg(feature = "ssh2")]
             Self::Ssh2(chan) => {
                 let _ = chan.close();
             }
+
+            #[cfg(feature = "libssh-rs")]
             Self::LibSsh(chan) => {
                 let _ = chan.close();
             }
@@ -74,6 +89,7 @@ impl ChannelWrap {
 
     pub fn request_pty(&mut self, newpty: &NewPty) -> anyhow::Result<()> {
         match self {
+            #[cfg(feature = "ssh2")]
             Self::Ssh2(chan) => Ok(chan.request_pty(
                 &newpty.term,
                 None,
@@ -84,6 +100,8 @@ impl ChannelWrap {
                     newpty.size.pixel_height.into(),
                 )),
             )?),
+
+            #[cfg(feature = "libssh-rs")]
             Self::LibSsh(chan) => Ok(chan.request_pty(
                 &newpty.term,
                 newpty.size.cols.into(),
@@ -94,42 +112,60 @@ impl ChannelWrap {
 
     pub fn request_env(&mut self, name: &str, value: &str) -> anyhow::Result<()> {
         match self {
+            #[cfg(feature = "ssh2")]
             Self::Ssh2(chan) => Ok(chan.setenv(name, value)?),
+
+            #[cfg(feature = "libssh-rs")]
             Self::LibSsh(chan) => Ok(chan.request_env(name, value)?),
         }
     }
 
     pub fn request_exec(&mut self, command_line: &str) -> anyhow::Result<()> {
         match self {
+            #[cfg(feature = "ssh2")]
             Self::Ssh2(chan) => Ok(chan.exec(command_line)?),
+
+            #[cfg(feature = "libssh-rs")]
             Self::LibSsh(chan) => Ok(chan.request_exec(command_line)?),
         }
     }
 
     pub fn request_shell(&mut self) -> anyhow::Result<()> {
         match self {
+            #[cfg(feature = "ssh2")]
             Self::Ssh2(chan) => Ok(chan.shell()?),
+
+            #[cfg(feature = "libssh-rs")]
             Self::LibSsh(chan) => Ok(chan.request_shell()?),
         }
     }
 
     pub fn resize_pty(&mut self, resize: &ResizePty) -> anyhow::Result<()> {
         match self {
+            #[cfg(feature = "ssh2")]
             Self::Ssh2(chan) => Ok(chan.request_pty_size(
                 resize.size.cols.into(),
                 resize.size.rows.into(),
                 Some(resize.size.pixel_width.into()),
                 Some(resize.size.pixel_height.into()),
             )?),
+
+            #[cfg(feature = "libssh-rs")]
             Self::LibSsh(chan) => {
                 Ok(chan.change_pty_size(resize.size.cols.into(), resize.size.rows.into())?)
             }
         }
     }
 
-    pub fn send_signal(&mut self, signame: &str) -> anyhow::Result<()> {
+    pub fn send_signal(
+        &mut self,
+        #[cfg_attr(not(feature = "libssh-rs"), allow(unused_variables))] signame: &str,
+    ) -> anyhow::Result<()> {
         match self {
+            #[cfg(feature = "ssh2")]
             Self::Ssh2(_) => Ok(()),
+
+            #[cfg(feature = "libssh-rs")]
             Self::LibSsh(chan) => Ok(chan.request_send_signal(signame)?),
         }
     }

--- a/wezterm-ssh/src/filewrap.rs
+++ b/wezterm-ssh/src/filewrap.rs
@@ -1,32 +1,45 @@
 use crate::sftp::types::Metadata;
 use crate::sftp::{SftpChannelError, SftpChannelResult};
-use libssh_rs as libssh;
-use std::io::Write;
 
 pub(crate) enum FileWrap {
+    #[cfg(feature = "ssh2")]
     Ssh2(ssh2::File),
-    LibSsh(libssh::SftpFile),
+
+    #[cfg(feature = "libssh-rs")]
+    LibSsh(libssh_rs::SftpFile),
 }
 
 impl FileWrap {
     pub fn reader(&mut self) -> Box<dyn std::io::Read + '_> {
         match self {
+            #[cfg(feature = "ssh2")]
             Self::Ssh2(file) => Box::new(file),
+
+            #[cfg(feature = "libssh-rs")]
             Self::LibSsh(file) => Box::new(file),
         }
     }
 
     pub fn writer(&mut self) -> Box<dyn std::io::Write + '_> {
         match self {
+            #[cfg(feature = "ssh2")]
             Self::Ssh2(file) => Box::new(file),
+
+            #[cfg(feature = "libssh-rs")]
             Self::LibSsh(file) => Box::new(file),
         }
     }
 
-    pub fn set_metadata(&mut self, metadata: Metadata) -> SftpChannelResult<()> {
+    pub fn set_metadata(
+        &mut self,
+        #[cfg_attr(not(feature = "ssh2"), allow(unused_variables))] metadata: Metadata,
+    ) -> SftpChannelResult<()> {
         match self {
+            #[cfg(feature = "ssh2")]
             Self::Ssh2(file) => Ok(file.setstat(metadata.into())?),
-            Self::LibSsh(_file) => Err(libssh::Error::fatal(
+
+            #[cfg(feature = "libssh-rs")]
+            Self::LibSsh(_file) => Err(libssh_rs::Error::fatal(
                 "FileWrap::set_metadata not implemented for libssh::SftpFile",
             )
             .into()),
@@ -35,7 +48,10 @@ impl FileWrap {
 
     pub fn metadata(&mut self) -> SftpChannelResult<Metadata> {
         match self {
+            #[cfg(feature = "ssh2")]
             Self::Ssh2(file) => Ok(file.stat().map(Metadata::from)?),
+
+            #[cfg(feature = "libssh-rs")]
             Self::LibSsh(file) => file
                 .metadata()
                 .map(Metadata::from)
@@ -45,8 +61,14 @@ impl FileWrap {
 
     pub fn fsync(&mut self) -> SftpChannelResult<()> {
         match self {
+            #[cfg(feature = "ssh2")]
             Self::Ssh2(file) => file.fsync().map_err(SftpChannelError::from),
-            Self::LibSsh(file) => Ok(file.flush()?),
+
+            #[cfg(feature = "libssh-rs")]
+            Self::LibSsh(file) => {
+                use std::io::Write;
+                Ok(file.flush()?)
+            }
         }
     }
 }

--- a/wezterm-ssh/src/lib.rs
+++ b/wezterm-ssh/src/lib.rs
@@ -1,3 +1,6 @@
+#[cfg(not(any(feature = "libssh-rs", feature = "ssh2")))]
+compile_error!("Either libssh-rs or ssh2 must be enabled!");
+
 mod auth;
 mod channelwrap;
 mod config;

--- a/wezterm-ssh/src/sessionwrap.rs
+++ b/wezterm-ssh/src/sessionwrap.rs
@@ -1,48 +1,59 @@
 use crate::channelwrap::ChannelWrap;
 use crate::sftpwrap::SftpWrap;
 use filedescriptor::{AsRawSocketDescriptor, SocketDescriptor, POLLIN, POLLOUT};
-use libssh_rs as libssh;
-use ssh2::BlockDirections;
 
+#[cfg(feature = "ssh2")]
 pub(crate) struct Ssh2Session {
     pub sess: ssh2::Session,
     pub sftp: Option<SftpWrap>,
 }
 
+#[cfg(feature = "libssh-rs")]
 pub(crate) struct LibSshSession {
-    pub sess: libssh::Session,
+    pub sess: libssh_rs::Session,
     pub sftp: Option<SftpWrap>,
 }
 
 pub(crate) enum SessionWrap {
+    #[cfg(feature = "ssh2")]
     Ssh2(Ssh2Session),
+
+    #[cfg(feature = "libssh-rs")]
     LibSsh(LibSshSession),
 }
 
 impl SessionWrap {
+    #[cfg(feature = "ssh2")]
     pub fn with_ssh2(sess: ssh2::Session) -> Self {
         Self::Ssh2(Ssh2Session { sess, sftp: None })
     }
 
-    pub fn with_libssh(sess: libssh::Session) -> Self {
+    #[cfg(feature = "libssh-rs")]
+    pub fn with_libssh(sess: libssh_rs::Session) -> Self {
         Self::LibSsh(LibSshSession { sess, sftp: None })
     }
 
     pub fn set_blocking(&mut self, blocking: bool) {
         match self {
+            #[cfg(feature = "ssh2")]
             Self::Ssh2(sess) => sess.sess.set_blocking(blocking),
+
+            #[cfg(feature = "libssh-rs")]
             Self::LibSsh(sess) => sess.sess.set_blocking(blocking),
         }
     }
 
     pub fn get_poll_flags(&self) -> i16 {
         match self {
+            #[cfg(feature = "ssh2")]
             Self::Ssh2(sess) => match sess.sess.block_directions() {
-                BlockDirections::None => 0,
-                BlockDirections::Inbound => POLLIN,
-                BlockDirections::Outbound => POLLOUT,
-                BlockDirections::Both => POLLIN | POLLOUT,
+                ssh2::BlockDirections::None => 0,
+                ssh2::BlockDirections::Inbound => POLLIN,
+                ssh2::BlockDirections::Outbound => POLLOUT,
+                ssh2::BlockDirections::Both => POLLIN | POLLOUT,
             },
+
+            #[cfg(feature = "libssh-rs")]
             Self::LibSsh(sess) => {
                 let (read, write) = sess.sess.get_poll_state();
                 match (read, write) {
@@ -57,17 +68,23 @@ impl SessionWrap {
 
     pub fn as_socket_descriptor(&self) -> SocketDescriptor {
         match self {
+            #[cfg(feature = "ssh2")]
             Self::Ssh2(sess) => sess.sess.as_socket_descriptor(),
+
+            #[cfg(feature = "libssh-rs")]
             Self::LibSsh(sess) => sess.sess.as_socket_descriptor(),
         }
     }
 
     pub fn open_session(&self) -> anyhow::Result<ChannelWrap> {
         match self {
+            #[cfg(feature = "ssh2")]
             Self::Ssh2(sess) => {
                 let channel = sess.sess.channel_session()?;
                 Ok(ChannelWrap::Ssh2(channel))
             }
+
+            #[cfg(feature = "libssh-rs")]
             Self::LibSsh(sess) => {
                 let channel = sess.sess.new_channel()?;
                 channel.open_session()?;

--- a/wezterm-ssh/src/sftp/error.rs
+++ b/wezterm-ssh/src/sftp/error.rs
@@ -36,20 +36,28 @@ pub enum SftpError {
     NoMedia = 13,
 
     // Below are libssh2-specific errors
+    #[cfg(feature = "ssh2")]
     #[error("No space available on filesystem")]
     NoSpaceOnFilesystem = 14,
+    #[cfg(feature = "ssh2")]
     #[error("Quota exceeded")]
     QuotaExceeded = 15,
+    #[cfg(feature = "ssh2")]
     #[error("Unknown principal")]
     UnknownPrincipal = 16,
+    #[cfg(feature = "ssh2")]
     #[error("Filesystem lock conflict")]
     LockConflict = 17,
+    #[cfg(feature = "ssh2")]
     #[error("Directory is not empty")]
     DirNotEmpty = 18,
+    #[cfg(feature = "ssh2")]
     #[error("Operation attempted against a path that is not a directory")]
     NotADirectory = 19,
+    #[cfg(feature = "ssh2")]
     #[error("Filename invalid")]
     InvalidFilename = 20,
+    #[cfg(feature = "ssh2")]
     #[error("Symlink loop encountered")]
     LinkLoop = 21,
 }
@@ -90,13 +98,23 @@ impl TryFrom<i32> for SftpError {
             11 => Ok(Self::FileAlreadyExists),
             12 => Ok(Self::WriteProtect),
             13 => Ok(Self::NoMedia),
+
+            // Errors only available with ssh2
+            #[cfg(feature = "ssh2")]
             14 => Ok(Self::NoSpaceOnFilesystem),
+            #[cfg(feature = "ssh2")]
             15 => Ok(Self::QuotaExceeded),
+            #[cfg(feature = "ssh2")]
             16 => Ok(Self::UnknownPrincipal),
+            #[cfg(feature = "ssh2")]
             17 => Ok(Self::LockConflict),
+            #[cfg(feature = "ssh2")]
             18 => Ok(Self::DirNotEmpty),
+            #[cfg(feature = "ssh2")]
             19 => Ok(Self::NotADirectory),
+            #[cfg(feature = "ssh2")]
             20 => Ok(Self::InvalidFilename),
+            #[cfg(feature = "ssh2")]
             21 => Ok(Self::LinkLoop),
 
             // Unsupported codes get reflected back
@@ -105,6 +123,7 @@ impl TryFrom<i32> for SftpError {
     }
 }
 
+#[cfg(feature = "ssh2")]
 impl TryFrom<ssh2::Error> for SftpError {
     type Error = ssh2::Error;
 
@@ -119,6 +138,7 @@ impl TryFrom<ssh2::Error> for SftpError {
     }
 }
 
+#[cfg(feature = "ssh2")]
 impl TryFrom<ssh2::ErrorCode> for SftpError {
     type Error = ssh2::ErrorCode;
 

--- a/wezterm-ssh/tests/e2e/sftp.rs
+++ b/wezterm-ssh/tests/e2e/sftp.rs
@@ -611,8 +611,9 @@ async fn canonicalize_should_either_return_resolved_path_or_error_if_missing(
         .await;
     match result {
         Ok(_) => {}
-        Err(SftpChannelError::Sftp(SftpError::NoSuchFile))
-        | Err(SftpChannelError::LibSsh(libssh_rs::Error::Sftp(_))) => {}
+        Err(SftpChannelError::Sftp(SftpError::NoSuchFile)) => {}
+        #[cfg(feature = "libssh-rs")]
+        Err(SftpChannelError::LibSsh(libssh_rs::Error::Sftp(_))) => {}
         x => panic!(
             "Unexpected result from canonicalize({}: {:?}",
             missing.path().display(),

--- a/wezterm-ssh/tests/sshd.rs
+++ b/wezterm-ssh/tests/sshd.rs
@@ -424,6 +424,11 @@ pub async fn session(sshd: &'_ Sshd) -> Session {
     let mut config = config.for_host("localhost");
     config.insert("port".to_string(), port.to_string());
     config.insert("wezterm_ssh_verbose".to_string(), "true".to_string());
+
+    // If libssh-rs is not loaded (but ssh2 is), then we use ssh2 as the backend
+    #[cfg(not(feature = "libssh-rs"))]
+    config.insert("wezterm_ssh_backend".to_string(), "ssh2".to_string());
+
     config.insert("user".to_string(), USERNAME.to_string());
     config.insert("identitiesonly".to_string(), "yes".to_string());
     config.insert(


### PR DESCRIPTION
Moves libssh-rs and ssh2 backends to be gated by features of the same name. This enables building wezterm-ssh with only one of two dependencies, getting around problems with compiling both for a cdylib target.

You can verify that each backend works by running with `cargo test --no-default-features --features libssh-rs` and `cargo test --no-default-features --features ssh2` from within the wezterm-ssh directory. If `libssh-rs` is not present, then the backend will be switched to `ssh2`.