### PR TITLE
Handle OpenSUSE package name variations

### DIFF
--- a/ci/deploy.sh
+++ b/ci/deploy.sh
@@ -124,7 +124,7 @@ case $OSTYPE in
     distro=$(lsb_release -is 2>/dev/null || sh -c "source /etc/os-release && echo \$NAME")
     distver=$(lsb_release -rs 2>/dev/null || sh -c "source /etc/os-release && echo \$VERSION_ID")
     case "$distro" in
-      *Fedora*|*CentOS*)
+      *Fedora*|*CentOS*|*SUSE*)
         WEZTERM_RPM_VERSION=$(echo ${TAG_NAME#nightly-} | tr - _)
         cat > wezterm.spec <<EOF
 Name: wezterm
@@ -134,7 +134,11 @@ Packager: Wez Furlong <wez@wezfurlong.org>
 License: MIT
 URL: https://wezfurlong.org/wezterm/
 Summary: Wez's Terminal Emulator.
+%if 0%{?suse_version}
+Requires: dbus-1, fontconfig, openssl, libxcb1, libxkbcommon0, libxkbcommon-x11-0, libwayland-client0, libwayland-egl1, libwayland-cursor0, Mesa-libEGL1, libxcb-keysyms1, xcb-util-wm-devel
+%else
 Requires: dbus, fontconfig, openssl, libxcb, libxkbcommon, libxkbcommon-x11, libwayland-client, libwayland-egl, libwayland-cursor, mesa-libEGL, xcb-util-keysyms, xcb-util-wm
+%endif
 
 %description
 wezterm is a terminal emulator with support for modern features


### PR DESCRIPTION
Deploy should create suse packages with correct dependencies now. Tested on opensuse thumbleweed and ubuntu mate. Needs to be invoked from a workflow for github actions integration.