### PR TITLE
Extend mouse capture concept to individual panes

### DIFF
--- a/wezterm-gui/src/termwindow/mod.rs
+++ b/wezterm-gui/src/termwindow/mod.rs
@@ -89,7 +89,7 @@ pub fn get_window_class() -> String {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum MouseCapture {
     UI,
-    Terminal,
+    TerminalPane(usize),
 }
 
 /// Type used together with Window::notify to do something in the

--- a/wezterm-gui/src/termwindow/mod.rs
+++ b/wezterm-gui/src/termwindow/mod.rs
@@ -89,7 +89,7 @@ pub fn get_window_class() -> String {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum MouseCapture {
     UI,
-    TerminalPane(usize),
+    TerminalPane(PaneId),
 }
 
 /// Type used together with Window::notify to do something in the


### PR DESCRIPTION
Extend mouse capture concept to individual terminal panes, so that when you're dragging the mouse with a pressed button in a pane it doesn't affect the others. This also fixes selection scrolling in individual panes.