### PR TITLE
fix(default-keys): aligned `Scroll Down One Page` command's key binding with the docs

### DIFF
--- a/wezterm-gui/src/commands.rs
+++ b/wezterm-gui/src/commands.rs
@@ -499,7 +499,7 @@ static DEFS: &[CommandDef] = &[
         doc: "Scrolls the viewport down by 1 page",
 
         exp: |exp| exp.push(ScrollByPage(NotNan::new(1.0).unwrap())),
-        keys: &[(Modifiers::SHIFT, "PageUp")],
+        keys: &[(Modifiers::SHIFT, "PageDown")],
         args: &[ArgType::ActivePane],
     },
     CommandDef {


### PR DESCRIPTION
PageUp -> PageDown, apparently it was a copy/paste issue.