### PR TITLE
Per pane scroll bar

### DIFF
--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -333,7 +333,7 @@ pub struct Config {
     pub hide_tab_bar_if_only_one_tab: bool,
 
     #[serde(default)]
-    pub enable_scroll_bar: bool,
+    pub scroll_bar_mode: ScrollBarMode,
 
     /// If false, do not try to use a Wayland protocol connection
     /// when starting the gui frontend, and instead use X11.
@@ -1462,5 +1462,18 @@ pub enum ExitBehavior {
 impl Default for ExitBehavior {
     fn default() -> Self {
         ExitBehavior::CloseOnCleanExit
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone, Copy, PartialEq, Eq)]
+pub enum ScrollBarMode {
+    None,
+    ActivePane,
+    AllPanes,
+}
+
+impl Default for ScrollBarMode {
+    fn default() -> Self {
+        ScrollBarMode::None
     }
 }

--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -332,6 +332,11 @@ pub struct Config {
     #[serde(default)]
     pub hide_tab_bar_if_only_one_tab: bool,
 
+    /// This config is deprecated in favour of the new scroll_bar_mode.
+    /// If true, scroll_bar_mode will be set to AllPanes, else to None.
+    #[serde(default)]
+    pub enable_scroll_bar: Option<bool>,
+
     #[serde(default)]
     pub scroll_bar_mode: ScrollBarMode,
 

--- a/wezterm-gui/src/scrollbar.rs
+++ b/wezterm-gui/src/scrollbar.rs
@@ -1,20 +1,28 @@
-use mux::pane::Pane;
+use mux::pane::{Pane, PaneId};
 use wezterm_term::StableRowIndex;
 
-pub struct ScrollHit {
-    /// Offset from the top of the window in pixels
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub struct ScrollThumb {
+    /// Offset from the top of the scroll area, in pixels.
     pub top: usize,
     /// Height of the thumb, in pixels.
     pub height: usize,
+    /// Offset from the top of the window, in pixels.
+    pub scrollbar_top: usize,
+    /// Height of the scroll bar / scroll area, in pixels.
+    pub scrollbar_height: usize,
+    /// Pane id associated with this scroll thumb
+    pub pane_id: PaneId,
 }
 
-impl ScrollHit {
-    /// Compute the y-coordinate for the top of the scrollbar thumb
-    /// and the height of the thumb and return them.
-    pub fn thumb(
+impl ScrollThumb {
+    /// Create a scroll bar thumb by calculating its parameters from window
+    /// and pane info.
+    pub fn new(
         pane: &dyn Pane,
         viewport: Option<StableRowIndex>,
-        max_thumb_height: usize,
+        scrollbar_top: usize,
+        scrollbar_height: usize,
         min_thumb_size: usize,
     ) -> Self {
         let render_dims = pane.get_dimensions();
@@ -26,7 +34,7 @@ impl ScrollHit {
 
         let scroll_size = render_dims.scrollback_rows as f32;
 
-        let thumb_size = (render_dims.viewport_rows as f32 / scroll_size) * max_thumb_height as f32;
+        let thumb_size = (render_dims.viewport_rows as f32 / scroll_size) * scrollbar_height as f32;
 
         let min_thumb_size = min_thumb_size as f32;
         let thumb_size = if thumb_size < min_thumb_size {
@@ -38,32 +46,25 @@ impl ScrollHit {
 
         let scroll_percent =
             1.0 - (scroll_top / (render_dims.physical_top - render_dims.scrollback_top) as f32);
-        let thumb_top = (scroll_percent * (max_thumb_height - thumb_size) as f32).ceil() as usize;
+        let thumb_top =
+            (scroll_percent * (scrollbar_height.saturating_sub(thumb_size)) as f32).ceil() as usize;
 
         Self {
             top: thumb_top,
             height: thumb_size,
+            scrollbar_top,
+            scrollbar_height,
+            pane_id: pane.pane_id(),
         }
     }
 
-    /// Given a new thumb top coordinate (produced by dragging the thumb),
-    /// compute the equivalent viewport offset.
-    pub fn thumb_top_to_scroll_top(
-        thumb_top: usize,
-        pane: &dyn Pane,
-        viewport: Option<StableRowIndex>,
-        max_thumb_height: usize,
-        min_thumb_size: usize,
-    ) -> StableRowIndex {
-        let thumb = Self::thumb(pane, viewport, max_thumb_height, min_thumb_size);
-        let available_height = max_thumb_height - thumb.height;
-        let scroll_percent = thumb_top.min(available_height) as f32 / available_height as f32;
-
-        let render_dims = pane.get_dimensions();
-
-        render_dims.scrollback_top.saturating_add(
-            ((render_dims.physical_top - render_dims.scrollback_top) as f32 * scroll_percent)
-                as StableRowIndex,
-        )
+    /// Given a cursor y offset from the window top and its offset from the
+    /// thumb button, calculate the equivalent scroll percentage. The percentage
+    /// goes from 0.0 when the thumb button is at the top of the scroll bar to
+    /// 1.0 when it's at the bottom.
+    pub fn scroll_percentage(&self, cursor_y: isize, thumb_offset: isize) -> f32 {
+        let effective_y = (cursor_y - thumb_offset - self.scrollbar_top as isize).max(0);
+        let available_height = self.scrollbar_height - self.height;
+        (effective_y as f32 / available_height as f32).min(1.)
     }
 }

--- a/wezterm-gui/src/scrollbar.rs
+++ b/wezterm-gui/src/scrollbar.rs
@@ -1,3 +1,4 @@
+use config::{ConfigHandle, ScrollBarMode};
 use mux::pane::{Pane, PaneId};
 use wezterm_term::StableRowIndex;
 
@@ -66,5 +67,13 @@ impl ScrollThumb {
         let effective_y = (cursor_y - thumb_offset - self.scrollbar_top as isize).max(0);
         let available_height = self.scrollbar_height - self.height;
         (effective_y as f32 / available_height as f32).min(1.)
+    }
+}
+
+pub fn get_scroll_bar_mode(config: &ConfigHandle) -> ScrollBarMode {
+    match config.enable_scroll_bar {
+        Some(true) => ScrollBarMode::AllPanes,
+        Some(false) => ScrollBarMode::None,
+        None => config.scroll_bar_mode,
     }
 }

--- a/wezterm-gui/src/termwindow/mod.rs
+++ b/wezterm-gui/src/termwindow/mod.rs
@@ -332,6 +332,7 @@ pub struct TermWindow {
     dead_key_status: DeadKeyStatus,
     key_table_state: KeyTableState,
     show_tab_bar: bool,
+    enable_scroll_bar: Option<bool>,
     scroll_bar_mode: ScrollBarMode,
     tab_bar: TabBarState,
     fancy_tab_bar: Option<box_model::ComputedElement>,
@@ -758,6 +759,7 @@ impl TermWindow {
             leader_is_down: None,
             dead_key_status: DeadKeyStatus::None,
             show_tab_bar,
+            enable_scroll_bar: config.enable_scroll_bar,
             scroll_bar_mode: config.scroll_bar_mode,
             tab_bar: TabBarState::default(),
             fancy_tab_bar: None,
@@ -1469,6 +1471,7 @@ impl TermWindow {
             None,
         );
 
+        self.enable_scroll_bar = config.enable_scroll_bar;
         self.scroll_bar_mode = config.scroll_bar_mode;
         self.shape_cache.borrow_mut().clear();
         self.fancy_tab_bar.take();
@@ -1503,7 +1506,7 @@ impl TermWindow {
     }
 
     fn update_scrollbar(&mut self) {
-        if self.scroll_bar_mode == ScrollBarMode::None {
+        if get_scroll_bar_mode(&self.config) == ScrollBarMode::None {
             return;
         }
 

--- a/wezterm-gui/src/termwindow/render.rs
+++ b/wezterm-gui/src/termwindow/render.rs
@@ -4,6 +4,7 @@ use crate::customglyph::{BlockKey, *};
 use crate::glium::texture::SrgbTexture2d;
 use crate::glyphcache::{CachedGlyph, GlyphCache};
 use crate::quad::Quad;
+use crate::scrollbar;
 use crate::shapecache::*;
 use crate::tabbar::{TabBarItem, TabEntry};
 use crate::termwindow::{
@@ -1295,8 +1296,9 @@ impl super::TermWindow {
             }
         }
 
-        if self.scroll_bar_mode == ScrollBarMode::AllPanes
-            || (self.scroll_bar_mode == ScrollBarMode::ActivePane && pos.is_active)
+        let scroll_bar_mode = scrollbar::get_scroll_bar_mode(config);
+        if scroll_bar_mode == ScrollBarMode::AllPanes
+            || (scroll_bar_mode == ScrollBarMode::ActivePane && pos.is_active)
         {
             let scrollbar_top = if pos.top == 0 {
                 top_bar_height as usize + border.top.get()

--- a/wezterm-gui/src/termwindow/resize.rs
+++ b/wezterm-gui/src/termwindow/resize.rs
@@ -1,3 +1,4 @@
+use crate::scrollbar;
 use crate::utilsprites::RenderMetrics;
 use ::window::{Dimensions, Window, WindowOps, WindowState};
 use config::{ConfigHandle, DimensionContext, ScrollBarMode};
@@ -467,7 +468,7 @@ impl super::TermWindow {
 /// size unless they've specified differently.
 pub fn effective_right_padding(config: &ConfigHandle, context: DimensionContext) -> u16 {
     let padding = config.window_padding.right.evaluate_as_pixels(context) as u16;
-    if config.scroll_bar_mode != ScrollBarMode::None {
+    if scrollbar::get_scroll_bar_mode(config) != ScrollBarMode::None {
         padding.max((context.pixel_cell / 2.) as u16)
     } else {
         padding

--- a/wezterm-gui/src/termwindow/resize.rs
+++ b/wezterm-gui/src/termwindow/resize.rs
@@ -1,6 +1,6 @@
 use crate::utilsprites::RenderMetrics;
 use ::window::{Dimensions, Window, WindowOps, WindowState};
-use config::{ConfigHandle, DimensionContext};
+use config::{ConfigHandle, DimensionContext, ScrollBarMode};
 use mux::Mux;
 use portable_pty::PtySize;
 use std::rc::Rc;
@@ -466,9 +466,10 @@ impl super::TermWindow {
 /// enabled the scroll bar then they will expect it to have a reasonable
 /// size unless they've specified differently.
 pub fn effective_right_padding(config: &ConfigHandle, context: DimensionContext) -> u16 {
-    if config.enable_scroll_bar && config.window_padding.right.is_zero() {
-        context.pixel_cell as u16
+    let padding = config.window_padding.right.evaluate_as_pixels(context) as u16;
+    if config.scroll_bar_mode != ScrollBarMode::None {
+        padding.max((context.pixel_cell / 2.) as u16)
     } else {
-        config.window_padding.right.evaluate_as_pixels(context) as u16
+        padding
     }
 }


### PR DESCRIPTION
Implement per-pane scroll bar

* Now instead of a boolean "enable_scroll_bar" config, you can control
  if you want to enable scroll bars on all panes (AllPanes), just the
  active one (ActivePane) or None at all with the config "scroll_bar_mode"
* Scroll bar width adjusted to ~1/4 of a cell, or it would not fit in
  split panes
* Adjusted horizontal panel split mouse dragging area size, so it's
  possible to also drag a scroll bar beside it
* Right window padding has an enforced minimum size of 1/4 of a cell when
  scrollbars are enabled

Dev notes:

* Mouse events for the scroll bar have a pane_id member, so they correctly
  trigger for their respective panes
* ScrollHit changed to instantiable ScrollThumb, encapsulating more
  information about the scroll bar, so the loginc doesn't need to be
  duplicated again in the mouse event handler
* Fixed a bug where split panes would not fill the screen all the way if
  it wasn't aligned to the cell size