### PR TITLE
Added support for kitty images protocol using Shared Memory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4038,6 +4038,7 @@ dependencies = [
  "libc",
  "log",
  "memmem",
+ "nix 0.23.1",
  "num-derive",
  "num-traits",
  "ordered-float",

--- a/termwiz/Cargo.toml
+++ b/termwiz/Cargo.toml
@@ -58,6 +58,7 @@ version = "0.3"
 [target."cfg(unix)".dependencies]
 signal-hook = "0.1"
 termios = "0.3"
+nix = "0.23.1"
 [target."cfg(windows)".dependencies.winapi]
 features = [
     "winbase",
@@ -68,6 +69,8 @@ features = [
     "handleapi",
     "fileapi",
     "synchapi",
+    "memoryapi",
+    "winnt",
 ]
 version = "0.3"
 


### PR DESCRIPTION
Allows reading data via shared memory on both Unix and Windows. Adds support for tasks 9 and 10 from issue 986 related to Kitty Image Protocol. Tested on Linux and on Windows 10 (Had to split the below script into two different parts and run the command via wezterm ssh) using the below python script:
```python
import sys
from base64 import b64encode
from multiprocessing import shared_memory
from time import sleep

width = 1920
height = 1080
depth = 4
size = width * height * depth
shm = shared_memory.SharedMemory(create=True, name="myshm", size = size)
img = shm.buf

for row in range(height):
    for col in range(width):
        img[(row * width + col) * 4 + 0] = int(255 / (height + 1) * row) # red
        img[(row * width + col) * 4 + 1] = int(255 / (width + 1) * col) # green
        img[(row * width + col) * 4 + 2] = 255 # blue
        img[(row * width + col) * 4 + 3] = 255

control_data = b'\033_Ga=T,f=32,t=s,s=' + str(width).encode() + b',v=' + str(height).encode() + b';'
end_sequence = b"\033\\"
string = control_data + b64encode(b"myshm") + end_sequence
sys.stdout.buffer.write(string)
sys.stdout.flush()
sleep(5)
print("Exiting")
```