### PR TITLE
Fix compile error by using i686-pc-windows-msvc

### DIFF
--- a/window/src/os/windows/window.rs
+++ b/window/src/os/windows/window.rs
@@ -49,7 +49,7 @@ use winreg::RegKey;
 
 const GCS_RESULTSTR: DWORD = 0x800;
 const GCS_COMPSTR: DWORD = 0x8;
-const ISC_SHOWUICOMPOSITIONWINDOW: LPARAM = 2147483648;
+const ISC_SHOWUICOMPOSITIONWINDOW: DWORD = 0x80000000;
 
 #[allow(non_snake_case)]
 #[repr(C)]
@@ -1728,7 +1728,7 @@ unsafe fn ime_set_context(
     lparam: LPARAM,
 ) -> Option<LRESULT> {
     // Don't show system CompositionWindow because application itself draws it
-    let lparam = lparam & !ISC_SHOWUICOMPOSITIONWINDOW;
+    let lparam = lparam & !(ISC_SHOWUICOMPOSITIONWINDOW as LPARAM);
     let result = DefWindowProcW(hwnd, msg, wparam, lparam);
     Some(result)
 }


### PR DESCRIPTION
This PR is to fix compile error by using x86_64-pc-windows-msvc related to my #1976.

https://github.com/wez/wezterm/blob/3800710eadcd058aeac44e32bd42990097143d9d/window/src/os/windows/window.rs#L52

I should have defined ISC_SHOWUICOMPOSITIONWINDOW in DWORD (u32) because LPARAM (isize) cannot accept 2147483648 (0x80000000) when pointer size is 32bit.

This fix is not important at all because wezterm does not support 32bit windows.
So, if you don't need the fix, please close the PR.