### PR TITLE
Add support for urgency hints

### DIFF
--- a/docs/config/lua/window/alert.md
+++ b/docs/config/lua/window/alert.md
@@ -1,0 +1,24 @@
+# `window:alert()`
+
+*Since: TODO*
+
+Requests the user attention by requesting his focus in an platform specific manner,
+e.g. by flashing the window's entry in the task bar or requesting focus.
+
+Behavior by platform:
+
+- X11: Set the windows urgency-hint
+- Windows: Currently unimplemented
+- OSX: Currently unimplemented
+- Wayland: Currently unimplemented
+
+
+```lua
+local wezterm = require 'wezterm'
+
+wezterm.on("window-config-reloaded", function(window, pane)
+  window:alert()
+end)
+
+return {}
+```

--- a/wezterm-gui/src/scripting/guiwin.rs
+++ b/wezterm-gui/src/scripting/guiwin.rs
@@ -44,6 +44,10 @@ impl UserData for GuiWin {
                 Ok(())
             },
         );
+        methods.add_method("alert", |_, this, _: ()| {
+            this.window.alert();
+            Ok(())
+        },);
         methods.add_method("get_appearance", |_, _, _: ()| {
             Ok(Connection::get().unwrap().get_appearance().to_string())
         });

--- a/wezterm-gui/src/scripting/guiwin.rs
+++ b/wezterm-gui/src/scripting/guiwin.rs
@@ -47,7 +47,7 @@ impl UserData for GuiWin {
         methods.add_method("alert", |_, this, _: ()| {
             this.window.alert();
             Ok(())
-        },);
+        });
         methods.add_method("get_appearance", |_, _, _: ()| {
             Ok(Connection::get().unwrap().get_appearance().to_string())
         });

--- a/wezterm-gui/src/scripting/guiwin.rs
+++ b/wezterm-gui/src/scripting/guiwin.rs
@@ -44,8 +44,8 @@ impl UserData for GuiWin {
                 Ok(())
             },
         );
