### PR TITLE
Use newer windows crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -692,12 +692,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "const-sha1"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb58b6451e8c2a812ad979ed1d83378caa5e927eef2622017a45f251457c2c9d"
-
-[[package]]
 name = "core-foundation"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5013,30 +5007,46 @@ dependencies = [
 
 [[package]]
 name = "windows"
-version = "0.11.0"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25b270ca3fa1282aa091f122551348f8186f07888dffdfe64df17206ad3b56d0"
+checksum = "0128fa8e65e0616e45033d68dc0b7fbd521080b7844e5cad3a4a4d201c4b2bd2"
 dependencies = [
- "const-sha1",
- "windows_gen",
- "windows_macros",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
-name = "windows_gen"
-version = "0.11.0"
+name = "windows_aarch64_msvc"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44bd40154eb69ba3c80f11752494a2a34d1b448b06b80449238edfbd00ec7eef"
+checksum = "cd761fd3eb9ab8cc1ed81e56e567f02dd82c4c837e48ac3b2181b9ffc5060807"
 
 [[package]]
-name = "windows_macros"
-version = "0.11.0"
+name = "windows_i686_gnu"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bae6942e04aa5792bbf3b3cf5ded1b7590a7ffd76d53ea179210b87911b6587f"
-dependencies = [
- "syn",
- "windows_gen",
-]
+checksum = "cab0cf703a96bab2dc0c02c0fa748491294bf9b7feb27e1f4f96340f208ada0e"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cfdbe89cc9ad7ce618ba34abc34bbb6c36d99e96cae2245b7943cd75ee773d0"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4dd9b0c0e9ece7bb22e84d70d01b71c6d6248b81a3c60d11869451b4cb24784"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff1e4aa646495048ec7f3ffddc411e1d829c026a2ec62b39da15c1055e406eaa"
 
 [[package]]
 name = "winreg"

--- a/wezterm-gui/Cargo.toml
+++ b/wezterm-gui/Cargo.toml
@@ -18,7 +18,6 @@ anyhow = "1.0"
 [target.'cfg(windows)'.build-dependencies]
 embed-resource = "1.3"
 cc = "1.0"
-windows = "0.11"
 
 [dependencies]
 anyhow = "1.0"
@@ -83,7 +82,6 @@ window = { path = "../window" }
 [target."cfg(windows)".dependencies]
 shared_library = "0.1"
 uds_windows = "1.0"
-windows = "0.11"
 winapi = { version = "0.3", features = [
     "winuser",
     "consoleapi",
@@ -92,6 +90,9 @@ winapi = { version = "0.3", features = [
     "namedpipeapi",
     "synchapi",
     "winsock2",
+]}
+windows = { version="0.33.0", features = [
+    "Win32_UI_Shell",
 ]}
 
 [dev-dependencies]

--- a/wezterm-gui/build.rs
+++ b/wezterm-gui/build.rs
@@ -149,8 +149,6 @@ END
             }
         }
         embed_resource::compile(rcfile_name);
-
-        windows::build!(Windows::Win32::UI::Shell::SetCurrentProcessExplicitAppUserModelID);
     }
 
     #[cfg(target_os = "macos")]

--- a/wezterm-gui/src/main.rs
+++ b/wezterm-gui/src/main.rs
@@ -844,12 +844,6 @@ pub fn run_ls_fonts(config: config::ConfigHandle, cmd: &LsFontsCommand) -> anyho
     Ok(())
 }
 
