### PR TITLE
docs: update minimum requires Rust version for build

### DIFF
--- a/ci/check-rust-version.sh
+++ b/ci/check-rust-version.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-min_rust=(1 53 0)
+min_rust=(1 56 0)
 rust_ver=()
 
 parse_rustc_version() {

--- a/docs/install/source.markdown
+++ b/docs/install/source.markdown
@@ -6,7 +6,7 @@ macOS.
 
 * Install `rustup` to get the `rust` compiler installed on your system.
   [Install rustup](https://www.rust-lang.org/en-US/install.html)
-* Rust version 1.51 or later is required
+* Rust version 1.56 or later is required
 * Build in release mode: `cargo build --release`
 * Run it via either `cargo run --release --bin wezterm` or `target/release/wezterm`
 


### PR DESCRIPTION
The doc used to indicate that v1.51 is required, but even v1.55 fails because of `bidi`:
```
❯ cargo build
error: failed to load manifest for workspace member `/home/catA/dm232107/src/wezterm/bidi`

Caused by:
  failed to parse manifest at `/home/catA/dm232107/src/wezterm/bidi/Cargo.toml`

Caused by:
  feature `edition2021` is required

  The package requires the Cargo feature called `edition2021`, but that feature is not stabilized in this version of Cargo (1.55.0 (32da73ab1 2021-08-23)).
  Consider trying a newer version of Cargo (this may require the nightly release).
  See https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#edition-2021 for more information about the status of this feature.
```
I tried version 1.58 and it works, but v1.56 should be okay (`edition2021` was standardized in v1.56).