### PR TITLE
Update wezterm-linuxbrew.rb.template to fix linuxbrew

### DIFF
--- a/ci/wezterm-linuxbrew.rb.template
+++ b/ci/wezterm-linuxbrew.rb.template
@@ -5,9 +5,9 @@
 class Wezterm < Formula
   desc "A GPU-accelerated cross-platform terminal emulator and multiplexer written by @wez and implemented in Rust"
   homepage "https://wezfurlong.org/wezterm/"
-  url "https://github.com/wez/wezterm/releases/download/@TAG@/WezTerm-@TAG@-Ubuntu16.04.AppImage"
+  url "https://github.com/wez/wezterm/releases/download/@TAG@/WezTerm-@TAG@-Ubuntu18.04.AppImage"
   sha256 "@SHA256@"
-  head "https://github.com/wez/wezterm/releases/download/nightly/WezTerm-nightly-Ubuntu16.04.AppImage"
+  head "https://github.com/wez/wezterm/releases/download/nightly/WezTerm-nightly-Ubuntu18.04.AppImage"
 
   def install
     Dir.glob("*.AppImage").each do |img|


### PR DESCRIPTION
Now, we cannot install wezterm by linuxbrew with the following error message
```
==> Downloading wez/wezterm@20220101-133340-7edc5b5a WezTerm-20220101-133340-7edc5b5a-Ubuntu16.04.AppImage (download)
curl: (22) The requested URL returned error: 404 
Error: wezterm: Failed to download resource "wezterm"
Download failed: wez/wezterm@20220101-133340-7edc5b5a WezTerm-20220101-133340-7edc5b5a-Ubuntu16.04.AppImage (download)
```
This patch will fix it.