### PR TITLE
Better upgrade instruction for nightly on mac

### DIFF
--- a/docs/install/macos.markdown
+++ b/docs/install/macos.markdown
@@ -31,12 +31,10 @@ If you'd like to use a nightly build:
 $ brew install --cask wez/wezterm/wezterm-nightly
 ```
 
-to upgrade to a newer nightly, it is simplest to remove then
-install:
+to upgrade to a newer nightly (normal `brew upgrade` will not upgrade it!):
 
 ```bash
-$ brew rm --cask wez/wezterm/wezterm-nightly
-$ brew install --cask wez/wezterm/wezterm-nightly
+$ brew upgrade --cask wezterm-nightly --no-quarantine --greedy-latest
 ```
 
 ## MacPorts


### PR DESCRIPTION
The old way would remove the icon form the dock. it needs greedy-latest because the cask is declared as `latest`.

See https://github.com/wez/wezterm/pull/1500 for the discussion