### PR TITLE
docs: fix truncate call in example and fix typo

### DIFF
--- a/docs/config/lua/config/window_close_confirmation.md
+++ b/docs/config/lua/config/window_close_confirmation.md
@@ -2,7 +2,7 @@
 
 Whether to display a confirmation prompt when the window is closed by the
 windowing environment, either because the user closed it with the window
-decorations, or instructed their window managed to close it.
+decorations, or instructed their window manager to close it.
 
 Set this to `"NeverPrompt"` if you don't like confirming closing
 windows every time.

--- a/docs/config/lua/window-events/format-tab-title.md
+++ b/docs/config/lua/window-events/format-tab-title.md
@@ -89,7 +89,7 @@ wezterm.on("format-tab-title", function(tab, tabs, panes, config, hover, max_wid
 
   -- ensure that the titles fit in the available space,
   -- and that we have room for the edges.
-  local title = wezterm.truncate_to_width(tab.active_pane.title, max_width-2)
+  local title = wezterm.truncate_right(tab.active_pane.title, max_width-2)
 
   return {
     {Background={Color=edge_background}},


### PR DESCRIPTION
- truncate_to_width doesn't exist in the current codebase
- small typo "window managed" -> "window manager"