### PR TITLE
filedescriptor: Try to produce similar errors across platforms

### DIFF
--- a/filedescriptor/src/unix.rs
+++ b/filedescriptor/src/unix.rs
@@ -536,7 +536,7 @@ mod macos {
         };
 
         if res < 0 {
-            Err(std::io::Error::last_os_error().into())
+            Err(Error::Poll(std::io::Error::last_os_error()))
         } else {
             for item in pfd.iter_mut() {
                 if is_set(&mut read_set, item.fd) {

--- a/filedescriptor/src/windows.rs
+++ b/filedescriptor/src/windows.rs
@@ -200,7 +200,10 @@ impl OwnedHandle {
             )
         };
         if ok == 0 {
-            Err(IoError::last_os_error().into())
+            Err(Error::Dup {
+                fd: (handle as isize).into(),
+                source: IoError::last_os_error(),
+            })
         } else {
             Ok(OwnedHandle {
                 handle: duped as *mut _,
@@ -549,7 +552,7 @@ pub fn poll_impl(pfd: &mut [pollfd], duration: Option<Duration>) -> Result<usize
         )
     };
     if poll_result < 0 {
-        Err(std::io::Error::last_os_error().into())
+        Err(Error::Poll(std::io::Error::last_os_error()))
     } else {
         Ok(poll_result as usize)
     }


### PR DESCRIPTION
filedescriptor has a special error variant `Error::Poll(err)` that is returned when `poll` fails. I had some code that calls `filedescriptor::poll` and checks the error to see if it was `EINTR`.

        match poll(...) {
            Err(filedescriptor::Error::Poll(err)) if err.kind() == ErrorKind::Interrupted => continue,
            ...
        }

I noticed while peeking at the source code for `poll` that this variant isn't being used on macOS. The error behavior is different on different platforms. This would have caused a bug in my code where `EINTR` was not handled correctly on Mac.

Maybe this is on purpose, as the error message `"poll failed"` is a bit misleading on Mac, where the crate is using `select` instead. Feel free to just close this, if so, but if the difference is considered a bug, this PR fixes it, along with two places where Windows code uses the same pattern.
