### PR TITLE
Fix typo in `strip-ansi-escapes --help` output

### DIFF
--- a/strip-ansi-escapes/src/main.rs
+++ b/strip-ansi-escapes/src/main.rs
@@ -9,7 +9,7 @@ use termwiz::escape::{Action, ControlCode};
 )]
 /// This is a little utility that strips escape sequences from
 /// stdin and prints the result on stdout.
-/// It preserves only printable characters and CL, LF and HT.
+/// It preserves only printable characters and CR, LF and HT.
 ///
 /// This utility is part of WezTerm.
 ///

--- a/termwiz/examples/strip-ansi-escapes.rs
+++ b/termwiz/examples/strip-ansi-escapes.rs
@@ -1,6 +1,6 @@
 //! This is a little utility that strips escape sequences from
 //! stdin and prints the result on stdout.
-//! It preserves only printable characters and CL, LF and HT.
+//! It preserves only printable characters and CR, LF and HT.
 use std::io::{Read, Result};
 use termwiz::escape::parser::Parser;
 use termwiz::escape::{Action, ControlCode};


### PR DESCRIPTION
`s/CL/CR/`