### PR TITLE
New optional argument 'doNotMoveCursor' for iTerm2 images.

### DIFF
--- a/term/src/terminalstate/iterm.rs
+++ b/term/src/terminalstate/iterm.rs
@@ -151,7 +151,7 @@ impl TerminalState {
             style: ImageAttachStyle::Iterm,
             image_id: None,
             placement_id: None,
-            do_not_move_cursor: false,
+            do_not_move_cursor: image.do_not_move_cursor,
         }) {
             log::error!("set iterm2 image: {:#}", err);
         }

--- a/termwiz/src/escape/osc.rs
+++ b/termwiz/src/escape/osc.rs
@@ -854,6 +854,8 @@ pub struct ITermFileData {
     /// if true, attempt to display in the terminal rather than downloading to
     /// the users download directory
     pub inline: bool,
+    /// if true, do not move the cursor
+    pub do_not_move_cursor: bool,
     /// The data to transfer
     pub data: Vec<u8>,
 }
@@ -927,6 +929,10 @@ impl ITermFileData {
             .map(|s| *s != "0")
             .unwrap_or(true);
         let inline = params.get("inline").map(|s| *s != "0").unwrap_or(false);
+        let do_not_move_cursor = params
+            .get("doNotMoveCursor")
+            .map(|s| *s != "0")
+            .unwrap_or(false);
         let data = data.ok_or_else(|| format!("didn't set data"))?;
         Ok(Self {
             name,
@@ -935,6 +941,7 @@ impl ITermFileData {
             height,
             preserve_aspect_ratio,
             inline,
+            do_not_move_cursor,
             data,
         })
     }
@@ -971,6 +978,10 @@ impl Display for ITermFileData {
         if self.inline {
             sep = emit_sep(sep, f)?;
             write!(f, "inline=1")?;
+        }
+        if self.do_not_move_cursor {
+            sep = emit_sep(sep, f)?;
+            write!(f, "doNotMoveCursor=1")?;
         }
         // Ensure that we emit a sep if we didn't already.
         // It will still be set to '=' in that case.
@@ -1614,6 +1625,7 @@ mod test {
                     height: ITermDimension::Automatic,
                     preserve_aspect_ratio: true,
                     inline: false,
+                    do_not_move_cursor: false,
                     data: b"hello".to_vec(),
                 }
             )))
@@ -1632,6 +1644,7 @@ mod test {
                     height: ITermDimension::Automatic,
                     preserve_aspect_ratio: true,
                     inline: false,
+                    do_not_move_cursor: false,
                     data: b"hello".to_vec(),
                 }
             )))
@@ -1650,6 +1663,7 @@ mod test {
                     height: ITermDimension::Automatic,
                     preserve_aspect_ratio: true,
                     inline: false,
+                    do_not_move_cursor: false,
                     data: b"hello".to_vec(),
                 }
             )))
@@ -1668,6 +1682,7 @@ mod test {
                     height: ITermDimension::Automatic,
                     preserve_aspect_ratio: true,
                     inline: false,
+                    do_not_move_cursor: false,
                     data: b"hello".to_vec(),
                 }
             )))
@@ -1691,6 +1706,7 @@ mod test {
                     height: ITermDimension::Automatic,
                     preserve_aspect_ratio: true,
                     inline: false,
+                    do_not_move_cursor: false,
                     data: b"hello".to_vec(),
                 }
             )))
@@ -1709,6 +1725,7 @@ mod test {
                     height: ITermDimension::Automatic,
                     preserve_aspect_ratio: true,
                     inline: false,
+                    do_not_move_cursor: false,
                     data: b"hello".to_vec(),
                 }
             )))
@@ -1733,6 +1750,7 @@ mod test {
                     height: ITermDimension::Percent(10),
                     preserve_aspect_ratio: true,
                     inline: false,
+                    do_not_move_cursor: false,
                     data: b"hello".to_vec(),
                 }
             )))
