### PR TITLE
docs: remove mention of SpawnTab in launch.md

### DIFF
--- a/docs/config/launch.md
+++ b/docs/config/launch.md
@@ -73,10 +73,10 @@ directory you can do so via the config, CLI, and when using
   ```
 
 * The [`SpawnCommandInNewTab`](lua/keyassignment/SpawnCommandInNewTab.md),
-  [`SpawnCommandInNewWindow`](lua/keyassignment/SpawnCommandInNewWindow.md),
-  [`SpawnTab`](lua/keyassignment/SpawnTab.md) key assignments, and the
-  [Launcher Menu](#the-launcher-menu) described below all accept a
-  [`SpawnCommand`](lua/SpawnCommand.md) object that accepts an optional `cwd` field:
+  and [`SpawnCommandInNewWindow`](lua/keyassignment/SpawnCommandInNewWindow.md)
+  key assignments, and the [Launcher Menu](#the-launcher-menu) described below
+  all accept a [`SpawnCommand`](lua/SpawnCommand.md) object that accepts an
+  optional `cwd` field:
 
   ```lua
   {


### PR DESCRIPTION
SpawnTab does not accept a SpawnCommand as an argument. See discussion [here](https://matrix.to/#/!PirwUBcuIlTXwNveYz:matrix.org/$h60T0Ps5F_D53fVH-dPHGrOJ4FiF_87IPbdePDFvHBs?via=matrix.org&via=securitydao.ems.host&via=synapse.travnewmatic.com).