### PR TITLE
gui: add config option for overriding color scheme scroll bar color

### DIFF
--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -20,7 +20,7 @@ use crate::wsl::WslDomain;
 use crate::{
     de_number, de_vec_table, default_config_with_overrides_applied, default_one_point_oh,
     default_one_point_oh_f64, default_true, KeyMapPreference, LoadedConfig, CONFIG_DIR,
-    CONFIG_FILE_OVERRIDE, CONFIG_OVERRIDES, CONFIG_SKIP, HOME_DIR,
+    CONFIG_FILE_OVERRIDE, CONFIG_OVERRIDES, CONFIG_SKIP, HOME_DIR, RgbaColor,
 };
 use anyhow::Context;
 use luahelper::impl_lua_conversion;
@@ -335,6 +335,11 @@ pub struct Config {
 
     #[serde(default)]
     pub enable_scroll_bar: bool,
+
+    /// If specified, overrides the scrollbar color that's currently
+    /// specified in the color scheme.
+    #[serde(default)]
+    pub scroll_bar_color: Option<RgbaColor>,
 
     /// If false, do not try to use a Wayland protocol connection
     /// when starting the gui frontend, and instead use X11.

--- a/wezterm-gui/src/termwindow/render.rs
+++ b/wezterm-gui/src/termwindow/render.rs
@@ -1303,7 +1303,10 @@ impl super::TermWindow {
             );
             let abs_thumb_top = thumb_y_offset + info.top;
             let thumb_size = info.height;
-            let color = palette.scrollbar_thumb.to_linear();
+            let color = match self.config.scroll_bar_color {
+                Some(color) => color.to_linear(),
+                None => palette.scrollbar_thumb.to_linear(),
+            };
 
             // Adjust the scrollbar thumb position
             let config = &self.config;


### PR DESCRIPTION
Useful for color schemes like Dracula+ where the default scrollbar
thumb color is really poorly contrasted with the background color
and it makes the scroll bar effectively invisible.