### PR TITLE
fix: tmux -CC capturep with extra \n

### DIFF
--- a/mux/src/tmux_commands.rs
+++ b/mux/src/tmux_commands.rs
@@ -308,12 +308,14 @@ impl TmuxCommand for CapturePane {
 
         let unescaped = termwiz::tmux_cc::unvis(&result.output).context("unescape pane content")?;
         let unescaped = unescaped.replace("\n", "\r\n");
+        // capturep contents returned from guarded lines which always contain a tailing '\n'
+        let trim_unescaped = &unescaped[0..unescaped.len() - 1];
 
         let pane_map = tmux_domain.inner.remote_panes.borrow();
         if let Some(pane) = pane_map.get(&self.0) {
             let mut pane = pane.lock().expect("Grant lock of tmux cmd queue failed");
             pane.output_write
-                .write_all(unescaped.as_bytes())
+                .write_all(trim_unescaped.as_bytes())
                 .context("writing capture pane result to output")?;
         }
 

--- a/mux/src/tmux_commands.rs
+++ b/mux/src/tmux_commands.rs
@@ -307,15 +307,14 @@ impl TmuxCommand for CapturePane {
         };
 
         let unescaped = termwiz::tmux_cc::unvis(&result.output).context("unescape pane content")?;
-        let unescaped = unescaped.replace("\n", "\r\n");
         // capturep contents returned from guarded lines which always contain a tailing '\n'
-        let trim_unescaped = &unescaped[0..unescaped.len() - 1];
+        let unescaped = &unescaped[0..unescaped.len().saturating_sub(1)].replace("\n", "\r\n");
 
         let pane_map = tmux_domain.inner.remote_panes.borrow();
         if let Some(pane) = pane_map.get(&self.0) {
             let mut pane = pane.lock().expect("Grant lock of tmux cmd queue failed");
             pane.output_write
-                .write_all(trim_unescaped.as_bytes())
+                .write_all(unescaped.as_bytes())
                 .context("writing capture pane result to output")?;
         }
 


### PR DESCRIPTION
If the original content is

```
wezterm▊ // <- cursor right after the word
```

then the returned content of `capturep` command will be 

```
%begin
wezterm // <- implicit \n
%end
```

thus the rendered content will be

```
wezterm
▊
```