### PR TITLE
Make the threshold for predictive echoing configurable

### DIFF
--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -1126,6 +1126,10 @@ pub fn default_write_timeout() -> Duration {
     Duration::from_secs(60)
 }
 
+pub fn default_local_echo_threshold_ms() -> Option<u64> {
+    Some(100)
+}
+
 fn default_bypass_mouse_reporting_modifiers() -> Modifiers {
     Modifiers::SHIFT
 }

--- a/config/src/ssh.rs
+++ b/config/src/ssh.rs
@@ -70,6 +70,9 @@ pub struct SshDomain {
     #[serde(default = "default_read_timeout")]
     pub timeout: Duration,
 
+    #[serde(default = "default_local_echo_threshold_ms")]
+    pub local_echo_threshold_ms: Option<u64>,
+
     /// The path to the wezterm binary on the remote host
     pub remote_wezterm_path: Option<String>,
 

--- a/config/src/tls.rs
+++ b/config/src/tls.rs
@@ -80,6 +80,9 @@ pub struct TlsDomainClient {
     #[serde(default = "default_write_timeout")]
     pub write_timeout: Duration,
 
+    #[serde(default = "default_local_echo_threshold_ms")]
+    pub local_echo_threshold_ms: Option<u64>,
+
     /// The path to the wezterm binary on the remote host
     pub remote_wezterm_path: Option<String>,
 }

--- a/config/src/unix.rs
+++ b/config/src/unix.rs
@@ -48,6 +48,10 @@ pub struct UnixDomain {
 
     #[serde(default = "default_write_timeout")]
     pub write_timeout: Duration,
+
+    /// Don't use default_local_echo_threshold_ms() here to
+    /// disable the predictive echo for Unix domains by default.
+    pub local_echo_threshold_ms: Option<u64>,
 }
 impl_lua_conversion!(UnixDomain);
 
@@ -62,6 +66,7 @@ impl Default for UnixDomain {
             skip_permissions_check: false,
             read_timeout: default_read_timeout(),
             write_timeout: default_write_timeout(),
+            local_echo_threshold_ms: None,
             proxy_command: None,
         }
     }

--- a/docs/config/lua/SshDomain.md
+++ b/docs/config/lua/SshDomain.md
@@ -108,3 +108,21 @@ return {
 }
 ```
 
+You may now specify the round-trip latency threshold for enabling predictive
+local echo using `local_echo_threshold_ms`. If the measured round-trip latency
+between the wezterm client and the server exceeds the specified threshold, the
+client will attempt to predict the server's response to key events and echo the
+result of that prediction locally without waiting, hence hiding latency to the
+user. This option only applies when `multiplexing = "WezTerm"`.
+
+```lua
+return {
+  ssh_domains = {
+    {
+      name = "my.server",
+      remote_address = "192.168.1.1",
+      local_echo_threshold_ms = 10,
+    }
+  },
+}
+```

--- a/docs/config/lua/TlsDomainClient.md
+++ b/docs/config/lua/TlsDomainClient.md
@@ -65,3 +65,25 @@ It is a lua object with the following fields:
     -- remote_wezterm_path = "/home/myname/bin/wezterm"
 }
 ```
+
+*Since: nightly builds only*
+
+You may now specify the round-trip latency threshold for enabling predictive
+local echo using `local_echo_threshold_ms`. If the measured round-trip latency
+between the wezterm client and the server exceeds the specified threshold, the
+client will attempt to predict the server's response to key events and echo the
+result of that prediction locally without waiting, hence hiding latency to the
+user. This option only applies when `multiplexing = "WezTerm"`.
+
+```lua
+return {
+  tls_domains = {
+    {
+      name = "server,name",
+      bootstrap_via_ssh = "server.hostname",
+      remote_address = "server.hostname:8080",
+      local_echo_threshold_ms = 10,
+    }
+  },
+}
+```

--- a/docs/multiplexing.md
+++ b/docs/multiplexing.md
@@ -157,6 +157,26 @@ return {
 }
 ```
 
+*Since: nightly builds only*
+
+You may now specify the round-trip latency threshold for enabling predictive
+local echo using `local_echo_threshold_ms`. If the measured round-trip latency
+between the wezterm client and the server exceeds the specified threshold, the
+client will attempt to predict the server's response to key events and echo the
+result of that prediction locally without waiting, hence hiding latency to the
+user. This option only applies when `multiplexing = "WezTerm"`.
+
+```lua
+return {
+  unix_domains = {
+    {
+      name = "unix",
+      local_echo_threshold_ms = 10,
+    }
+  },
+}
+```
+
 ### Connecting into Windows Subsystem for Linux
 
 *Note: this only works with WSL 1. [WSL 2 doesn't support AF_UNIX interop](https://github.com/microsoft/WSL/issues/5961)*

--- a/wezterm-client/src/pane/renderable.rs
+++ b/wezterm-client/src/pane/renderable.rs
@@ -133,9 +133,11 @@ impl RenderableInner {
 
     /// Predictive echo can be noisy when the link is working well,
     /// so we only employ it when it looks like the latency is high.
-    /// We pick 100ms as the threshold for this.
     fn should_predict(&self) -> bool {
-        !self.client.is_local() && self.last_input_rtt >= 100
+        self.client
+            .local_echo_threshold_ms
+            .map(|thresh| self.last_input_rtt >= thresh)
+            .unwrap_or(false)
     }
 
     /// Compute a "prediction" and apply it to the line data that we


### PR DESCRIPTION
Some users (including myself) have a higher tolerance for latency than mispredictions for the predictive echo feature -- I always used `--predict=never` in mosh for instance. Since the threshold for activating that feature is currently hardcoded, there is no easy way (that I know of) to disable it, or to set it to a alternative value. To allow this, let's expose it in a new config knob that defaults to 100ms hence retaining the current behavior.