-#[cfg(windows)]
-mod win_bindings {
-    ::windows::include_bindings!();
-    pub use self::Windows::Win32::UI::Shell::SetCurrentProcessExplicitAppUserModelID;
-}
-
 fn run() -> anyhow::Result<()> {
     // Inform the system of our AppUserModelID.
     // Without this, our toast notifications won't be correctly
@@ -857,7 +851,10 @@ fn run() -> anyhow::Result<()> {
     #[cfg(windows)]
     {
         unsafe {
-            win_bindings::SetCurrentProcessExplicitAppUserModelID("org.wezfurlong.wezterm").is_ok();
+            ::windows::Win32::UI::Shell::SetCurrentProcessExplicitAppUserModelID(
+                ::windows::core::PCWSTR(wide_string("org.wezfurlong.wezterm").as_ptr()),
+            )
+            .unwrap();
         }
     }
 

--- a/wezterm-toast-notification/Cargo.toml
+++ b/wezterm-toast-notification/Cargo.toml
@@ -24,8 +24,10 @@ core-foundation = "0.7"
 objc = "0.2"
 
 [target.'cfg(windows)'.dependencies]
-windows = "0.11"
+windows = { version="0.33.0", features = [
+    "Data_Xml_Dom",
+    "Foundation",
+    "UI_Notifications",
+    "Win32_Foundation",
+]}
 xml-rs = "0.8"
-
-[target.'cfg(windows)'.build-dependencies]
-windows = "0.11"

--- a/wezterm-toast-notification/build.rs
+++ b/wezterm-toast-notification/build.rs
@@ -2,13 +2,4 @@ fn main() {
     if cfg!(target_os = "macos") {
         println!("cargo:rustc-link-lib=framework=UserNotifications");
     }
-    #[cfg(windows)]
-    {
-        windows::build!(
-            Windows::Data::Xml::Dom::XmlDocument,
-            Windows::Foundation::*,
-            Windows::UI::Notifications::*,
-            Windows::Win32::Foundation::E_POINTER,
-        );
-    }
 }

--- a/wezterm-toast-notification/src/windows.rs
+++ b/wezterm-toast-notification/src/windows.rs
@@ -3,23 +3,18 @@
 use crate::ToastNotification as TN;
 use xml::escape::escape_str_pcdata;
 
-#[allow(dead_code)]
-mod bindings {
-    ::windows::include_bindings!();
-}
-
-use bindings::Windows::Data::Xml::Dom::XmlDocument;
-use bindings::Windows::Foundation::*;
-use bindings::Windows::UI::Notifications::*;
-use windows::{Error as WinError, IInspectable, Interface};
+use windows::core::{Error as WinError, IInspectable, Interface, HSTRING};
+use windows::Data::Xml::Dom::XmlDocument;
+use windows::Foundation::TypedEventHandler;
+use windows::Win32::Foundation::E_POINTER;
+use windows::UI::Notifications::{
+    ToastActivatedEventArgs, ToastNotification, ToastNotificationManager,
+};
 
 fn unwrap_arg<T>(a: &Option<T>) -> Result<&T, WinError> {
     match a {
         Some(t) => Ok(t),
-        None => Err(WinError::new(
-            crate::windows::bindings::Windows::Win32::Foundation::E_POINTER,
-            "option is none",
-        )),
+        None => Err(WinError::new(E_POINTER, HSTRING::from("option is none"))),
     }
 }
 
@@ -36,7 +31,7 @@ fn show_notif_impl(toast: TN) -> Result<(), Box<dyn std::error::Error>> {
         ""
     };
 
-    xml.LoadXml(format!(
+    xml.LoadXml(HSTRING::from(format!(
         r#"<toast duration="long">
         <visual>
             <binding template="ToastGeneric">
@@ -49,7 +44,7 @@ fn show_notif_impl(toast: TN) -> Result<(), Box<dyn std::error::Error>> {
         escape_str_pcdata(&toast.title),
         escape_str_pcdata(&toast.message),
         url_actions
-    ))?;
+    )))?;
 
     let notif = ToastNotification::CreateToastNotification(xml)?;
 
@@ -82,7 +77,9 @@ fn show_notif_impl(toast: TN) -> Result<(), Box<dyn std::error::Error>> {
     }))?;
     */
 
-    let notifier = ToastNotificationManager::CreateToastNotifierWithId("org.wezfurlong.wezterm")?;
+    let notifier = ToastNotificationManager::CreateToastNotifierWithId(HSTRING::from(
+        "org.wezfurlong.wezterm",
+    ))?;
 
     notifier.Show(&notif)?;
 

--- a/window/src/os/mod.rs
+++ b/window/src/os/mod.rs
@@ -1,7 +1,7 @@
 #[cfg(windows)]
 pub mod windows;
 #[cfg(windows)]
-pub use windows::*;
+pub use self::windows::*;
 
 #[cfg(feature = "wayland")]
 pub mod wayland;

--- a/window/src/os/windows/mod.rs
+++ b/window/src/os/windows/mod.rs
@@ -9,7 +9,7 @@ pub use connection::*;
 pub use event::*;
 
 /// Convert a rust string to a windows wide string
-fn wide_string(s: &str) -> Vec<u16> {
+pub fn wide_string(s: &str) -> Vec<u16> {
     use std::os::windows::ffi::OsStrExt;
     std::ffi::OsStr::new(s)
         .encode_wide()


### PR DESCRIPTION
Upgrade the windows crate version to 0.33.0.

This is in anticipation of its use in another PR, and also it's future-proof.