### PR TITLE
Termwiz: fix partial bracketed paste panic

### DIFF
--- a/termwiz/src/input.rs
+++ b/termwiz/src/input.rs
@@ -1276,7 +1276,7 @@ impl InputParser {
                         callback(InputEvent::Paste(pasted));
                         self.state = InputState::Normal;
                     } else {
-                        self.state = InputState::Pasting(self.buf.len() - end_paste.len());
+                        self.state = InputState::Pasting(0);
                         return;
                     }
                 }

--- a/termwiz/src/input.rs
+++ b/termwiz/src/input.rs
@@ -1593,4 +1593,19 @@ mod test {
             "\x1bOP".to_string()
         );
     }
+
+    #[test]
+    fn partial_bracketed_paste() {
+        let mut p = InputParser::new();
+
+        let input = b"\x1b[200~1234";
+        let input2 = b"5678\x1b[201~";
+
+        let mut inputs = vec![];
+
+        p.parse(input, |e| inputs.push(e), false);
+        p.parse(input2, |e| inputs.push(e), false);
+
+        assert_eq!(vec![InputEvent::Paste("12345678".to_owned())], inputs)
+    }
 }


### PR DESCRIPTION
First of all thanks for the great lib!
We started using `termwiz` in [zellij](https://github.com/zellij-org/zellij), and this came up for some users on wsl: https://github.com/zellij-org/zellij/issues/1292, because sometimes we get a bracketed paste instruction split over two reads from stdin.

The problem is that `InputParser` panics when fed a partial bracketed paste instruction.

Minimal reproduction is:
```
let mut p = InputParser::new();
let input = b"\x1b[200~1234";
let input2 = b"4567\x1b[201~";
p.parse(input, |e| println!("{:?}", e), false);
p.parse(input2, |e| println!("{:?}", e), false);
```

In debug mode it panics on the first parse:
```thread 'input::test::partial_bracketed_paste' panicked at 'attempt to subtract with overflow', termwiz/src/input.rs:1279:58```

While in release mode the panic happens on the second parse:
```thread 'input::test::partial_bracketed_paste' panicked at 'range start index 18446744073709551613 out of range for slice of length 12', termwiz/src/readbuf.rs:47:25```

Not 100% sure on the fix, I'm assuming that the buffer won't advance until the `end_paste` sequence is found, and it does solve the problem with zellij in wsl.