### PR TITLE
Fix uninit UB in filedescriptor unix.rs

### DIFF
--- a/filedescriptor/src/unix.rs
+++ b/filedescriptor/src/unix.rs
@@ -461,9 +461,11 @@ mod macos {
     impl FdSet {
         pub fn new() -> Self {
             unsafe {
-                let mut set = std::mem::MaybeUninit::uninit().assume_init();
-                FD_ZERO(&mut set);
-                Self { set }
+                let mut set = std::mem::MaybeUninit::uninit();
+                FD_ZERO(set.as_mut_ptr());
+                Self {
+                    set: set.assume_init(),
+                }
             }
         }
 


### PR DESCRIPTION
See the MaybeUninit docs https://doc.rust-lang.org/stable/std/mem/union.MaybeUninit.html

>  This makes it undefined behavior to have uninitialized data in a variable even if that variable has an integer type, which otherwise can hold any fixed bit pattern

And the assume_init docs https://doc.rust-lang.org/stable/std/mem/union.MaybeUninit.html#method.assume_init

> Calling this when the content is not yet fully initialized causes immediate undefined behavior.

This PR simply moves the assume_init to after the FD_ZERO call so it is only assumed initialized once it has been zeroed