### PR TITLE
Improve RESIZE window decorations on Windows (more features)

### DIFF
--- a/wezterm-gui/src/tabbar.rs
+++ b/wezterm-gui/src/tabbar.rs
@@ -23,6 +23,16 @@ pub enum TabBarItem {
     NewTabButton,
 }
 
+impl Into<::window::TabBarItem> for TabBarItem {
+    fn into(self) -> ::window::TabBarItem {
+        match self {
+            TabBarItem::None => ::window::TabBarItem::None,
+            TabBarItem::Tab { tab_idx, active } => ::window::TabBarItem::Tab { tab_idx, active },
+            TabBarItem::NewTabButton => ::window::TabBarItem::NewTabButton,
+        }
+    }
+}
+
 #[derive(Clone, Debug, PartialEq)]
 pub struct TabEntry {
     pub item: TabBarItem,

--- a/wezterm-gui/src/termwindow/mouseevent.rs
+++ b/wezterm-gui/src/termwindow/mouseevent.rs
@@ -369,6 +369,7 @@ impl super::TermWindow {
         }
         self.update_title_post_status();
         context.set_cursor(Some(MouseCursor::Arrow));
+        context.mouse_event_tab_bar(item.into(), event.clone());
     }
 
     pub fn mouse_event_above_scroll_thumb(

--- a/window/src/lib.rs
+++ b/window/src/lib.rs
@@ -64,6 +64,12 @@ pub enum MouseCursor {
     SizeLeftRight,
 }
 
+pub enum TabBarItem {
+    None,
+    Tab { tab_idx: usize, active: bool },
+    NewTabButton,
+}
+
 /// Represents the preferred appearance of the windowing
 /// environment.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -283,4 +289,6 @@ pub trait WindowOps {
     fn get_title_font_and_point_size(&self) -> Option<(wezterm_font::parser::ParsedFont, f64)> {
         None
     }
+
+    fn mouse_event_tab_bar(&self, _item: TabBarItem, _event: MouseEvent) {}
 }