@@ -1751,6 +1769,26 @@ mod test {
                     height: ITermDimension::Pixels(10),
                     preserve_aspect_ratio: false,
                     inline: true,
+                    do_not_move_cursor: false,
+                    data: b"hello".to_vec(),
+                }
+            )))
+        );
+
+        assert_eq!(
+            parse(
+                &["1337", "File=name=bXluYW1l", "preserveAspectRatio=0", "width=5", "inline=1", "doNotMoveCursor=1", "height=10px","size=234:aGVsbG8="],
+                "\x1b]1337;File=size=234;name=bXluYW1l;width=5;height=10px;preserveAspectRatio=0;inline=1;doNotMoveCursor=1:aGVsbG8=\x1b\\"
+            ),
+            OperatingSystemCommand::ITermProprietary(ITermProprietary::File(Box::new(
+                ITermFileData {
+                    name: Some("myname".into()),
+                    size: Some(234),
+                    width: ITermDimension::Cells(5),
+                    height: ITermDimension::Pixels(10),
+                    preserve_aspect_ratio: false,
+                    inline: true,
+                    do_not_move_cursor: true,
                     data: b"hello".to_vec(),
                 }
             )))

--- a/termwiz/src/escape/parser/mod.rs
+++ b/termwiz/src/escape/parser/mod.rs
@@ -1041,6 +1041,7 @@ mod test {
                         height: ITermDimension::Automatic,
                         preserve_aspect_ratio: true,
                         inline: false,
+                        do_not_move_cursor: false,
                         data: b"hello".to_vec(),
                     }
                 )))

--- a/termwiz/src/render/terminfo.rs
+++ b/termwiz/src/render/terminfo.rs
@@ -586,6 +586,7 @@ impl TerminfoRenderer {
                             height: ITermDimension::Cells(image.height as i64),
                             preserve_aspect_ratio: true,
                             inline: true,
+                            do_not_move_cursor: false,
                             data,
                         };
 

--- a/wezterm-font/src/fcwrap.rs
+++ b/wezterm-font/src/fcwrap.rs
@@ -125,7 +125,7 @@ impl<'a> CharSetRef<'a> {
                 for j in 0..32 {
                     if mask & (1 << j) != 0 {
                         let new_code_point = base_code_point + (j + i * 32) as u32;
-                        if new_code_point - 1 > code_point {
+                        if new_code_point > 0 && new_code_point - 1 > code_point {
                             coverage.add_range_unchecked(range_start..code_point + 1);
                             range_start = new_code_point;
                         }

--- a/wezterm-gui/src/update.rs
+++ b/wezterm-gui/src/update.rs
@@ -298,6 +298,7 @@ fn set_banner_from_release_info(latest: &Release) {
         height: ITermDimension::Cells(2),
         preserve_aspect_ratio: true,
         inline: true,
+        do_not_move_cursor: false,
         data: ICON_DATA.to_vec(),
     };
     let icon = OperatingSystemCommand::ITermProprietary(ITermProprietary::File(Box::new(icon)));

--- a/wezterm/src/main.rs
+++ b/wezterm/src/main.rs
@@ -218,6 +218,7 @@ impl ImgCatCommand {
                 height: self.height.unwrap_or_else(Default::default),
                 preserve_aspect_ratio: !self.no_preserve_aspect_ratio,
                 inline: true,
+                do_not_move_cursor: false,
                 data,
             },
         )));


### PR DESCRIPTION
For #1424

New optional argument 'doNotMoveCursor' for iTerm2 images.  This permits iTerm2 images to be drawn anywhere on screen without scrolling the cursor, including the bottom row.

Also included is a check in fcwrap.rs to_range_set(), without which was causing a panic at runtime due to subtraction from unsigned leading to overflow.

(Sidebar: I had to switch to Rust nightly to compile git head, due to the sysinfo dependency not compiling with Rust stable.  Is that intended behavior?)