### PR TITLE
Typo : « miss symbol `,` » & « missed symbol `}` »

### DIFF
--- a/docs/config/font-shaping.md
+++ b/docs/config/font-shaping.md
@@ -65,11 +65,12 @@ return {
   font = wezterm.font_with_fallback({
     {
        family="JetBrains Mono",
-       weight="Medium"
+       weight="Medium",
        harfbuzz_features={"calt=0", "clig=0", "liga=0"}
     },
     {family="Terminus", weight="Bold"},
-    "Noto Color Emoji"),
+    "Noto Color Emoji"
+  }),
 }
 ```
 


### PR DESCRIPTION
A quick fix for the config file :-)
Thanx for the work, it's inspiring !