### PR TITLE
assets/shell-integration: improve the integration with ble.sh

### DIFF
--- a/assets/shell-integration/wezterm.sh
+++ b/assets/shell-integration/wezterm.sh
@@ -13,12 +13,12 @@
 # WEZTERM_SHELL_SKIP_CWD - disables OSC 7 cwd setting
 
 # shellcheck disable=SC2166
-if [ -z "${BASH_VERSION}" -a -z "${ZSH_NAME}" ] ; then
+if [ -z "${BASH_VERSION-}" -a -z "${ZSH_NAME-}" ] ; then
   # Only for bash or zsh
   return 0
 fi
 
-if [ "${WEZTERM_SHELL_SKIP_ALL}" = "1" ] ; then
+if [ "${WEZTERM_SHELL_SKIP_ALL-}" = "1" ] ; then
   return 0
 fi
 
@@ -27,7 +27,7 @@ if [[ $- != *i* ]] ; then
   return 0
 fi
 
-case "$TERM" in
+case "${TERM-}" in
   linux | dumb )
     # Avoid terminals that don't like OSC sequences
     return 0
@@ -385,7 +385,7 @@ fi;
 
 # blesh provides it's own preexec mechanism which is recommended over bash-preexec
 # See https://github.com/akinomyoga/ble.sh/wiki/Manual-%C2%A71-Introduction#user-content-fn-blehook for more details
-if [[ ! -n "$BLE_VERSION" ]]; then
+if [[ ! -n "${BLE_VERSION-}" ]]; then
   __wezterm_install_bash_prexec
 fi
 
@@ -413,7 +413,7 @@ __wezterm_semantic_precmd() {
     __wezterm_save_ps2="$PS2"
     # Markup the left and right prompts so that the terminal
     # knows that they are semantically prompt output.
-    if [[ -n "$ZSH_NAME" ]] ; then
+    if [[ -n "${ZSH_NAME-}" ]] ; then
       PS1=$'%{\e]133;P;k=i\a%}'$PS1$'%{\e]133;B\a%}'
       PS2=$'%{\e]133;P;k=s\a%}'$PS2$'%{\e]133;B\a%}'
     else
@@ -442,8 +442,8 @@ function __wezterm_semantic_preexec() {
 # Register the various functions; take care to perform osc7 after
 # the semantic zones as we don't want to perturb the last command
 # status before we've had a chance to report it to the terminal
-if [[ -z "${WEZTERM_SHELL_SKIP_SEMANTIC_ZONES}" ]]; then
-  if [[ -n "$BLE_VERSION" ]]; then
+if [[ -z "${WEZTERM_SHELL_SKIP_SEMANTIC_ZONES-}" ]]; then
+  if [[ -n "${BLE_VERSION-}" ]]; then
     blehook PRECMD+=__wezterm_semantic_precmd
     blehook PREEXEC+=__wezterm_semantic_preexec
   else
@@ -452,8 +452,8 @@ if [[ -z "${WEZTERM_SHELL_SKIP_SEMANTIC_ZONES}" ]]; then
   fi
 fi
 
-if [[ -z "${WEZTERM_SHELL_SKIP_CWD}" ]] ; then
-  if [[ -n "$BLE_VERSION" ]]; then
+if [[ -z "${WEZTERM_SHELL_SKIP_CWD-}" ]] ; then
+  if [[ -n "${BLE_VERSION-}" ]]; then
     blehook PRECMD+=__wezterm_osc7
   else
     precmd_functions+=(__wezterm_osc7)

--- a/assets/shell-integration/wezterm.sh
+++ b/assets/shell-integration/wezterm.sh
@@ -444,8 +444,8 @@ function __wezterm_semantic_preexec() {
 # status before we've had a chance to report it to the terminal
 if [[ -z "${WEZTERM_SHELL_SKIP_SEMANTIC_ZONES-}" ]]; then
   if [[ -n "${BLE_VERSION-}" ]]; then
-    blehook PRECMD+=__wezterm_semantic_precmd
-    blehook PREEXEC+=__wezterm_semantic_preexec
+    blehook PRECMD!=__wezterm_semantic_precmd
+    blehook PREEXEC!=__wezterm_semantic_preexec
   else
     precmd_functions+=(__wezterm_semantic_precmd)
     preexec_functions+=(__wezterm_semantic_preexec)
@@ -454,7 +454,7 @@ fi
 
 if [[ -z "${WEZTERM_SHELL_SKIP_CWD-}" ]] ; then
   if [[ -n "${BLE_VERSION-}" ]]; then
-    blehook PRECMD+=__wezterm_osc7
+    blehook PRECMD!=__wezterm_osc7
   else
     precmd_functions+=(__wezterm_osc7)
   fi

--- a/assets/shell-integration/wezterm.sh
+++ b/assets/shell-integration/wezterm.sh
@@ -444,6 +444,7 @@ function __wezterm_semantic_preexec() {
 # status before we've had a chance to report it to the terminal
 if [[ -z "${WEZTERM_SHELL_SKIP_SEMANTIC_ZONES-}" ]]; then
   if [[ -n "${BLE_VERSION-}" ]]; then
+    bleopt prompt_command_changes_layout:=1
     blehook PRECMD!=__wezterm_semantic_precmd
     blehook PREEXEC!=__wezterm_semantic_preexec
   else


### PR DESCRIPTION
Here are fixes for the shell integration. These are additional adjustments to 56e9a9af7 and 78ea214a9. Let me open this as a draft PR. There can be even more fixes because the check of the shell integration with `ble.sh` is still ongoing (Cc: @SuperSandro2000).

- 608aad49f In case that the shell option `set -u` is set, the optional variables are referenced as `${varname-}`
- 9df1b53db The precmd/preexec hooks are registered only when it is not yet registered. This avoids duplicate precmd/preexec handlers after `wezterm.sh` is sourced multiple times. Maybe we also want to modify the code for `bash-preexec`?
- e2c0816c2 By default, ble.sh assumes that the cursor position and the terminal contents are not changed by calling PRECMD/PROMPT_COMMAND. However, it seems the escape sequence sent from the wezterm precmd handler causes a newline when the cursor position is not at the beginning of the line. This breaks the internal layout calculation of ble.sh. To tell ble.sh that PRECMD can change the layout, we set a blesh option.

**Update 2022-03-04**: I'm currently waiting for https://github.com/rcaloras/bash-preexec/pull/129 being processed.
 