### PR TITLE
Docs: Note on toast notification duration for Windows

### DIFF
--- a/docs/config/lua/window/toast_notification.md
+++ b/docs/config/lua/window/toast_notification.md
@@ -11,7 +11,9 @@ An optional *timeout* parameter can be provided; if so, it specifies how long
 the notification will remain prominently displayed in milliseconds.  To specify
 a timeout without specifying a url, set the url parameter to `nil`.  The timeout
 you specify may not be respected by the system, particularly in X11/Wayland
-environments.
+environments. *Note: On Windows the specified timeout will not be honored. The
+default is a duration of 25s, unless wezterm is built without the duration 
+attribute in the toast tag in which case it will default to 7s.*
 
 The notification will persist on screen until dismissed or clicked, or until its
 timeout duration elapses.


### PR DESCRIPTION
Notes that toast notification timeout duration is not honored on Windows. I spent a little time trying to figure out why my toast notifications were hanging out for 25 seconds and it turns out that on windows the only options for timeout are `duration="long"` and the implicit `duration="short"` in the toast tag at [wezterm-toast-notification/src/windows.rs](https://github.com/wez/wezterm/blob/ca0e35826280e21793cba84fc782071ed1728a90/wezterm-toast-notification/src/windows.rs#L40). So I figured a note would be good for anyone else messing with toast notifications on windows.