### PR TITLE
Fix IME candidate window position (Windows, X11)

### DIFF
--- a/wezterm-gui/src/termwindow/mod.rs
+++ b/wezterm-gui/src/termwindow/mod.rs
@@ -1733,8 +1733,12 @@ impl TermWindow {
     fn update_text_cursor(&mut self, pane: &Rc<dyn Pane>) {
         let cursor = pane.get_cursor_position();
         if let Some(win) = self.window.as_ref() {
-            let top = pane.get_dimensions().physical_top + if self.show_tab_bar { -1 } else { 0 };
-
+            let top = pane.get_dimensions().physical_top;
+            let tab_bar_height = if self.show_tab_bar {
+                self.tab_bar_pixel_height().unwrap()
+            } else {
+                0.0
+            };
             let (padding_left, padding_top) = self.padding_left_top();
 
             let r = Rect::new(
@@ -1742,6 +1746,7 @@ impl TermWindow {
                     (cursor.x.max(0) as isize * self.render_metrics.cell_size.width)
                         .add(padding_left as isize),
                     ((cursor.y - top).max(0) as isize * self.render_metrics.cell_size.height)
+                        .add(tab_bar_height as isize)
                         .add(padding_top as isize),
                 ),
                 self.render_metrics.cell_size,

--- a/window/src/os/x11/window.rs
+++ b/window/src/os/x11/window.rs
@@ -1147,7 +1147,7 @@ impl XWindowInner {
         self.conn().ime.borrow_mut().update_pos(
             self.window_id,
             self.last_cursor_position.min_x() as i16,
-            (self.last_cursor_position.max_y() + self.last_cursor_position.height()) as i16,
+            self.last_cursor_position.max_y() as i16,
         );
     }
 


### PR DESCRIPTION
This PR is to fix IME candidate window position caused by wrong usage of Win32 API and misalignment of tab_bar_height.
I tested it with Japanese IME on Windows and X11, but I don't test it with other IMEs and on MacOS.

before:
![スクリーンショット 2022-05-11 231145](https://user-images.githubusercontent.com/171798/167872295-1896df00-f89e-4205-b8f4-6fdee03f0783.png)

after:
![スクリーンショット 2022-05-11 231240](https://user-images.githubusercontent.com/171798/167872320-d58e2d0a-60bc-4b42-9fa9-3625612ed625.png)

