### PR TITLE
SGR-Pixels mouse encoding (1016)

### DIFF
--- a/term/src/input.rs
+++ b/term/src/input.rs
@@ -37,10 +37,18 @@ pub struct MouseEvent {
     pub kind: MouseEventKind,
     pub x: usize,
     pub y: VisibleRowIndex,
-    pub x_offset: usize,
-    pub y_offset: usize,
+    pub x_pixel_offset: usize,
+    pub y_pixel_offset: usize,
     pub button: MouseButton,
     pub modifiers: KeyModifiers,
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub struct ClickPosition {
+    pub column: usize,
+    pub row: i64,
+    pub x_pixel_offset: usize,
+    pub y_pixel_offset: usize,
 }
 
 /// This is a little helper that keeps track of the "click streak",
@@ -52,7 +60,7 @@ pub struct MouseEvent {
 #[derive(Debug, Clone)]
 pub struct LastMouseClick {
     pub button: MouseButton,
-    position: (usize, i64, usize, usize),
+    pub position: ClickPosition,
     time: Instant,
     pub streak: usize,
 }
@@ -61,7 +69,7 @@ pub struct LastMouseClick {
 const CLICK_INTERVAL: u64 = 500;
 
 impl LastMouseClick {
-    pub fn new(button: MouseButton, position: (usize, i64, usize, usize)) -> Self {
+    pub fn new(button: MouseButton, position: ClickPosition) -> Self {
         Self {
             button,
             position,
@@ -70,7 +78,7 @@ impl LastMouseClick {
         }
     }
 
-    pub fn add(&self, button: MouseButton, position: (usize, i64, usize, usize)) -> Self {
+    pub fn add(&self, button: MouseButton, position: ClickPosition) -> Self {
         let now = Instant::now();
         let streak = if button == self.button
             && position == self.position

--- a/term/src/input.rs
+++ b/term/src/input.rs
@@ -37,6 +37,8 @@ pub struct MouseEvent {
     pub kind: MouseEventKind,
     pub x: usize,
     pub y: VisibleRowIndex,
+    pub x_offset: usize,
+    pub y_offset: usize,
     pub button: MouseButton,
     pub modifiers: KeyModifiers,
 }
@@ -50,7 +52,7 @@ pub struct MouseEvent {
 #[derive(Debug, Clone)]
 pub struct LastMouseClick {
     pub button: MouseButton,
-    position: (usize, i64),
+    position: (usize, i64, usize, usize),
     time: Instant,
     pub streak: usize,
 }
@@ -59,7 +61,7 @@ pub struct LastMouseClick {
 const CLICK_INTERVAL: u64 = 500;
 
 impl LastMouseClick {
-    pub fn new(button: MouseButton, position: (usize, i64)) -> Self {
+    pub fn new(button: MouseButton, position: (usize, i64, usize, usize)) -> Self {
         Self {
             button,
             position,
@@ -68,7 +70,7 @@ impl LastMouseClick {
         }
     }
 
-    pub fn add(&self, button: MouseButton, position: (usize, i64)) -> Self {
+    pub fn add(&self, button: MouseButton, position: (usize, i64, usize, usize)) -> Self {
         let now = Instant::now();
         let streak = if button == self.button
             && position == self.position

--- a/term/src/terminalstate/mod.rs
+++ b/term/src/terminalstate/mod.rs
@@ -663,8 +663,8 @@ impl TerminalState {
                     modifiers: KeyModifiers::NONE,
                     x: 0,
                     y: 0,
-                    x_offset: 0,
-                    y_offset: 0,
+                    x_pixel_offset: 0,
+                    y_pixel_offset: 0,
                 })
                 .ok();
             }

--- a/term/src/terminalstate/mouse.rs
+++ b/term/src/terminalstate/mouse.rs
@@ -69,8 +69,8 @@ impl TerminalState {
                 self.writer,
                 "\x1b[<{};{};{}M",
                 button,
-                (event.x * (self.pixel_width / width)) + event.x_offset + 1,
-                (event.y as usize * (self.pixel_height / height)) + event.y_offset + 1
+                (event.x * (self.pixel_width / width)) + event.x_pixel_offset + 1,
+                (event.y as usize * (self.pixel_height / height)) + event.y_pixel_offset + 1
             )?;
             self.writer.flush()?;
         } else if self.mouse_tracking || self.button_event_mouse || self.any_event_mouse {
@@ -123,8 +123,8 @@ impl TerminalState {
                 self.writer,
                 "\x1b[<{};{};{}M",
                 button,
-                (event.x * (self.pixel_width / width)) + event.x_offset + 1,
-                (event.y as usize * (self.pixel_height / height)) + event.y_offset + 1
+                (event.x * (self.pixel_width / width)) + event.x_pixel_offset + 1,
+                (event.y as usize * (self.pixel_height / height)) + event.y_pixel_offset + 1
             )?;
             self.writer.flush()?;
         } else {
@@ -162,8 +162,10 @@ impl TerminalState {
                         self.writer,
                         "\x1b[<{};{};{}m",
                         release_button,
-                        (event.x * (self.pixel_width / width)) + event.x_offset + 1,
-                        (event.y as usize * (self.pixel_height / height)) + event.y_offset + 1
+                        (event.x * (self.pixel_width / width)) + event.x_pixel_offset + 1,
+                        (event.y as usize * (self.pixel_height / height))
+                            + event.y_pixel_offset
+                            + 1
                     )?;
                     self.writer.flush()?;
                 } else {
@@ -214,8 +216,8 @@ impl TerminalState {
                     self.writer,
                     "\x1b[<{};{};{}M",
                     button,
-                    (event.x * (self.pixel_width / width)) + event.x_offset + 1,
-                    (event.y as usize * (self.pixel_height / height)) + event.y_offset + 1
+                    (event.x * (self.pixel_width / width)) + event.x_pixel_offset + 1,
+                    (event.y as usize * (self.pixel_height / height)) + event.y_pixel_offset + 1
                 )?;
                 self.writer.flush()?;
             } else {

--- a/term/src/terminalstate/mouse.rs
+++ b/term/src/terminalstate/mouse.rs
@@ -63,12 +63,14 @@ impl TerminalState {
         } else if self.mouse_encoding == MouseEncoding::SgrPixels
             && (self.mouse_tracking || self.button_event_mouse || self.any_event_mouse)
         {
+            let height = self.screen.physical_rows as usize;
+            let width = self.screen.physical_cols as usize;
             write!(
                 self.writer,
                 "\x1b[<{};{};{}M",
                 button,
-                (event.x * self.pixel_width) + event.x_offset + 1,
-                (event.y as usize * self.pixel_height) + event.y_offset + 1
+                (event.x * (self.pixel_width / width)) + event.x_offset + 1,
+                (event.y as usize * (self.pixel_height / height)) + event.y_offset + 1
             )?;
             self.writer.flush()?;
         } else if self.mouse_tracking || self.button_event_mouse || self.any_event_mouse {
@@ -115,12 +117,14 @@ impl TerminalState {
             )?;
             self.writer.flush()?;
         } else if self.mouse_encoding == MouseEncoding::SgrPixels {
+            let height = self.screen.physical_rows as usize;
+            let width = self.screen.physical_cols as usize;
             write!(
                 self.writer,
                 "\x1b[<{};{};{}M",
                 button,
-                (event.x * self.pixel_width) + event.x_offset + 1,
-                (event.y as usize * self.pixel_height) + event.y_offset + 1
+                (event.x * (self.pixel_width / width)) + event.x_offset + 1,
+                (event.y as usize * (self.pixel_height / height)) + event.y_offset + 1
             )?;
             self.writer.flush()?;
         } else {
@@ -152,12 +156,14 @@ impl TerminalState {
                     )?;
                     self.writer.flush()?;
                 } else if self.mouse_encoding == MouseEncoding::SgrPixels {
+                    let height = self.screen.physical_rows as usize;
+                    let width = self.screen.physical_cols as usize;
                     write!(
                         self.writer,
                         "\x1b[<{};{};{}m",
                         release_button,
-                        (event.x * self.pixel_width) + event.x_offset + 1,
-                        (event.y as usize * self.pixel_height) + event.y_offset + 1
+                        (event.x * (self.pixel_width / width)) + event.x_offset + 1,
+                        (event.y as usize * (self.pixel_height / height)) + event.y_offset + 1
                     )?;
                     self.writer.flush()?;
                 } else {
@@ -202,12 +208,14 @@ impl TerminalState {
                 )?;
                 self.writer.flush()?;
             } else if self.mouse_encoding == MouseEncoding::SgrPixels {
+                let height = self.screen.physical_rows as usize;
+                let width = self.screen.physical_cols as usize;
                 write!(
                     self.writer,
                     "\x1b[<{};{};{}M",
                     button,
-                    (event.x * self.pixel_width) + event.x_offset + 1,
-                    (event.y as usize * self.pixel_height) + event.y_offset + 1
+                    (event.x * (self.pixel_width / width)) + event.x_offset + 1,
+                    (event.y as usize * (self.pixel_height / height)) + event.y_offset + 1
                 )?;
                 self.writer.flush()?;
             } else {

--- a/term/src/terminalstate/performer.rs
+++ b/term/src/terminalstate/performer.rs
@@ -1,5 +1,7 @@
 use crate::terminal::Alert;
-use crate::terminalstate::{default_color_map, CharSet, TabStop, UnicodeVersionStackEntry};
+use crate::terminalstate::{
+    default_color_map, CharSet, MouseEncoding, TabStop, UnicodeVersionStackEntry,
+};
 use crate::{ClipboardSelection, Position, TerminalState, VisibleRowIndex};
 use crate::{DCS, ST};
 use log::{debug, error};
@@ -513,7 +515,7 @@ impl<'a> Performer<'a> {
                 self.application_keypad = false;
                 self.bracketed_paste = false;
                 self.focus_tracking = false;
-                self.sgr_mouse = false;
+                self.mouse_encoding = MouseEncoding::X10;
                 self.sixel_scrolls_right = false;
                 self.any_event_mouse = false;
                 self.button_event_mouse = false;

--- a/termwiz/src/input.rs
+++ b/termwiz/src/input.rs
@@ -64,6 +64,7 @@ bitflags! {
 pub enum InputEvent {
     Key(KeyEvent),
     Mouse(MouseEvent),
+    PixelMouse(PixelMouseEvent),
     /// Detected that the user has resized the terminal
     Resized {
         cols: usize,
@@ -81,6 +82,15 @@ pub enum InputEvent {
 pub struct MouseEvent {
     pub x: u16,
     pub y: u16,
+    pub mouse_buttons: MouseButtons,
+    pub modifiers: Modifiers,
+}
+
+#[cfg_attr(feature = "use_serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PixelMouseEvent {
+    pub x_pixels: u16,
+    pub y_pixels: u16,
     pub mouse_buttons: MouseButtons,
     pub modifiers: Modifiers,
 }
@@ -1267,17 +1277,15 @@ impl InputParser {
                                         modifiers,
                                     }));
                                 }
-                                // AZL - I don't quite understand this
-                                // bit.  Needs to be fixed up.
                                 MouseReport::SGR1016 {
                                     x_pixels,
                                     y_pixels,
                                     button,
                                     modifiers,
                                 } => {
-                                    callback(InputEvent::Mouse(MouseEvent {
-                                        x: x_pixels,
-                                        y: y_pixels,
+                                    callback(InputEvent::PixelMouse(PixelMouseEvent {
+                                        x_pixels: x_pixels,
+                                        y_pixels: y_pixels,
                                         mouse_buttons: button.into(),
                                         modifiers,
                                     }));

--- a/termwiz/src/input.rs
+++ b/termwiz/src/input.rs
@@ -1267,6 +1267,21 @@ impl InputParser {
                                         modifiers,
                                     }));
                                 }
+                                // AZL - I don't quite understand this
+                                // bit.  Needs to be fixed up.
+                                MouseReport::SGR1016 {
+                                    x_pixels,
+                                    y_pixels,
+                                    button,
+                                    modifiers,
+                                } => {
+                                    callback(InputEvent::Mouse(MouseEvent {
+                                        x: x_pixels,
+                                        y: y_pixels,
+                                        mouse_buttons: button.into(),
+                                        modifiers,
+                                    }));
+                                }
                             }
                             continue;
                         }

--- a/wezterm-gui/src/termwindow/mouseevent.rs
+++ b/wezterm-gui/src/termwindow/mouseevent.rs
@@ -115,25 +115,16 @@ impl super::TermWindow {
                 // Perform click counting
                 let button = mouse_press_to_tmb(press);
 
+                let click_position = ClickPosition {
+                    column: x,
+                    row: y,
+                    x_pixel_offset,
+                    y_pixel_offset,
+                };
+
                 let click = match self.last_mouse_click.take() {
-                    None => LastMouseClick::new(
-                        button,
-                        ClickPosition {
-                            column: x,
-                            row: y,
-                            x_pixel_offset,
-                            y_pixel_offset,
-                        },
-                    ),
-                    Some(click) => click.add(
-                        button,
-                        ClickPosition {
-                            column: x,
-                            row: y,
-                            x_pixel_offset,
-                            y_pixel_offset,
-                        },
-                    ),
+                    None => LastMouseClick::new(button, click_position),
+                    Some(click) => click.add(button, click_position),
                 };
                 self.last_mouse_click = Some(click);
                 self.current_mouse_buttons.retain(|p| p != press);
@@ -192,7 +183,17 @@ impl super::TermWindow {
         if let Some(item) = ui_item {
             self.mouse_event_ui_item(item, pane, y, event, context);
         } else {
-            self.mouse_event_terminal(pane, x, y, x_pixel_offset, y_pixel_offset, event, context);
+            self.mouse_event_terminal(
+                pane,
+                ClickPosition {
+                    column: x,
+                    row: y,
+                    x_pixel_offset,
+                    y_pixel_offset,
+                },
+                event,
+                context,
+            );
         }
     }
 
@@ -431,17 +432,17 @@ impl super::TermWindow {
         }
     }
 
-    pub fn mouse_event_terminal(
+    fn mouse_event_terminal(
         &mut self,
         mut pane: Rc<dyn Pane>,
-        mut x: usize,
-        mut y: i64,
-        x_pixel_offset: usize,
-        y_pixel_offset: usize,
+        position: ClickPosition,
         event: MouseEvent,
         context: &dyn WindowOps,
     ) {
         let mut is_click_to_focus = false;
+
+        let mut x = position.column;
+        let mut y = position.row;
 
         for pos in self.get_panes_to_render() {
             if y >= pos.top as i64
@@ -697,8 +698,8 @@ impl super::TermWindow {
             },
             x,
             y,
-            x_pixel_offset,
-            y_pixel_offset,
+            x_pixel_offset: position.x_pixel_offset,
+            y_pixel_offset: position.y_pixel_offset,
             modifiers: window_mods_to_termwiz_mods(event.modifiers),
         };
 

--- a/wezterm-gui/src/termwindow/mouseevent.rs
+++ b/wezterm-gui/src/termwindow/mouseevent.rs
@@ -85,6 +85,17 @@ impl super::TermWindow {
         }
         .trunc() as usize;
 
+        let y_offset = (event
+            .coords
+            .y
+            .sub(padding_top as isize)
+            .sub(first_line_offset)
+            .max(0)
+            % self.render_metrics.cell_size.height) as usize;
+
+        let x_offset = (event.coords.x.sub(padding_left as isize).max(0)
+            % self.render_metrics.cell_size.width) as usize;
+
         self.last_mouse_coords = (x, y);
 
         match event.kind {
@@ -105,8 +116,8 @@ impl super::TermWindow {
                 let button = mouse_press_to_tmb(press);
 
                 let click = match self.last_mouse_click.take() {
-                    None => LastMouseClick::new(button, (x, y)),
-                    Some(click) => click.add(button, (x, y)),
+                    None => LastMouseClick::new(button, (x, y, x_offset, y_offset)),
+                    Some(click) => click.add(button, (x, y, x_offset, y_offset)),
                 };
                 self.last_mouse_click = Some(click);
                 self.current_mouse_buttons.retain(|p| p != press);
@@ -165,7 +176,7 @@ impl super::TermWindow {
         if let Some(item) = ui_item {
             self.mouse_event_ui_item(item, pane, y, event, context);
         } else {
-            self.mouse_event_terminal(pane, x, y, event, context);
+            self.mouse_event_terminal(pane, x, y, x_offset, y_offset, event, context);
         }
     }
 
@@ -409,6 +420,8 @@ impl super::TermWindow {
         mut pane: Rc<dyn Pane>,
         mut x: usize,
         mut y: i64,
+        x_offset: usize,
+        y_offset: usize,
         event: MouseEvent,
         context: &dyn WindowOps,
     ) {
@@ -668,6 +681,8 @@ impl super::TermWindow {
             },
             x,
             y,
+            x_offset,
+            y_offset,
             modifiers: window_mods_to_termwiz_mods(event.modifiers),
         };
 


### PR DESCRIPTION
This is for #1457 .

* DECRQM/DECRPM work for applications to detect support.
* Pixels are passed as offsets through the mouse event so that x/y retain their text coordinate meaning.  For SGR-Pixels encoding the x+offset / y+offset is converted back into screen pixel coordinates.
* I do not have test coverage, I think?  But all tests pass.
