### PR TITLE
docs: add split/panes keybindings

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -10,7 +10,7 @@
 * Render underline, double-underline, italic, bold, strikethrough (most other terminal emulators do not support as many render attributes)
 * Configuration via a <a href="config/files.html">configuration file</a> with hot reloading
 * Multiple Windows (Hotkey: `Super-N`)
-* Splits/Panes
+* Splits/Panes (Split horizontally/vertically: `Ctrl-Shift-Alt-%` and `Ctrl-Shift-Alt-"`, move between panes: `Ctrl-ArrowKey`)
 * Tabs (Hotkey: `Super-T`, next/prev: `Super-Shift-[` and `Super-Shift-]`, go-to: `Super-[1-9]`)
   <video width="80%" controls src="screenshots/wezterm-tabs.mp4" loop></video>
 * [SSH client with native tabs](ssh.html)


### PR DESCRIPTION
Terminal splits/panes are not documented, so I added some keybinding references to the feature list.