### PR TITLE
fix: tmux -CC sync cursor position after attach

### DIFF
--- a/mux/src/localpane.rs
+++ b/mux/src/localpane.rs
@@ -24,7 +24,7 @@ use url::Url;
 use wezterm_term::color::ColorPalette;
 use wezterm_term::{
     Alert, AlertHandler, CellAttributes, Clipboard, DownloadHandler, KeyCode, KeyModifiers,
-    MouseEvent, SemanticZone, StableRowIndex, Terminal, TerminalConfiguration,
+    MouseEvent, SemanticZone, StableRowIndex, Terminal, Position, TerminalConfiguration,
 };
 
 #[derive(Debug)]
@@ -70,6 +70,12 @@ impl Pane for LocalPane {
             cursor.visibility = termwiz::surface::CursorVisibility::Hidden;
         }
         cursor
+    }
+
+    fn set_cursor_position(&self, x: u64, y: u64) {
+        self.terminal
+            .borrow_mut()
+            .set_cursor_pos(&Position::Absolute(x as i64), &Position::Absolute(y as i64));
     }
 
     fn get_keyboard_encoding(&self) -> KeyboardEncoding {

--- a/mux/src/localpane.rs
+++ b/mux/src/localpane.rs
@@ -24,7 +24,7 @@ use url::Url;
 use wezterm_term::color::ColorPalette;
 use wezterm_term::{
     Alert, AlertHandler, CellAttributes, Clipboard, DownloadHandler, KeyCode, KeyModifiers,
-    MouseEvent, SemanticZone, StableRowIndex, Terminal, Position, TerminalConfiguration,
+    MouseEvent, Position, SemanticZone, StableRowIndex, Terminal, TerminalConfiguration,
 };
 
 #[derive(Debug)]

--- a/mux/src/pane.rs
+++ b/mux/src/pane.rs
@@ -172,6 +172,8 @@ pub trait Pane: Downcast {
     /// the visible screen
     fn get_cursor_position(&self) -> StableCursorPosition;
 
+    fn set_cursor_position(&self, _x: u64, _y: u64) {}
+
     fn get_current_seqno(&self) -> SequenceNo;
 
     /// Given a range of lines, return the subset of those lines that

--- a/term/src/terminalstate/mod.rs
+++ b/term/src/terminalstate/mod.rs
@@ -901,7 +901,7 @@ impl TerminalState {
 
     /// Sets the cursor position. x and y are 0-based and relative to the
     /// top left of the visible screen.
-    fn set_cursor_pos(&mut self, x: &Position, y: &Position) {
+    pub fn set_cursor_pos(&mut self, x: &Position, y: &Position) {
         let x = match *x {
             Position::Relative(x) => (self.cursor.x as i64 + x)
                 .min(


### PR DESCRIPTION
This combine with #1676 should make the cursor position correct after attaching to an existing tmux session. Not sure if it's fine to expose the `set_cursor_pos` method from `TerminalState` and add a `set_cursor_position` method to the `Pane` trait (which is default empty implemented).