### PR TITLE
Implement native window dragging on Windows

### DIFF
--- a/wezterm-gui/src/termwindow/mouseevent.rs
+++ b/wezterm-gui/src/termwindow/mouseevent.rs
@@ -3,6 +3,7 @@ use crate::termwindow::keyevent::window_mods_to_termwiz_mods;
 use crate::termwindow::{PositionedSplit, ScrollHit, UIItem, UIItemType, TMB};
 use ::window::{
     MouseButtons as WMB, MouseCursor, MouseEvent, MouseEventKind as WMEK, MousePress, WindowOps,
+    WindowState,
 };
 use config::keyassignment::{MouseEventTrigger, SpawnTabDomain};
 use mux::pane::Pane;
@@ -352,7 +353,12 @@ impl super::TermWindow {
                 }
                 TabBarItem::None => {
                     // Potentially starting a drag by the tab bar
-                    self.window_drag_position.replace(event.clone());
+                    if !self
+                        .window_state
+                        .intersects(WindowState::MAXIMIZED | WindowState::FULL_SCREEN)
+                    {
+                        self.window_drag_position.replace(event.clone());
+                    }
                     context.request_drag_move();
                 }
             },
@@ -370,6 +376,12 @@ impl super::TermWindow {
                     self.show_launcher();
                 }
                 TabBarItem::None => {}
+            },
+            WMEK::Move => match item {
+                TabBarItem::None => {
+                    context.set_mouse_drag_position(event.screen_coords);
+                }
+                _ => {}
             },
             _ => {}
         }

--- a/wezterm-gui/src/termwindow/mouseevent.rs
+++ b/wezterm-gui/src/termwindow/mouseevent.rs
@@ -379,7 +379,7 @@ impl super::TermWindow {
             },
             WMEK::Move => match item {
                 TabBarItem::None => {
-                    context.set_mouse_drag_position(event.screen_coords);
+                    context.set_window_drag_position(event.screen_coords);
                 }
                 _ => {}
             },

--- a/window/src/lib.rs
+++ b/window/src/lib.rs
@@ -255,7 +255,7 @@ pub trait WindowOps {
     /// This is only implemented on backends that need to
     /// know if the mouse is in a drag area to handle the
     /// click before forwarding the event (Windows).
-    fn set_mouse_drag_position(&self, _coords: ScreenPoint) {}
+    fn set_window_drag_position(&self, _coords: ScreenPoint) {}
 
     /// Changes the location of the window on the screen.
     /// The coordinates are of the top left pixel of the

--- a/window/src/lib.rs
+++ b/window/src/lib.rs
@@ -249,6 +249,14 @@ pub trait WindowOps {
     /// window movement on the server side (Wayland).
     fn request_drag_move(&self) {}
 
+    /// Signal to the windowing system that the mouse is over
+    /// a window dragging area.
+    ///
+    /// This is only implemented on backends that need to
+    /// know if the mouse is in a drag area to handle the
+    /// click before forwarding the event (Windows).
+    fn set_mouse_drag_position(&self, _coords: ScreenPoint) {}
+
     /// Changes the location of the window on the screen.
     /// The coordinates are of the top left pixel of the
     /// client area.

--- a/window/src/os/windows/window.rs
+++ b/window/src/os/windows/window.rs
@@ -86,7 +86,7 @@ pub(crate) struct WindowInner {
     dead_pending: Option<(Modifiers, u32)>,
     saved_placement: Option<WINDOWPLACEMENT>,
     track_mouse_leave: bool,
-    mouse_drag_position: Option<ScreenPoint>,
+    window_drag_position: Option<ScreenPoint>,
 
     keyboard_info: KeyboardLayoutInfo,
     appearance: Appearance,
@@ -450,7 +450,7 @@ impl Window {
             dead_pending: None,
             saved_placement: None,
             track_mouse_leave: false,
-            mouse_drag_position: None,
+            window_drag_position: None,
             config: config.clone(),
         }));
 
@@ -750,9 +750,9 @@ impl WindowOps for Window {
         clipboard_win::set_clipboard_string(&text).ok();
     }
 
-    fn set_mouse_drag_position(&self, coords: ScreenPoint) {
+    fn set_window_drag_position(&self, coords: ScreenPoint) {
         Connection::with_window_inner(self.0, move |inner| {
-            inner.mouse_drag_position = Some(coords);
+            inner.window_drag_position = Some(coords);
 
             Ok(())
         });
@@ -1020,7 +1020,7 @@ unsafe fn wm_nchittest(hwnd: HWND, msg: UINT, wparam: WPARAM, lparam: LPARAM) ->
             }
         }
 
-        if let Some(coords) = inner.mouse_drag_position {
+        if let Some(coords) = inner.window_drag_position {
             if coords == screen_point && inner.saved_placement.is_none() {
                 return Some(HTCAPTION);
             }


### PR DESCRIPTION
Implement native window dragging by the tabbar on Windows, when window decoration = `RESIZE`, so things like drag to snap and double click to max/minimize works.

Also prevent dragging by the tabbar when the window is maximized (and decoration is not `RESIZE`) or in full screen, since those cause undesirable behavior.