### PR TITLE
Fix update instruction for nightly macosx via brew

### DIFF
--- a/docs/install/macos.markdown
+++ b/docs/install/macos.markdown
@@ -36,7 +36,7 @@ install:
 
 ```bash
 $ brew rm --cask wez/wezterm/wezterm-nightly
-$ brew upgrade --cask wez/wezterm/wezterm-nightly
+$ brew install --cask wez/wezterm/wezterm-nightly
 ```
 
 ## MacPorts


### PR DESCRIPTION
The update variant errored after rm the cask and I had to install the cask again.