--- a/window/src/os/windows/window.rs
+++ b/window/src/os/windows/window.rs
@@ -863,15 +863,15 @@ unsafe fn wm_nchittest(
         let mut inner = inner.borrow_mut();
 
         if inner.config.window_decorations != WindowDecorations::RESIZE {
-            return None
+            return None;
         }
 
         // Let the default procedure handle resizing areas
         let result = DefWindowProcW(hwnd, _msg, _wparam, _lparam);
 
         match result {
-            HTNOWHERE | HTRIGHT | HTLEFT | HTTOPLEFT | HTTOP | HTTOPRIGHT
-            | HTBOTTOMRIGHT | HTBOTTOM | HTBOTTOMLEFT => {
+            HTNOWHERE | HTRIGHT | HTLEFT | HTTOPLEFT | HTTOP | HTTOPRIGHT | HTBOTTOMRIGHT
+            | HTBOTTOM | HTBOTTOMLEFT => {
                 return Some(result);
             }
             _ => {}

--- a/window/src/os/windows/window.rs
+++ b/window/src/os/windows/window.rs
@@ -822,7 +822,7 @@ unsafe fn wm_nccalcsize(
     _lparam: LPARAM,
 ) -> Option<LRESULT> {
     if let Some(inner) = rc_from_hwnd(hwnd) {
-        let mut inner = inner.borrow_mut();
+        let inner = inner.borrow_mut();
 
         if !(_wparam == 1 && inner.config.window_decorations == WindowDecorations::RESIZE) {
             return None;
@@ -860,7 +860,7 @@ unsafe fn wm_nchittest(
     _lparam: LPARAM,
 ) -> Option<LRESULT> {
     if let Some(inner) = rc_from_hwnd(hwnd) {
-        let mut inner = inner.borrow_mut();
+        let inner = inner.borrow_mut();
 
         if inner.config.window_decorations != WindowDecorations::RESIZE {
             return None;

--- a/window/src/os/windows/window.rs
+++ b/window/src/os/windows/window.rs
@@ -896,14 +896,10 @@ unsafe fn wm_nchittest(hwnd: HWND, msg: UINT, wparam: WPARAM, lparam: LPARAM) ->
         // The adjustment in NCCALCSIZE messes with the detection
         // of the top hit area so manually fixing that.
         let dpi = GetDpiForWindow(hwnd);
-        let frame_y = GetSystemMetricsForDpi(SM_CYFRAME, dpi);
+        let frame_y = GetSystemMetricsForDpi(SM_CYFRAME, dpi) as isize;
 
-        let cursor_point = MAKEPOINTS(lparam as u32);
-        let mut cursor_point = POINT {
-            x: cursor_point.x as i32,
-            y: cursor_point.y as i32,
-        };
-        ScreenToClient(hwnd, &mut cursor_point);
+        let coords = mouse_coords(lparam);
+        let cursor_point = screen_to_client(hwnd, ScreenPoint::new(coords.x, coords.y));
 
         // check if in resize area
         if cursor_point.y >= 0 && cursor_point.y < frame_y {
@@ -1241,11 +1237,8 @@ fn mods_and_buttons(wparam: WPARAM) -> (Modifiers, MouseButtons) {
 }
 
 fn mouse_coords(lparam: LPARAM) -> Point {
-    // Take care to get the signedness correct!
-    let x = (lparam & 0xffff) as u16 as i16 as isize;
-    let y = ((lparam >> 16) & 0xffff) as u16 as i16 as isize;
-
-    Point::new(x, y)
+    let point = MAKEPOINTS(lparam as _);
+    Point::new(point.x as _, point.y as _)
 }
 
 fn screen_to_client(hwnd: HWND, point: ScreenPoint) -> Point {

--- a/window/src/os/windows/window.rs
+++ b/window/src/os/windows/window.rs
@@ -899,7 +899,8 @@ unsafe fn wm_nchittest(hwnd: HWND, msg: UINT, wparam: WPARAM, lparam: LPARAM) ->
         let frame_y = GetSystemMetricsForDpi(SM_CYFRAME, dpi) as isize;
 
         let coords = mouse_coords(lparam);
-        let cursor_point = screen_to_client(hwnd, ScreenPoint::new(coords.x, coords.y));
+        let screen_coords = ScreenPoint::new(coords.x, coords.y);
+        let cursor_point = screen_to_client(hwnd, screen_coords);
 
         // check if in resize area
         if cursor_point.y >= 0 && cursor_point.y < frame_y {
@@ -911,9 +912,8 @@ unsafe fn wm_nchittest(hwnd: HWND, msg: UINT, wparam: WPARAM, lparam: LPARAM) ->
             return Some(HTCAPTION);
         }
 
-        if let Some(coords) = inner.last_tabbar_empty_area_coords {
-            let cursor_point = MAKEPOINTS(lparam as u32);
-            if (cursor_point.x, cursor_point.y) == (coords.x as i16, coords.y as i16) {
+        if let Some(tabbar_coords) = inner.last_tabbar_empty_area_coords {
+            if screen_coords == tabbar_coords {
                 return Some(HTCAPTION);
             }
         }


### PR DESCRIPTION
The problems are described in #1674.

This change fixes all of them. The code is what's generally done to make an app with a custom title bar, with tabs like Firefox for instance:

- It handles `nccalcsize`, so that you draw your own borders/window decorations.
- It handles `nchittest` to deal with mouse input in your custom title bar.

In addition to #1675, this one also makes the empty area of the tab bar act as a native title bar, with features:

- Double click to max/minimize
- Drag to corners of the screen to snap/maximize
- Drag when maximized to restore original size
- Shake while dragging to minimize/restore other windows
- Right click to open the context menu

This is based on this article: https://kubyshkin.name/posts/win32-window-custom-title-bar-caption/

I hacked a way to check if the mouse is over the empty area of the tab bar, it's unclear if that's a good enough solution or if some other plumbing should be implemented to enable that.