### PR TITLE
Overhaul scroll thumb calculation

### DIFF
--- a/wezterm-gui/src/scrollbar.rs
+++ b/wezterm-gui/src/scrollbar.rs
@@ -1,4 +1,3 @@
-use ::window::*;
 use mux::pane::Pane;
 use wezterm_term::StableRowIndex;
 
@@ -7,12 +6,6 @@ pub struct ScrollHit {
     pub top: usize,
     /// Height of the thumb, in pixels.
     pub height: usize,
-    /// Number of rows that correspond to the thumb in rows.
-    /// This is normally == viewport height, but in the case
-    /// where there are a sufficient number of rows of scrollback
-    /// that the pixel height of the thumb would be too small,
-    /// we will scale things in order to remain useful.
-    pub rows: f32,
 }
 
 impl ScrollHit {
@@ -21,46 +14,34 @@ impl ScrollHit {
     pub fn thumb(
         pane: &dyn Pane,
         viewport: Option<StableRowIndex>,
-        dims: &Dimensions,
-        tab_bar_height: f32,
-        tab_bar_at_bottom: bool,
+        max_thumb_height: usize,
+        min_thumb_size: usize,
     ) -> Self {
-        let max_thumb_height = dims.pixel_height as f32 - tab_bar_height;
         let render_dims = pane.get_dimensions();
 
         let scroll_top = render_dims
             .physical_top
-            .saturating_sub(viewport.unwrap_or(render_dims.physical_top));
+            .saturating_sub(viewport.unwrap_or(render_dims.physical_top))
+            as f32;
 
         let scroll_size = render_dims.scrollback_rows as f32;
 
-        let thumb_size = (render_dims.viewport_rows as f32 / scroll_size) * max_thumb_height;
+        let thumb_size = (render_dims.viewport_rows as f32 / scroll_size) * max_thumb_height as f32;
 
-        const MIN_HEIGHT: f32 = 10.;
-        let (thumb_size, rows) = if thumb_size < MIN_HEIGHT {
-            (
-                MIN_HEIGHT,
-                render_dims.viewport_rows as f32 * MIN_HEIGHT / thumb_size,
-            )
+        let min_thumb_size = min_thumb_size as f32;
+        let thumb_size = if thumb_size < min_thumb_size {
+            min_thumb_size
         } else {
-            (thumb_size, render_dims.viewport_rows as f32)
-        };
+            thumb_size
+        }
+        .ceil() as usize;
 
-        let thumb_top = if tab_bar_at_bottom {
-            0.
-        } else {
-            tab_bar_height
-        } + (1.
-            - (scroll_top as f32 + render_dims.viewport_rows as f32) / scroll_size)
-            * max_thumb_height;
-
-        let thumb_size = thumb_size.ceil() as usize;
-        let thumb_top = thumb_top.ceil() as usize;
+        let scroll_percent = 1.0 - (scroll_top / render_dims.physical_top as f32);
+        let thumb_top = (scroll_percent * (max_thumb_height - thumb_size) as f32).ceil() as usize;
 
         Self {
             top: thumb_top,
             height: thumb_size,
-            rows,
         }
     }
 
@@ -70,17 +51,17 @@ impl ScrollHit {
         thumb_top: usize,
         pane: &dyn Pane,
         viewport: Option<StableRowIndex>,
-        dims: &Dimensions,
-        tab_bar_height: f32,
-        tab_bar_at_bottom: bool,
+        max_thumb_height: usize,
+        min_thumb_size: usize,
     ) -> StableRowIndex {
-        let render_dims = pane.get_dimensions();
-        let thumb = Self::thumb(pane, viewport, dims, tab_bar_height, tab_bar_at_bottom);
+        let thumb = Self::thumb(pane, viewport, max_thumb_height, min_thumb_size);
+        let available_height = max_thumb_height - thumb.height;
+        let scroll_percent = thumb_top.min(available_height) as f32 / available_height as f32;
 
-        let rows_from_top = ((thumb_top as f32) / thumb.height as f32) * thumb.rows;
+        let render_dims = pane.get_dimensions();
 
         render_dims
             .scrollback_top
-            .saturating_add(rows_from_top as StableRowIndex)
+            .saturating_add((render_dims.physical_top as f32 * scroll_percent) as StableRowIndex)
     }
 }

--- a/wezterm-gui/src/termwindow/mod.rs
+++ b/wezterm-gui/src/termwindow/mod.rs
@@ -305,6 +305,7 @@ pub struct TermWindow {
     show_scroll_bar: bool,
     tab_bar: TabBarState,
     fancy_tab_bar: Option<box_model::ComputedElement>,
+    fancy_tab_bar_height: Option<f32>,
     pub right_status: String,
     last_ui_item: Option<UIItem>,
     /// Tracks whether the current mouse-down event is part of click-focus.
@@ -640,7 +641,7 @@ impl TermWindow {
         // for the tab bar state.
         let show_tab_bar = config.enable_tab_bar && !config.hide_tab_bar_if_only_one_tab;
         let tab_bar_height = if show_tab_bar {
-            Self::tab_bar_pixel_height_impl(&config, &fontconfig, &render_metrics)? as usize
+            Self::tab_bar_pixel_height_impl(&config, &fontconfig, &render_metrics, &None)? as usize
         } else {
             0
         };
@@ -728,6 +729,7 @@ impl TermWindow {
             show_scroll_bar: config.enable_scroll_bar,
             tab_bar: TabBarState::default(),
             fancy_tab_bar: None,
+            fancy_tab_bar_height: None,
             right_status: String::new(),
             last_mouse_coords: (0, -1),
             window_drag_position: None,

--- a/wezterm-gui/src/termwindow/mouseevent.rs
+++ b/wezterm-gui/src/termwindow/mouseevent.rs
@@ -263,7 +263,8 @@ impl super::TermWindow {
             (tab_bar_height, 0.0)
         };
 
-        let y_offset = top_bar_height + self.get_os_border().top.get() as f32;
+        let border = self.get_os_border();
+        let y_offset = top_bar_height + border.top.get() as f32;
 
         let from_top = start_event.coords.y.saturating_sub(item.y as isize);
         let effective_thumb_top = event
@@ -279,7 +280,7 @@ impl super::TermWindow {
             &*pane,
             current_viewport,
             self.dimensions.pixel_height.saturating_sub(
-                y_offset as usize + self.get_os_border().bottom.get() + bottom_bar_height as usize,
+                y_offset as usize + border.bottom.get() + bottom_bar_height as usize,
             ),
             (self.render_metrics.cell_size.height as f32 / 2.0) as usize,
         );

--- a/window/src/lib.rs
+++ b/window/src/lib.rs
@@ -51,8 +51,7 @@ pub struct Dimensions {
     pub dpi: usize,
 }
 
-pub type Length = euclid::Length<isize, PixelUnit>;
-pub type LengthF = euclid::Length<f32, PixelUnit>;
+pub type ULength = euclid::Length<usize, PixelUnit>;
 pub type Rect = euclid::Rect<isize, PixelUnit>;
 pub type RectF = euclid::Rect<f32, PixelUnit>;
 pub type Size = euclid::Size2D<isize, PixelUnit>;

--- a/window/src/os/macos/window.rs
+++ b/window/src/os/macos/window.rs
@@ -5,10 +5,10 @@ use super::{nsstring, nsstring_to_str};
 use crate::connection::ConnectionOps;
 use crate::parameters::{Border, Parameters, TitleBar};
 use crate::{
-    Clipboard, Connection, DeadKeyStatus, Dimensions, Handled, KeyCode, KeyEvent, Length,
-    Modifiers, MouseButtons, MouseCursor, MouseEvent, MouseEventKind, MousePress, Point,
-    RawKeyEvent, Rect, ScreenPoint, Size, WindowDecorations, WindowEvent, WindowEventSender,
-    WindowOps, WindowState,
+    Clipboard, Connection, DeadKeyStatus, Dimensions, Handled, KeyCode, KeyEvent, Modifiers,
+    MouseButtons, MouseCursor, MouseEvent, MouseEventKind, MousePress, Point, RawKeyEvent, Rect,
+    ScreenPoint, Size, ULength, WindowDecorations, WindowEvent, WindowEventSender, WindowOps,
+    WindowState,
 };
 use anyhow::{anyhow, bail, ensure};
 use async_trait::async_trait;
@@ -713,10 +713,10 @@ impl WindowOps for Window {
                     let insets: NSEdgeInsets = unsafe { msg_send![main_screen, safeAreaInsets] };
                     log::trace!("{:?}", insets);
                     Some(Border {
-                        top: Length::new(insets.top.ceil() as isize),
-                        left: Length::new(insets.left.ceil() as isize),
-                        right: Length::new(insets.right.ceil() as isize),
-                        bottom: Length::new(insets.bottom.ceil() as isize),
+                        top: ULength::new(insets.top.ceil() as usize),
+                        left: ULength::new(insets.left.ceil() as usize),
+                        right: ULength::new(insets.right.ceil() as usize),
+                        bottom: ULength::new(insets.bottom.ceil() as usize),
                         color: crate::color::LinearRgba::with_components(0., 0., 0., 1.),
                     })
                 } else {
@@ -728,8 +728,8 @@ impl WindowOps for Window {
 
         Ok(Some(Parameters {
             title_bar: TitleBar {
-                padding_left: Length::new(0),
-                padding_right: Length::new(0),
+                padding_left: ULength::new(0),
+                padding_right: ULength::new(0),
                 height: None,
                 font_and_size: None,
             },

--- a/window/src/os/parameters.rs
+++ b/window/src/os/parameters.rs
@@ -1,23 +1,23 @@
 use wezterm_color_types::LinearRgba;
 use wezterm_font::parser::ParsedFont;
 
-use crate::Length;
+use crate::ULength;
 
 pub type FontAndSize = (ParsedFont, f64);
 
 pub struct TitleBar {
-    pub padding_left: Length,
-    pub padding_right: Length,
-    pub height: Option<Length>,
+    pub padding_left: ULength,
+    pub padding_right: ULength,
+    pub height: Option<ULength>,
     pub font_and_size: Option<FontAndSize>,
 }
 
 #[derive(Default, Clone)]
 pub struct Border {
-    pub top: Length,
-    pub left: Length,
-    pub bottom: Length,
-    pub right: Length,
+    pub top: ULength,
+    pub left: ULength,
+    pub bottom: ULength,
+    pub right: ULength,
     pub color: LinearRgba,
 }
 

--- a/window/src/os/windows/window.rs
+++ b/window/src/os/windows/window.rs
@@ -2,9 +2,9 @@ use super::*;
 use crate::connection::ConnectionOps;
 use crate::parameters::{self, Parameters};
 use crate::{
-    Appearance, Clipboard, DeadKeyStatus, Dimensions, Handled, KeyCode, KeyEvent, Length,
-    Modifiers, MouseButtons, MouseCursor, MouseEvent, MouseEventKind, MousePress, Point,
-    RawKeyEvent, Rect, ScreenPoint, WindowDecorations, WindowEvent, WindowEventSender, WindowOps,
+    Appearance, Clipboard, DeadKeyStatus, Dimensions, Handled, KeyCode, KeyEvent, Modifiers,
+    MouseButtons, MouseCursor, MouseEvent, MouseEventKind, MousePress, Point, RawKeyEvent, Rect,
+    ScreenPoint, ULength, WindowDecorations, WindowEvent, WindowEventSender, WindowOps,
     WindowState,
 };
 use anyhow::{bail, Context};
@@ -792,7 +792,7 @@ impl WindowOps for Window {
             }
         };
 
-        const BASE_BORDER: Length = Length::new(0);
+        const BASE_BORDER: ULength = ULength::new(0);
         let is_resize = config.window_decorations == WindowDecorations::RESIZE;
 
         let title_font = {
@@ -802,20 +802,20 @@ impl WindowOps for Window {
 
         Ok(Some(Parameters {
             title_bar: parameters::TitleBar {
-                padding_left: Length::new(0),
-                padding_right: Length::new(0),
+                padding_left: ULength::new(0),
+                padding_right: ULength::new(0),
                 height: None,
                 font_and_size: title_font,
             },
             border_dimensions: Some(parameters::Border {
                 top: if is_resize && !*IS_WIN10 && !is_full_screen {
-                    BASE_BORDER + Length::new(1)
+                    BASE_BORDER + ULength::new(1)
                 } else {
                     BASE_BORDER
                 },
                 left: BASE_BORDER,
                 bottom: if is_resize && *IS_WIN10 && !is_full_screen {
-                    BASE_BORDER + Length::new(2)
+                    BASE_BORDER + ULength::new(2)
                 } else {
                     BASE_BORDER
                 },


### PR DESCRIPTION
- Simplify scroll thumb calculations
- Correct thumb position when dragging with mouse
- Support border OS parameters
- Use usize for OS borders, to explicitly only accept positive integers
- Get correct tab height when using fancy tab bar
- Correctly draw depending on tab bar position
- Adjust minimum thumb size to be 1/2 of a cell height, so it has consistent size across platforms and screen densities

Fixes #1525