### PR TITLE
docs: add a keyword to help find an option

### DIFF
--- a/docs/config/lua/config/show_tab_index_in_tab_bar.md
+++ b/docs/config/lua/config/show_tab_index_in_tab_bar.md
@@ -1,6 +1,6 @@
 # `show_tab_index_in_tab_bar = true`
 
-When set to `true` (the default), tab titles show their tab number with a
+When set to `true` (the default), tab titles show their tab number (tab index) with a
 prefix such as `1:`.  When false, no numeric prefix is shown.
 
 The [tab_and_split_indices_are_zero_based](tab_and_split_indices_are_zero_based.md) setting controls whether numbering starts with `0` or `1`.


### PR DESCRIPTION
'tab index' doesn't find this due to the '_' characters, so I've added a phrase without them

will hopefully help avoid isues like this https://github.com/wez/wezterm/issues/1442