-        methods.add_method("alert", |_, this, _: ()| {
-            this.window.alert();
+        methods.add_method("request_attention", |_, this, new_state: bool| {
+            this.window.set_attention_hint(new_state);
             Ok(())
         });
         methods.add_method("get_appearance", |_, _, _: ()| {

--- a/window/src/lib.rs
+++ b/window/src/lib.rs
@@ -271,6 +271,9 @@ pub trait WindowOps {
 
     fn toggle_fullscreen(&self) {}
 
+    /// Set the window urgent/important/flashing/alerted
+    fn alert(&self) {}
+
     fn config_did_change(&self, _config: &config::ConfigHandle) {}
 
     /// Configure the Window so that the desktop environment

--- a/window/src/lib.rs
+++ b/window/src/lib.rs
@@ -272,7 +272,7 @@ pub trait WindowOps {
     fn toggle_fullscreen(&self) {}
 
     /// Set the window urgent/important/flashing/alerted
-    fn alert(&self) {}
+    fn set_attention_hint(&self, _new_state: bool) {}
 
     fn config_did_change(&self, _config: &config::ConfigHandle) {}
 

--- a/window/src/os/x11/window.rs
+++ b/window/src/os/x11/window.rs
@@ -931,7 +931,7 @@ impl XWindowInner {
             // but subsequent setting then works.
             Err(_) => xcb_util::icccm::WmHints::empty().build(),
         };
-        let is_urgent = false; // hints.is_urgent().unwrap_or(false);
+        let is_urgent = hints.is_urgent().unwrap_or(false);
         if !is_urgent {
             let mut builder = xcb_util::icccm::WmHints::empty();
             builder = match hints.input() {

--- a/window/src/os/x11/window.rs
+++ b/window/src/os/x11/window.rs
@@ -921,21 +921,22 @@ impl XWindowInner {
     }
 
     fn alert(&mut self) {
-        let hintreply = xcb_util::icccm::get_wm_hints(self.conn().conn(), self.window_id).get_reply();
+        let hintreply =
+            xcb_util::icccm::get_wm_hints(self.conn().conn(), self.window_id).get_reply();
         let hints = match hintreply {
             Ok(h) => h,
             // This is, admittingly, a bit scary. But apparently, wmhints may be unset for the
             // window on first call. This means that 0 is return as the result of the wrapped
             // xcb_icccm_get_wm_hints, which the rust wrapping discharges to Err(null),
             // but subsequent setting then works.
-            Err(_) => xcb_util::icccm::WmHints::empty().build()
+            Err(_) => xcb_util::icccm::WmHints::empty().build(),
         };
         let is_urgent = false; // hints.is_urgent().unwrap_or(false);
         if !is_urgent {
             let mut builder = xcb_util::icccm::WmHints::empty();
             builder = match hints.input() {
                 Some(b) => builder.input(b),
-                None => builder
+                None => builder,
             };
             if hints.is_iconic() {
                 builder = builder.is_iconic();
@@ -951,21 +952,25 @@ impl XWindowInner {
             }
             builder = match hints.icon_pixmap() {
                 Some(i) => builder.icon_pixmap(i),
-                None => builder
+                None => builder,
             };
             builder = match hints.icon_mask() {
                 Some(i) => builder.icon_mask(i),
-                None => builder
+                None => builder,
             };
             builder = match hints.icon_window() {
                 Some(i) => builder.icon_window(i),
-                None => builder
+                None => builder,
             };
             builder = match hints.window_group() {
                 Some(i) => builder.icon_window(i),
-                None => builder
+                None => builder,
             };
-            xcb_util::icccm::set_wm_hints(self.conn().conn(), self.window_id, &builder.is_urgent().build());
+            xcb_util::icccm::set_wm_hints(
+                self.conn().conn(),
+                self.window_id,
+                &builder.is_urgent().build(),
+            );
         }
     }
 

--- a/window/src/os/x_and_wayland.rs
+++ b/window/src/os/x_and_wayland.rs
@@ -237,6 +237,14 @@ impl WindowOps for Window {
         }
     }
 
+    fn alert(&self) {
+        match self {
+            Self::X11(x) => x.alert(),
+            #[cfg(feature = "wayland")]
+            Self::Wayland(w) => w.alert(),
+        }
+    }
+
     fn config_did_change(&self, config: &ConfigHandle) {
         match self {
             Self::X11(x) => x.config_did_change(config),

--- a/window/src/os/x_and_wayland.rs
+++ b/window/src/os/x_and_wayland.rs
@@ -237,11 +237,11 @@ impl WindowOps for Window {
         }
     }
 
-    fn alert(&self) {
+    fn set_attention_hint(&self, new_state: bool) {
         match self {
-            Self::X11(x) => x.alert(),
+            Self::X11(x) => x.set_attention_hint(new_state),
             #[cfg(feature = "wayland")]
-            Self::Wayland(w) => w.alert(),
+            Self::Wayland(w) => w.set_attention_hint(new_state),
         }
     }
 


### PR DESCRIPTION
Note: Please regard this PR more as a WIP for starting a discussion, and not as a completely polished submission.

Often, programs want to request the user's focus. The common way to do so is by using the "bell". Currently, wezterm offers the user three major options for this event: AudibleBell (play a sound), VisualBell (blink the whole terminal pane) and sending a ToastNotification from the lua callback.

However, nearly all platforms furthermore posess a native mechanism to request focus:
- X11: Set the `URGENCY`-flag in `WM_FLAGS` (as specified in the [icccm standard](https://tronche.com/gui/x/icccm/sec-4.html#s-4.1.2.4)
- Wayland: Via the [xdg-activation protocol](https://gitlab.freedesktop.org/wayland/wayland-protocols/-/blob/main/staging/xdg-activation/xdg-activation-v1.xml)
- Windows: Via [FlashWindow](https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-flashwindow), which causes the Taskbar icon to flash
- OSX:Bounce the icon in the bar (Probably, I've never really used that platform, and haven't found any references by casually googling)

Often, these mechanisms allow for a tight integration with the overall system, e.g. by offering keybindings to switch to the alerted window, etc.pp., so I as a user would be interested in exposing "urgency" to the system.

The most generic way I've found for adding this behavior is by exposing the signaling capability to the lua bindings, that way, the user is completely flexible in how and when she wants to actually use this mechanism:

```lua
wezterm.on("bell", function(window, pane)
	window:alert();
end)
```

For now, this PR only implements this behavior on X11, because this happens to be what I am using. For wayland, it seems that the xdg-activation protocol is not yet supported in wayland-rs (at least to my understanding, I've never really worked with wayland so far, but at least grepping the repository does not yield any matches for 'activation'). I do not have access to Windows or OSX machines.

On the implementation itself: I really hate how I seem to be forced to manually reimplement a copy mechanism for `WmHints` in `XWindowInner::alert`, however, I have not seen any option (sort of transmuting the object, which seems very wrong) to keep the old urgency values. Unfortunately, the documentation on `xcb_util::icccm::(get|set)_wm_hints` seems very sparse, but the implementation seems to not update but completely replace the wm-hints, so this dance seems necessary. Other libraries offer this functionality in a more straightforward fashion (e.g. [here](https://github.com/alacritty/alacritty/pull/812/files#diff-046e4a8d68b341cbc69ff710f5c2a0530f57ad4a1a2c78a3f723efba02533530R327) is alacritty's implementation using xlib), so I'm really not sure if the xcb_utils-wrapping is strange or I'm just a bid slow on the uptake :D

Furthermore, I'm not sure if `alert()` is the best name for the functionality.

Thanks for reading this far (and WezTerm in general)! As a sidenote, I'm not really a rust programmer (yet), so feel free to point out any strange things within the code.
  ~ Simon

More related urls:
[Here](https://codeberg.org/dnkl/foot/commit/92e517ae34243d9c294e966221f5a4589684a9b5) is foot's implementation of xdg-activation support, it does not seem tooo bad, but I wonder if this can be done (in a clean fashion) without involving/buggering wayland-rs.