### PR TITLE
fix socketpair() implementation to build on Illumos

### DIFF
--- a/filedescriptor/src/unix.rs
+++ b/filedescriptor/src/unix.rs
@@ -392,7 +392,12 @@ pub fn socketpair_impl() -> Result<(FileDescriptor, FileDescriptor)> {
 #[doc(hidden)]
 pub fn socketpair_impl() -> Result<(FileDescriptor, FileDescriptor)> {
     let mut fds = [-1i32; 2];
-    let res = unsafe { libc::socketpair(libc::PF_LOCAL, libc::SOCK_STREAM, 0, fds.as_mut_ptr()) };
+    #[cfg(target_os = "illumos")]
+    let domain = libc::AF_UNIX;
+    #[cfg(not(target_os = "illumos"))]
+    let domain = libc::PF_LOCAL;
+
+    let res = unsafe { libc::socketpair(domain, libc::SOCK_STREAM, 0, fds.as_mut_ptr()) };
     if res == -1 {
         Err(Error::Socketpair(std::io::Error::last_os_error()))
     } else {

--- a/filedescriptor/src/unix.rs
+++ b/filedescriptor/src/unix.rs
@@ -392,12 +392,7 @@ pub fn socketpair_impl() -> Result<(FileDescriptor, FileDescriptor)> {
 #[doc(hidden)]
 pub fn socketpair_impl() -> Result<(FileDescriptor, FileDescriptor)> {
     let mut fds = [-1i32; 2];
-    #[cfg(target_os = "illumos")]
-    let domain = libc::AF_UNIX;
-    #[cfg(not(target_os = "illumos"))]
-    let domain = libc::PF_LOCAL;
-
-    let res = unsafe { libc::socketpair(domain, libc::SOCK_STREAM, 0, fds.as_mut_ptr()) };
+    let res = unsafe { libc::socketpair(libc::AF_UNIX, libc::SOCK_STREAM, 0, fds.as_mut_ptr()) };
     if res == -1 {
         Err(Error::Socketpair(std::io::Error::last_os_error()))
     } else {


### PR DESCRIPTION
The PF_LOCAL #define isn't available on Illumos.  The correct value to use on that OS is AF_UNIX.  I suspect that AF_UNIX is the correct value to use everywhere, but I didn't want to make a universal change without having more systems to test on.

As written, this change should only affect Illumos systems.  As a sanity check, I've also built on Linux and macos.