### PR TITLE
gui: improve mouse text selection

### DIFF
--- a/term/src/input.rs
+++ b/term/src/input.rs
@@ -36,8 +36,8 @@ pub struct MouseEvent {
     pub kind: MouseEventKind,
     pub x: usize,
     pub y: VisibleRowIndex,
-    pub x_pixel_offset: usize,
-    pub y_pixel_offset: usize,
+    pub x_pixel_offset: isize,
+    pub y_pixel_offset: isize,
     pub button: MouseButton,
     pub modifiers: KeyModifiers,
 }
@@ -46,8 +46,8 @@ pub struct MouseEvent {
 pub struct ClickPosition {
     pub column: usize,
     pub row: i64,
-    pub x_pixel_offset: usize,
-    pub y_pixel_offset: usize,
+    pub x_pixel_offset: isize,
+    pub y_pixel_offset: isize,
 }
 
 /// This is a little helper that keeps track of the "click streak",

--- a/term/src/terminalstate/mouse.rs
+++ b/term/src/terminalstate/mouse.rs
@@ -69,8 +69,10 @@ impl TerminalState {
                 self.writer,
                 "\x1b[<{};{};{}M",
                 button,
-                (event.x * (self.pixel_width / width)) + event.x_pixel_offset + 1,
-                (event.y as usize * (self.pixel_height / height)) + event.y_pixel_offset + 1
+                (event.x * (self.pixel_width / width)) + event.x_pixel_offset.max(0) as usize + 1,
+                (event.y as usize * (self.pixel_height / height))
+                    + event.y_pixel_offset.max(0) as usize
+                    + 1
             )?;
             self.writer.flush()?;
         } else if self.mouse_tracking || self.button_event_mouse || self.any_event_mouse {
@@ -123,8 +125,10 @@ impl TerminalState {
                 self.writer,
                 "\x1b[<{};{};{}M",
                 button,
-                (event.x * (self.pixel_width / width)) + event.x_pixel_offset + 1,
-                (event.y as usize * (self.pixel_height / height)) + event.y_pixel_offset + 1
+                (event.x * (self.pixel_width / width)) + event.x_pixel_offset.max(0) as usize + 1,
+                (event.y as usize * (self.pixel_height / height))
+                    + event.y_pixel_offset.max(0) as usize
+                    + 1
             )?;
             self.writer.flush()?;
         } else {
@@ -162,9 +166,11 @@ impl TerminalState {
                         self.writer,
                         "\x1b[<{};{};{}m",
                         release_button,
-                        (event.x * (self.pixel_width / width)) + event.x_pixel_offset + 1,
+                        (event.x * (self.pixel_width / width))
+                            + event.x_pixel_offset.max(0) as usize
+                            + 1,
                         (event.y as usize * (self.pixel_height / height))
-                            + event.y_pixel_offset
+                            + event.y_pixel_offset.max(0) as usize
                             + 1
                     )?;
                     self.writer.flush()?;
@@ -227,8 +233,12 @@ impl TerminalState {
                     self.writer,
                     "\x1b[<{};{};{}M",
                     button,
-                    (event.x * (self.pixel_width / width)) + event.x_pixel_offset + 1,
-                    (event.y as usize * (self.pixel_height / height)) + event.y_pixel_offset + 1
+                    (event.x * (self.pixel_width / width))
+                        + event.x_pixel_offset.max(0) as usize
+                        + 1,
+                    (event.y as usize * (self.pixel_height / height))
+                        + event.y_pixel_offset.max(0) as usize
+                        + 1
                 )?;
                 self.writer.flush()?;
             } else {

--- a/wezterm-gui/src/overlay/copy.rs
+++ b/wezterm-gui/src/overlay/copy.rs
@@ -107,7 +107,7 @@ impl CopyRenderable {
         self.window
             .notify(TermWindowNotif::Apply(Box::new(move |term_window| {
                 let mut selection = term_window.selection(pane_id);
-                selection.start = Some(start);
+                selection.origin = Some(start);
                 selection.range = Some(range);
                 window.invalidate();
             })));

--- a/wezterm-gui/src/overlay/quickselect.rs
+++ b/wezterm-gui/src/overlay/quickselect.rs
@@ -685,7 +685,7 @@ impl QuickSelectRenderable {
         self.window
             .notify(TermWindowNotif::Apply(Box::new(move |term_window| {
                 let mut selection = term_window.selection(pane_id);
-                selection.start.take();
+                selection.origin.take();
                 selection.range.take();
             })));
     }
@@ -705,7 +705,7 @@ impl QuickSelectRenderable {
                             x: result.start_x,
                             y: result.start_y,
                         };
-                        selection.start = Some(start);
+                        selection.origin = Some(start);
                         selection.range = Some(SelectionRange {
                             start,
                             end: SelectionCoordinate {

--- a/wezterm-gui/src/overlay/search.rs
+++ b/wezterm-gui/src/overlay/search.rs
@@ -490,7 +490,7 @@ impl SearchRenderable {
         self.window
             .notify(TermWindowNotif::Apply(Box::new(move |term_window| {
                 let mut selection = term_window.selection(pane_id);
-                selection.start.take();
+                selection.origin.take();
                 selection.range.take();
             })));
     }
@@ -507,7 +507,7 @@ impl SearchRenderable {
                     x: result.start_x,
                     y: result.start_y,
                 };
-                selection.start = Some(start);
+                selection.origin = Some(start);
                 selection.range = Some(SelectionRange {
                     start,
                     end: SelectionCoordinate {

--- a/wezterm-gui/src/selection.rs
+++ b/wezterm-gui/src/selection.rs
@@ -12,7 +12,7 @@ use wezterm_term::{SemanticZone, StableRowIndex};
 pub struct Selection {
     /// Remembers the starting coordinate of the selection prior to
     /// dragging.
-    pub start: Option<SelectionCoordinate>,
+    pub origin: Option<SelectionCoordinate>,
     /// Holds the not-normalized selection range.
     pub range: Option<SelectionRange>,
     /// When the selection was made wrt. the pane content
@@ -25,12 +25,12 @@ impl Selection {
     #[allow(dead_code)]
     pub fn clear(&mut self) {
         self.range = None;
-        self.start = None;
+        self.origin = None;
     }
 
-    pub fn begin(&mut self, start: SelectionCoordinate) {
+    pub fn begin(&mut self, origin: SelectionCoordinate) {
         self.range = None;
-        self.start = Some(start);
+        self.origin = Some(origin);
     }
 
     #[allow(dead_code)]

--- a/wezterm-gui/src/termwindow/box_model.rs
+++ b/wezterm-gui/src/termwindow/box_model.rs
@@ -4,7 +4,7 @@ use crate::customglyph::{BlockKey, Poly};
 use crate::glyphcache::CachedGlyph;
 use crate::termwindow::render::rgbcolor_to_window_color;
 use crate::termwindow::{
-    MappedQuads, RenderState, SrgbTexture2d, TermWindowNotif, UIItem, UIItemType,
+    MappedQuads, MouseCapture, RenderState, SrgbTexture2d, TermWindowNotif, UIItem, UIItemType,
 };
 use crate::utilsprites::RenderMetrics;
 use ::window::{RectF, WindowOps};
@@ -756,17 +756,18 @@ impl super::TermWindow {
     ) -> anyhow::Result<()> {
         let colors = match &element.hover_colors {
             Some(hc) => {
-                let hovering = match &self.current_mouse_event {
-                    Some(event) => {
-                        let mouse_x = event.coords.x as f32;
-                        let mouse_y = event.coords.y as f32;
-                        mouse_x >= element.bounds.min_x()
-                            && mouse_x <= element.bounds.max_x()
-                            && mouse_y >= element.bounds.min_y()
-                            && mouse_y <= element.bounds.max_y()
-                    }
-                    None => false,
-                };
+                let hovering =
+                    match &self.current_mouse_event {
+                        Some(event) => {
+                            let mouse_x = event.coords.x as f32;
+                            let mouse_y = event.coords.y as f32;
+                            mouse_x >= element.bounds.min_x()
+                                && mouse_x <= element.bounds.max_x()
+                                && mouse_y >= element.bounds.min_y()
+                                && mouse_y <= element.bounds.max_y()
+                        }
+                        None => false,
+                    } && matches!(self.current_mouse_capture, None | Some(MouseCapture::UI));
                 if hovering {
                     hc
                 } else {

--- a/wezterm-gui/src/termwindow/selection.rs
+++ b/wezterm-gui/src/termwindow/selection.rs
@@ -63,25 +63,41 @@ impl super::TermWindow {
     ) {
         self.selection(pane.pane_id()).seqno = pane.get_current_seqno();
         let mode = mode.unwrap_or(SelectionMode::Cell);
-        let (x, y, position) = match self.pane_state(pane.pane_id()).mouse_terminal_coords {
-            Some(coords) => (coords.0.column, coords.1, coords.0),
+        let (position, y) = match self.pane_state(pane.pane_id()).mouse_terminal_coords {
+            Some(coords) => coords,
             None => return,
         };
+        let x = position.column;
         match mode {
             SelectionMode::Cell => {
+                // Origin is the cell in which the selection action started. E.g. the cell
+                // that had the mouse over it when the left mouse button was pressed
                 let origin = self
                     .selection(pane.pane_id())
                     .origin
                     .unwrap_or(SelectionCoordinate { x, y });
                 self.selection(pane.pane_id()).origin = Some(origin);
 
-                let (start_x, end_x) = if (origin.x <= x && origin.y == y) || origin.y < y {
+                // Compute the start and end horizontall cell of the selection.
+                // The selection extent depends on the mouse cursor position in relation
+                // to the origin.
+                let (start_x, end_x) = if (x >= origin.x && y == origin.y) || y > origin.y {
+                    // If the selection is extending forwards from the origin, it includes the
+                    // origin and doesn't include the cell under the cursor. Note that the
+                    // reported cell here is offset by -50% from the real cell you see on the
+                    // screen, so this causes a visual cell on the screen to be selected when
+                    // the mouse moves over 50% of its width, which effectively means the next
+                    // cell is being reported here, hence it's excluded
                     (origin.x, x.saturating_sub(1))
                 } else {
+                    // If the selection is extending backwards from the origin, it doesn't
+                    // include the origin and includes the cell under the cursor, which has
+                    // the same effect as described above when going backwards
                     (origin.x.saturating_sub(1), x)
                 };
 
                 self.selection(pane.pane_id()).range = if origin.x != x || origin.y != y {
+                    // Only considers a selection if the cursor moved from the origin point
                     Some(
                         SelectionRange::start(SelectionCoordinate {
                             x: start_x,

--- a/wezterm-gui/src/termwindow/selection.rs
+++ b/wezterm-gui/src/termwindow/selection.rs
@@ -1,10 +1,14 @@
-use crate::selection::{SelectionCoordinate, SelectionMode, SelectionRange};
+use crate::selection::{Selection, SelectionCoordinate, SelectionMode, SelectionRange};
 use ::window::WindowOps;
-use mux::pane::Pane;
-use std::rc::Rc;
+use mux::pane::{Pane, PaneId};
+use std::{cell::RefMut, rc::Rc};
 use wezterm_term::StableRowIndex;
 
 impl super::TermWindow {
+    pub fn selection(&self, pane_id: PaneId) -> RefMut<Selection> {
+        RefMut::map(self.pane_state(pane_id), |state| &mut state.selection)
+    }
+
     pub fn selection_text(&self, pane: &Rc<dyn Pane>) -> String {
         let mut s = String::new();
         if let Some(sel) = self
@@ -58,29 +62,42 @@ impl super::TermWindow {
     ) {
         self.selection(pane.pane_id()).seqno = pane.get_current_seqno();
         let mode = mode.unwrap_or(SelectionMode::Cell);
-        let (x, y) = match self.pane_state(pane.pane_id()).mouse_terminal_coords {
-            Some(coords) => coords,
+        let (x, y, position) = match self.pane_state(pane.pane_id()).mouse_terminal_coords {
+            Some(coords) => (coords.0.column, coords.1, coords.0),
             None => return,
         };
         match mode {
             SelectionMode::Cell => {
-                let end = SelectionCoordinate { x, y };
-                let selection_range = self.selection(pane.pane_id()).range.take();
-                let sel = match selection_range {
-                    None => {
-                        SelectionRange::start(self.selection(pane.pane_id()).start.unwrap_or(end))
-                            .extend(end)
-                    }
-                    Some(sel) => sel.extend(end),
+                let origin = self
+                    .selection(pane.pane_id())
+                    .origin
+                    .unwrap_or(SelectionCoordinate { x, y });
+                self.selection(pane.pane_id()).origin = Some(origin);
+
+                let (start_x, end_x) = if (origin.x <= x && origin.y == y) || origin.y < y {
+                    (origin.x, x.saturating_sub(1))
+                } else {
+                    (origin.x.saturating_sub(1), x)
                 };
-                self.selection(pane.pane_id()).range = Some(sel);
+
+                self.selection(pane.pane_id()).range = if origin.x != x || origin.y != y {
+                    Some(
+                        SelectionRange::start(SelectionCoordinate {
+                            x: start_x,
+                            y: origin.y,
+                        })
+                        .extend(SelectionCoordinate { x: end_x, y }),
+                    )
+                } else {
+                    None
+                };
             }
             SelectionMode::Word => {
                 let end_word = SelectionRange::word_around(SelectionCoordinate { x, y }, &**pane);
 
                 let start_coord = self
                     .selection(pane.pane_id())
-                    .start
+                    .origin
                     .clone()
                     .unwrap_or(end_word.start);
                 let start_word = SelectionRange::word_around(start_coord, &**pane);
@@ -93,7 +110,7 @@ impl super::TermWindow {
 
                 let start_coord = self
                     .selection(pane.pane_id())
-                    .start
+                    .origin
                     .clone()
                     .unwrap_or(end_line.start);
                 let start_line = SelectionRange::line_around(start_coord, &**pane);
@@ -106,7 +123,7 @@ impl super::TermWindow {
 
                 let start_coord = self
                     .selection(pane.pane_id())
-                    .start
+                    .origin
                     .clone()
                     .unwrap_or(end_word.start);
                 let start_word = SelectionRange::zone_around(start_coord, &**pane);
@@ -116,32 +133,16 @@ impl super::TermWindow {
             }
         }
 
-        // When the mouse gets close enough to the top or bottom then scroll
-        // the viewport so that we can see more in that direction and are able
-        // to select more than fits in the viewport.
-
-        // This is similar to the logic in the copy mode overlay, but the gap
-        // is smaller because it feels more natural for mouse selection to have
-        // a smaller gap.
-        const VERTICAL_GAP: isize = 1;
         let dims = pane.get_dimensions();
-        let top = self
-            .get_viewport(pane.pane_id())
-            .unwrap_or(dims.physical_top);
-        let vertical_gap = if dims.physical_top <= VERTICAL_GAP {
-            1
-        } else {
-            VERTICAL_GAP
-        };
-        let top_gap = y - top;
-        if top_gap < vertical_gap {
-            // Increase the gap so we can "look ahead"
-            self.set_viewport(pane.pane_id(), Some(y.saturating_sub(vertical_gap)), dims);
-        } else {
-            let bottom_gap = (dims.viewport_rows as isize).saturating_sub(top_gap);
-            if bottom_gap < vertical_gap {
-                self.set_viewport(pane.pane_id(), Some(top + vertical_gap - bottom_gap), dims);
-            }
+
+        // Scroll viewport when mouse mouves out of its vertical bounds
+        if position.row == 0 && position.y_pixel_offset < 0 {
+            self.set_viewport(pane.pane_id(), Some(y.saturating_sub(1)), dims);
+        } else if position.row >= dims.viewport_rows as i64 {
+            let top = self
+                .get_viewport(pane.pane_id())
+                .unwrap_or(dims.physical_top);
+            self.set_viewport(pane.pane_id(), Some(top + 1), dims);
         }
 
         self.window.as_ref().unwrap().invalidate();
@@ -149,7 +150,7 @@ impl super::TermWindow {
 
     pub fn select_text_at_mouse_cursor(&mut self, mode: SelectionMode, pane: &Rc<dyn Pane>) {
         let (x, y) = match self.pane_state(pane.pane_id()).mouse_terminal_coords {
-            Some(coords) => coords,
+            Some(coords) => (coords.0.column, coords.1),
             None => return,
         };
         match mode {
@@ -157,21 +158,21 @@ impl super::TermWindow {
                 let start = SelectionCoordinate { x, y };
                 let selection_range = SelectionRange::line_around(start, &**pane);
 
-                self.selection(pane.pane_id()).start = Some(start);
+                self.selection(pane.pane_id()).origin = Some(start);
                 self.selection(pane.pane_id()).range = Some(selection_range);
             }
             SelectionMode::Word => {
                 let selection_range =
                     SelectionRange::word_around(SelectionCoordinate { x, y }, &**pane);
 
-                self.selection(pane.pane_id()).start = Some(selection_range.start);
+                self.selection(pane.pane_id()).origin = Some(selection_range.start);
                 self.selection(pane.pane_id()).range = Some(selection_range);
             }
             SelectionMode::SemanticZone => {
                 let selection_range =
                     SelectionRange::zone_around(SelectionCoordinate { x, y }, &**pane);
 
-                self.selection(pane.pane_id()).start = Some(selection_range.start);
+                self.selection(pane.pane_id()).origin = Some(selection_range.start);
                 self.selection(pane.pane_id()).range = Some(selection_range);
             }
             SelectionMode::Cell => {

--- a/wezterm-gui/src/termwindow/selection.rs
+++ b/wezterm-gui/src/termwindow/selection.rs
@@ -1,7 +1,8 @@
 use crate::selection::{Selection, SelectionCoordinate, SelectionMode, SelectionRange};
 use ::window::WindowOps;
 use mux::pane::{Pane, PaneId};
-use std::{cell::RefMut, rc::Rc};
+use std::cell::RefMut;
+use std::rc::Rc;
 use wezterm_term::StableRowIndex;
 
 impl super::TermWindow {


### PR DESCRIPTION
* implement mouse press capture between the terminal and UI, so when you
  start selecting text from the terminal the tabs won't activate and
  vice-versa
* selecting from the top and bottom lines won't scroll the viewport
  anymore, it will only scroll if the mouse is moved out of line bounds
* change cell selection so that it behaves like text selection usually
  does in other popular software

refs: https://github.com/wez/wezterm/issues/1199
refs: https://github.com/wez/wezterm/issues/1386
refs: https://github.com/wez/wezterm/issues/354
possibly: https://github.com/wez/wezterm/issues/1589