### PR TITLE
Improve RESIZE window decorations on Windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5001,6 +5001,7 @@ dependencies = [
  "wezterm-font",
  "wezterm-input-types",
  "winapi 0.3.9",
+ "windows",
  "winreg 0.6.2",
  "x11",
  "xcb 0.9.0",

--- a/assets/windows/manifest.manifest
+++ b/assets/windows/manifest.manifest
@@ -1,9 +1,43 @@
-<?xml version='1.0' encoding='UTF-8' standalone='yes'?>
-<assembly xmlns="urn:schemas-microsoft-com:asm.v1"
-    manifestVersion="1.0" xmlns:asmv3="urn:schemas-microsoft-com:asm.v3" >
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly
+  manifestVersion="1.0"
+  xmlns="urn:schemas-microsoft-com:asm.v1"
+  xmlns:asmv3="urn:schemas-microsoft-com:asm.v3"
+>
   <asmv3:application>
     <asmv3:windowsSettings xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">
       <dpiAwareness>PerMonitorV2</dpiAwareness>
     </asmv3:windowsSettings>
   </asmv3:application>
+  <dependency>
+    <dependentAssembly>
+      <assemblyIdentity
+        type="win32"
+        name="Microsoft.Windows.Common-Controls"
+        version="6.0.0.0"
+        processorArchitecture="*"
+        publicKeyToken="6595b64144ccf1df"
+        language="*"
+      />
+    </dependentAssembly>
+  </dependency>
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <!-- Windows 10 and Windows 11 -->
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
+    </application>
+  </compatibility>
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
+    <security>
+      <requestedPrivileges>
+        <!--
+          UAC settings:
+          - app should run at same integrity level as calling process
+          - app does not need to manipulate windows belonging to
+            higher-integrity-level processes
+          -->
+        <requestedExecutionLevel level="asInvoker" uiAccess="false" />
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
 </assembly>

--- a/wezterm-gui/build.rs
+++ b/wezterm-gui/build.rs
@@ -103,8 +103,8 @@ fn main() {
 #include <winres.h>
 // This ID is coupled with code in window/src/os/windows/window.rs
 #define IDI_ICON 0x101
+1 RT_MANIFEST "{win}\\manifest.manifest"
 IDI_ICON ICON "{win}\\terminal.ico"
-APP_MANIFEST RT_MANIFEST "{win}\\manifest.manifest"
 VS_VERSION_INFO VERSIONINFO
 FILEVERSION     1,0,0,0
 PRODUCTVERSION  1,0,0,0

--- a/wezterm-gui/src/termwindow/render.rs
+++ b/wezterm-gui/src/termwindow/render.rs
@@ -920,6 +920,58 @@ impl super::TermWindow {
         Ok(())
     }
 
+    fn paint_window_borders(&mut self) -> anyhow::Result<()> {
+        if let Some(ref os_params) = self.os_parameters {
+            if let Some(ref border_dimensions) = os_params.border_dimensions {
+                let gl_state = self.render_state.as_ref().unwrap();
+                let vb = &gl_state.vb[1];
+                let mut vb_mut = vb.current_vb_mut();
+                let mut layer1 = vb.map(&mut vb_mut);
+
+                let height = self.dimensions.pixel_height as f32;
+                let width = self.dimensions.pixel_width as f32;
+
+                let border_top = border_dimensions.top.get() as f32;
+                if border_top > 0.0 {
+                    self.filled_rectangle(
+                        &mut layer1,
+                        euclid::rect(0.0, 0.0, width, border_top),
+                        border_dimensions.color,
+                    )?;
+                }
+
+                let border_left = border_dimensions.left.get() as f32;
+                if border_left > 0.0 {
+                    self.filled_rectangle(
+                        &mut layer1,
+                        euclid::rect(0.0, 0.0, border_left, height),
+                        border_dimensions.color,
+                    )?;
+                }
+
+                let border_bottom = border_dimensions.bottom.get() as f32;
+                if border_bottom > 0.0 {
+                    self.filled_rectangle(
+                        &mut layer1,
+                        euclid::rect(0.0, height - border_bottom, width, height),
+                        border_dimensions.color,
+                    )?;
+                }
+
+                let border_right = border_dimensions.right.get() as f32;
+                if border_right > 0.0 {
+                    self.filled_rectangle(
+                        &mut layer1,
+                        euclid::rect(width - border_right, 0.0, width, height),
+                        border_dimensions.color,
+                    )?;
+                }
+            }
+        }
+
+        Ok(())
+    }
+
     pub fn paint_pane_opengl(
         &mut self,
         pos: &PositionedPane,
@@ -1556,6 +1608,8 @@ impl super::TermWindow {
         if self.show_tab_bar {
             self.paint_tab_bar()?;
         }
+
+        self.paint_window_borders()?;
 
         Ok(())
     }

--- a/wezterm-gui/src/termwindow/resize.rs
+++ b/wezterm-gui/src/termwindow/resize.rs
@@ -39,7 +39,11 @@ impl super::TermWindow {
             log::trace!("dimensions didn't change NOP!");
             return;
         }
+        let last_state = self.window_state;
         self.window_state = window_state;
+        if last_state != self.window_state {
+            self.load_os_parameters();
+        }
         // For simple, user-interactive resizes where the dpi doesn't change,
         // skip our scaling recalculation
         if live_resizing && self.dimensions.dpi == dimensions.dpi {

--- a/window/Cargo.toml
+++ b/window/Cargo.toml
@@ -47,18 +47,22 @@ wezterm-font = { path = "../wezterm-font" }
 wezterm-input-types = { path = "../wezterm-input-types" }
 
 [target."cfg(windows)".dependencies]
+clipboard-win = "2.2"
+shared_library = "0.1"
 winapi = { version = "0.3", features = [
     "dwmapi",
     "handleapi",
     "imm",
     "libloaderapi",
     "synchapi",
+    "sysinfoapi",
     "winerror",
     "winuser",
 ]}
+windows = { version="0.33.0", features = [
+    "UI_ViewManagement",
+]}
 winreg = "0.6"
-clipboard-win = "2.2"
-shared_library = "0.1"
 
 [target.'cfg(all(unix, not(target_os = "macos")))'.dependencies]
 dirs-next = "2.0"

--- a/window/src/lib.rs
+++ b/window/src/lib.rs
@@ -287,6 +287,7 @@ pub trait WindowOps {
     fn get_os_parameters(
         &self,
         _config: &ConfigHandle,
+        _window_state: WindowState,
     ) -> anyhow::Result<Option<os::parameters::Parameters>> {
         Ok(None)
     }

--- a/window/src/lib.rs
+++ b/window/src/lib.rs
@@ -1,5 +1,6 @@
 use async_trait::async_trait;
 use bitflags::bitflags;
+use config::ConfigHandle;
 use promise::Future;
 use std::any::Any;
 use std::rc::Rc;
@@ -50,6 +51,8 @@ pub struct Dimensions {
     pub dpi: usize,
 }
 
+pub type Length = euclid::Length<isize, PixelUnit>;
+pub type LengthF = euclid::Length<f32, PixelUnit>;
 pub type Rect = euclid::Rect<isize, PixelUnit>;
 pub type RectF = euclid::Rect<f32, PixelUnit>;
 pub type Size = euclid::Size2D<isize, PixelUnit>;
@@ -281,7 +284,10 @@ pub trait WindowOps {
     /// environment.
     fn set_resize_increments(&self, _x: u16, _y: u16) {}
 
-    fn get_title_font_and_point_size(&self) -> Option<(wezterm_font::parser::ParsedFont, f64)> {
-        None
+    fn get_os_parameters(
+        &self,
+        _config: &ConfigHandle,
+    ) -> anyhow::Result<Option<os::parameters::Parameters>> {
+        Ok(None)
     }
 }

--- a/window/src/os/mod.rs
+++ b/window/src/os/mod.rs
@@ -16,3 +16,5 @@ pub use x_and_wayland::*;
 pub mod macos;
 #[cfg(target_os = "macos")]
 pub use self::macos::*;
+
+pub mod parameters;

--- a/window/src/os/parameters.rs
+++ b/window/src/os/parameters.rs
@@ -3,11 +3,13 @@ use wezterm_font::parser::ParsedFont;
 
 use crate::Length;
 
+pub type FontAndSize = (ParsedFont, f64);
+
 pub struct TitleBar {
     pub padding_left: Length,
     pub padding_right: Length,
     pub height: Option<Length>,
-    pub font_and_size: Option<(ParsedFont, f64)>,
+    pub font_and_size: Option<FontAndSize>,
 }
 
 pub struct Border {

--- a/window/src/os/parameters.rs
+++ b/window/src/os/parameters.rs
@@ -1,0 +1,24 @@
+use wezterm_color_types::LinearRgba;
+use wezterm_font::parser::ParsedFont;
+
+use crate::Length;
+
+pub struct TitleBar {
+    pub padding_left: Length,
+    pub padding_right: Length,
+    pub height: Option<Length>,
+    pub font_and_size: Option<(ParsedFont, f64)>,
+}
+
+pub struct Border {
+    pub top: Length,
+    pub left: Length,
+    pub bottom: Length,
+    pub right: Length,
+    pub color: LinearRgba,
+}
+
+pub struct Parameters {
+    pub title_bar: TitleBar,
+    pub border_dimensions: Option<Border>, // If present, the application should draw it
+}

--- a/window/src/os/windows/extra_constants.rs
+++ b/window/src/os/windows/extra_constants.rs
@@ -1,5 +1,3 @@
-use winapi::um::winuser::WM_USER;
-
 pub const TMT_CAPTIONFONT: i32 = 801;
 pub const HP_HEADERITEM: i32 = 1;
 pub const HIS_NORMAL: i32 = 1;

--- a/window/src/os/windows/extra_constants.rs
+++ b/window/src/os/windows/extra_constants.rs
@@ -1,0 +1,7 @@
+use winapi::um::winuser::WM_USER;
+
+pub const TMT_CAPTIONFONT: i32 = 801;
+pub const HP_HEADERITEM: i32 = 1;
+pub const HIS_NORMAL: i32 = 1;
+
+pub const UM_APPEARANCE_CHANGED: u32 = WM_USER + 1;

--- a/window/src/os/windows/extra_constants.rs
+++ b/window/src/os/windows/extra_constants.rs
@@ -3,5 +3,3 @@ use winapi::um::winuser::WM_USER;
 pub const TMT_CAPTIONFONT: i32 = 801;
 pub const HP_HEADERITEM: i32 = 1;
 pub const HIS_NORMAL: i32 = 1;
-
-pub const UM_APPEARANCE_CHANGED: u32 = WM_USER + 1;

--- a/window/src/os/windows/mod.rs
+++ b/window/src/os/windows/mod.rs
@@ -1,5 +1,6 @@
 pub mod connection;
 pub mod event;
+mod extra_constants;
 mod keycodes;
 mod wgl;
 pub mod window;

--- a/window/src/os/windows/window.rs
+++ b/window/src/os/windows/window.rs
@@ -748,9 +748,7 @@ impl WindowOps for Window {
         window_state: WindowState,
     ) -> anyhow::Result<Option<Parameters>> {
         let hwnd = self.0 .0;
-        if hwnd.is_null() {
-            return Err(anyhow::anyhow!("HWND is null"));
-        }
+        anyhow::ensure!(!hwnd.is_null(), "HWND is null");
 
         let has_focus = unsafe { GetFocus() } == hwnd;
         let is_full_screen = window_state.contains(WindowState::FULL_SCREEN);

--- a/window/src/os/windows/window.rs
+++ b/window/src/os/windows/window.rs
@@ -752,7 +752,7 @@ impl WindowOps for Window {
             return Err(anyhow::anyhow!("HWND is null"));
         }
 
-        let has_focus = !unsafe { GetFocus() }.is_null();
+        let has_focus = unsafe { GetFocus() } == hwnd;
         let is_full_screen = window_state.contains(WindowState::FULL_SCREEN);
 
         // let title_font = unsafe {

--- a/window/src/os/windows/window.rs
+++ b/window/src/os/windows/window.rs
@@ -753,19 +753,16 @@ impl WindowOps for Window {
         let has_focus = unsafe { GetFocus() } == hwnd;
         let is_full_screen = window_state.contains(WindowState::FULL_SCREEN);
 
-        // let title_font = unsafe {
-        //     let hdc = GetDC(hwnd);
-        //     if hdc.is_null() {
-        //         return Err(anyhow::anyhow!("Could not get device context"));
-        //     }
-        //     let result = match get_title_log_font(hwnd, hdc) {
-        //         Some(lf) => Some(wezterm_font::locator::gdi::parse_log_font(&lf, hdc)?),
-        //         None => None,
-        //     };
-        //     ReleaseDC(hwnd, hdc);
-        //     result
-        // };
-        let title_font = None;
+        let title_font = unsafe {
+            let hdc = GetDC(hwnd);
+            anyhow::ensure!(!hdc.is_null(), "Could not get device context");
+            let result = match get_title_log_font(hwnd, hdc) {
+                Some(lf) => wezterm_font::locator::gdi::parse_log_font(&lf, hdc).ok(),
+                None => None,
+            };
+            ReleaseDC(hwnd, hdc);
+            result
+        };
 
         let hkcu = RegKey::predef(HKEY_CURRENT_USER);
         let use_accent = hkcu

--- a/window/src/os/windows/window.rs
+++ b/window/src/os/windows/window.rs
@@ -259,7 +259,11 @@ impl WindowInner {
                 window_state: if self.saved_placement.is_some() {
                     WindowState::FULL_SCREEN
                 } else {
-                    WindowState::default()
+                    match get_window_state(self.hwnd.0) {
+                        SW_SHOWMAXIMIZED => WindowState::MAXIMIZED,
+                        SW_SHOWMINIMIZED => WindowState::HIDDEN,
+                        _ => WindowState::default(),
+                    }
                 },
                 live_resizing: self.in_size_move,
             });

--- a/window/src/os/windows/window.rs
+++ b/window/src/os/windows/window.rs
@@ -1115,17 +1115,6 @@ fn apply_theme(hwnd: HWND) -> Option<LRESULT> {
     None
 }
 
-fn dispatch_appearance_changed(hwnd: HWND) -> Option<LRESULT> {
-    if let Some(inner) = rc_from_hwnd(hwnd) {
-        let mut inner = inner.borrow_mut();
-        let appearance = inner.appearance;
-        inner
-            .events
-            .dispatch(WindowEvent::AppearanceChanged(appearance));
-    }
-    None
-}
-
 unsafe fn wm_enter_exit_size_move(
     hwnd: HWND,
     msg: UINT,


### PR DESCRIPTION
The problems are described in #1674.

This change fixes all of them. The code is what's generally done to make an app with a custom title bar, with tabs like Firefox for instance:

- It handles `nccalcsize`, so that you draw your own borders/window decorations.
- It handles `nchittest` to deal with mouse input in your custom title bar.

This is based on this article: https://kubyshkin.name/posts/win32-window-custom-title-bar-caption/