### PR TITLE
Detect mouse leaving the window

### DIFF
--- a/wezterm-gui/src/termwindow/mod.rs
+++ b/wezterm-gui/src/termwindow/mod.rs
@@ -837,6 +837,10 @@ impl TermWindow {
                 self.mouse_event_impl(event, window);
                 Ok(true)
             }
+            WindowEvent::MouseLeave => {
+                self.mouse_leave_impl(window);
+                Ok(true)
+            }
             WindowEvent::Resized {
                 dimensions,
                 window_state,

--- a/wezterm-gui/src/termwindow/mouseevent.rs
+++ b/wezterm-gui/src/termwindow/mouseevent.rs
@@ -200,9 +200,7 @@ impl super::TermWindow {
     }
 
     pub fn mouse_leave_impl(&mut self, context: &dyn WindowOps) {
-        self.last_ui_item = None;
-        self.last_mouse_coords = (0, -1);
-        self.update_title_post_status();
+        self.current_mouse_event = None;
         context.invalidate();
     }
 

--- a/wezterm-gui/src/termwindow/mouseevent.rs
+++ b/wezterm-gui/src/termwindow/mouseevent.rs
@@ -199,6 +199,13 @@ impl super::TermWindow {
         }
     }
 
+    pub fn mouse_leave_impl(&mut self, context: &dyn WindowOps) {
+        self.last_ui_item = None;
+        self.last_mouse_coords = (0, -1);
+        self.update_title_post_status();
+        context.invalidate();
+    }
+
     fn drag_split(
         &mut self,
         mut item: UIItem,

--- a/window/examples/async.rs
+++ b/window/examples/async.rs
@@ -80,7 +80,8 @@ impl MyWindow {
             WindowEvent::AppearanceChanged(_)
             | WindowEvent::AdviseDeadKeyStatus(_)
             | WindowEvent::Notification(_)
-            | WindowEvent::FocusChanged(_) => {}
+            | WindowEvent::FocusChanged(_)
+            | WindowEvent::MouseLeave => {}
         }
     }
 }

--- a/window/src/lib.rs
+++ b/window/src/lib.rs
@@ -168,6 +168,7 @@ pub enum WindowEvent {
     KeyEvent(KeyEvent),
 
     MouseEvent(MouseEvent),
+    MouseLeave,
 
     AppearanceChanged(Appearance),
 

--- a/window/src/os/wayland/pointer.rs
+++ b/window/src/os/wayland/pointer.rs
@@ -104,6 +104,7 @@ pub struct PendingMouse {
     surface_coords: Option<(f64, f64)>,
     button: Vec<(MousePress, ButtonState)>,
     scroll: Option<(f64, f64)>,
+    in_window: bool,
 }
 
 impl PendingMouse {
@@ -114,6 +115,7 @@ impl PendingMouse {
             button: vec![],
             scroll: None,
             surface_coords: None,
+            in_window: false,
         }))
     }
 
@@ -126,7 +128,14 @@ impl PendingMouse {
                     .lock()
                     .unwrap()
                     .update_last_serial(serial);
+                self.in_window = true;
                 false
+            }
+            PointerEvent::Leave { .. } => {
+                let changed = self.in_window;
+                self.surface_coords = None;
+                self.in_window = false;
+                changed
             }
             PointerEvent::Motion {
                 surface_x,
@@ -203,6 +212,10 @@ impl PendingMouse {
 
     pub fn scroll(pending: &Arc<Mutex<Self>>) -> Option<(f64, f64)> {
         pending.lock().unwrap().scroll.take()
+    }
+
+    pub fn in_window(pending: &Arc<Mutex<Self>>) -> bool {
+        pending.lock().unwrap().in_window
     }
 }
 

--- a/window/src/os/wayland/window.rs
+++ b/window/src/os/wayland/window.rs
@@ -537,6 +537,11 @@ impl WaylandWindowInner {
                 self.events.dispatch(WindowEvent::MouseEvent(event));
             }
         }
+
+        if !PendingMouse::in_window(&pending_mouse) {
+            self.events.dispatch(WindowEvent::MouseLeave);
+            self.refresh_frame();
+        }
     }
 
     fn get_dpi_factor(&self) -> i32 {

--- a/window/src/os/windows/window.rs
+++ b/window/src/os/windows/window.rs
@@ -1172,17 +1172,7 @@ unsafe fn mouse_leave(hwnd: HWND, _msg: UINT, _wparam: WPARAM, _lparam: LPARAM) 
         let mut inner = inner.borrow_mut();
 
         inner.track_mouse_leave = false;
-
-        let coords = Point::new(-1, -1);
-        let event = MouseEvent {
-            kind: MouseEventKind::Move,
-            coords,
-            screen_coords: client_to_screen(hwnd, coords),
-            mouse_buttons: MouseButtons::default(),
-            modifiers: Modifiers::default(),
-        };
-
-        inner.events.dispatch(WindowEvent::MouseEvent(event));
+        inner.events.dispatch(WindowEvent::MouseLeave);
 
         Some(0)
     } else {

--- a/window/src/os/x11/connection.rs
+++ b/window/src/os/x11/connection.rs
@@ -138,6 +138,10 @@ fn window_id_from_event(event: &xcb::GenericEvent) -> Option<xcb::xproto::Window
             let msg: &xcb::FocusOutEvent = unsafe { xcb::cast_event(event) };
             Some(msg.event())
         }
+        xcb::LEAVE_NOTIFY => {
+            let msg: &xcb::LeaveNotifyEvent = unsafe { xcb::cast_event(event) };
+            Some(msg.event())
+        }
         _ => None,
     }
 }

--- a/window/src/os/x11/window.rs
+++ b/window/src/os/x11/window.rs
@@ -414,6 +414,9 @@ impl XWindowInner {
                 log::trace!("Calling focus_change(false)");
                 self.events.dispatch(WindowEvent::FocusChanged(false));
             }
+            xcb::LEAVE_NOTIFY => {
+                self.events.dispatch(WindowEvent::MouseLeave);
+            }
             _ => {
                 eprintln!("unhandled: {:x}", r);
             }
@@ -825,6 +828,7 @@ impl XWindow {
                             | xcb::EVENT_MASK_BUTTON_PRESS
                             | xcb::EVENT_MASK_BUTTON_RELEASE
                             | xcb::EVENT_MASK_POINTER_MOTION
+                            | xcb::EVENT_MASK_LEAVE_WINDOW
                             | xcb::EVENT_MASK_BUTTON_MOTION
                             | xcb::EVENT_MASK_KEY_RELEASE
                             | xcb::EVENT_MASK_PROPERTY_CHANGE


### PR DESCRIPTION
Detect when mouse leaves the window, for instance to clear the hover state of the items in the tab bar.

This fixes #1434 on Windows, Wayland, X11 and macOS