### PR TITLE
Fix the Path style with tilde key prefix not working in background image config 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -662,6 +662,7 @@ dependencies = [
  "bstr 0.2.17",
  "chrono",
  "colorgrad",
+ "dirs 4.0.0",
  "dirs-next",
  "enum-display-derive",
  "filenamegen",
@@ -952,6 +953,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13aea89a5c93364a98e9b37b2fa237effbb694d5cfe01c5b70941f7eb087d5e3"
 dependencies = [
  "cfg-if 0.1.10",
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
+dependencies = [
  "dirs-sys",
 ]
 
@@ -3983,7 +3993,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76971977e6121664ec1b960d1313aacfa75642adc93b9d4d53b247bd4cb1747e"
 dependencies = [
- "dirs",
+ "dirs 2.0.2",
  "fnv",
  "nom 5.1.2",
  "phf",

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -18,6 +18,7 @@ bstr = "0.2"
 chrono = {version="0.4", features=["unstable-locales"]}
 colorgrad = "0.5"
 dirs-next = "2.0"
+dirs = "4.0.0"
 enum-display-derive = "0.1"
 filenamegen = "0.2"
 hostname = "0.3"

--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -17,11 +17,6 @@ use termwiz::surface::CursorShape;
 use wezterm_bidi::ParagraphDirectionHint;
 use wezterm_input_types::{KeyCode, Modifiers, WindowDecorations};
 
-use crate::{
-    CONFIG_DIR, CONFIG_FILE_OVERRIDE, CONFIG_OVERRIDES,
-    CONFIG_SKIP, de_number, default_config_with_overrides_applied, default_one_point_oh, default_one_point_oh_f64,
-    default_true, HOME_DIR, LoadedConfig, make_lua_context,
-};
 use crate::background::Gradient;
 use crate::bell::{AudibleBell, EasingFunction, VisualBell};
 use crate::color::{ColorSchemeFile, HsbTransform, Palette, TabBarStyle, WindowFrameConfig};
@@ -38,6 +33,11 @@ use crate::tls::{TlsDomainClient, TlsDomainServer};
 use crate::units::{de_pixels, Dimension};
 use crate::unix::UnixDomain;
 use crate::wsl::WslDomain;
+use crate::{
+    de_number, default_config_with_overrides_applied, default_one_point_oh,
+    default_one_point_oh_f64, default_true, make_lua_context, LoadedConfig, CONFIG_DIR,
+    CONFIG_FILE_OVERRIDE, CONFIG_OVERRIDES, CONFIG_SKIP, HOME_DIR,
+};
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Config {
@@ -257,8 +257,8 @@ pub struct Config {
     #[serde(default)]
     pub keys: Vec<Key>,
     #[serde(
-    default = "default_bypass_mouse_reporting_modifiers",
-    deserialize_with = "crate::keys::de_modifiers"
+        default = "default_bypass_mouse_reporting_modifiers",
+        deserialize_with = "crate::keys::de_modifiers"
     )]
     pub bypass_mouse_reporting_modifiers: Modifiers,
 
@@ -812,13 +812,12 @@ impl Config {
                 let path_with_home = expand_tilde(path);
                 if path_with_home.is_some() {
                     cfg.window_background_image.replace(path_with_home.unwrap());
-                }else{
+                } else {
                     if !path.is_absolute() {
                         cfg.window_background_image.replace(config_dir.join(path));
                     }
                 }
             }
-
         }
 
         // Add some reasonable default font rules
@@ -1198,9 +1197,9 @@ fn default_stateless_process_list() -> Vec<String> {
         "pwsh.exe",
         "powershell.exe",
     ]
-        .iter()
-        .map(|s| s.to_string())
-        .collect()
+    .iter()
+    .map(|s| s.to_string())
+    .collect()
 }
 
 fn default_status_update_interval() -> u64 {
@@ -1323,8 +1322,8 @@ impl_lua_conversion!(NewlineCanon);
 
 impl<'de> Deserialize<'de> for NewlineCanon {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-        where
-            D: Deserializer<'de>,
+    where
+        D: Deserializer<'de>,
     {
         struct Helper;
 
@@ -1336,8 +1335,8 @@ impl<'de> Deserialize<'de> for NewlineCanon {
             }
 
             fn visit_bool<E>(self, value: bool) -> Result<NewlineCanon, E>
-                where
-                    E: serde::de::Error,
+            where
+                E: serde::de::Error,
             {
                 Ok(if value {
                     NewlineCanon::CarriageReturnAndLineFeed
@@ -1347,8 +1346,8 @@ impl<'de> Deserialize<'de> for NewlineCanon {
             }
 
             fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
-                where
-                    E: serde::de::Error,
+            where
+                E: serde::de::Error,
             {
                 match v {
                     "None" => Ok(NewlineCanon::None),


### PR DESCRIPTION
While I try to config the background image with `tilde key prefix` such as below

```lua
local wezterm = require 'wezterm';

return {
  font = wezterm.font_with_fallback({
    "Monaco",
    { family = "JetBrains Mono", weight = "Regular" },
    "Hack Nerd Font Mono",
    "MesloLGS NF",
    "PowerlineSymbols",
  }),
  font_size = 12.0,
  window_background_opacity = 0.95,
  window_background_image = "~/Documents/background.png",
  window_background_image_hsb = {
    -- Darken the background image by reducing it to 1/3rd
    brightness = 0.01,

    -- You can adjust the hue by scaling its value.
    -- a multiplier of 1.0 leaves the value unchanged.
    hue = 1.0,

    -- You can adjust the saturation also.
    saturation = 1.0,
  },
  use_ime = true,
}
```

The config module will parse the path to `$HOME/.config/wezterm/~/Documents/background.png`