### PR TITLE
Fix IME candidate window position when tab bar is at bottom

### DIFF
--- a/wezterm-gui/src/termwindow/mod.rs
+++ b/wezterm-gui/src/termwindow/mod.rs
@@ -1734,7 +1734,7 @@ impl TermWindow {
         let cursor = pane.get_cursor_position();
         if let Some(win) = self.window.as_ref() {
             let top = pane.get_dimensions().physical_top;
-            let tab_bar_height = if self.show_tab_bar {
+            let tab_bar_height = if self.show_tab_bar && !self.config.tab_bar_at_bottom {
                 self.tab_bar_pixel_height().unwrap()
             } else {
                 0.0


### PR DESCRIPTION
Fixed IME candidate window position being shifted down when `tab_bar_at_bottom = true`.

## before
![wezterm-fix-composition-pos-before](https://user-images.githubusercontent.com/2226696/168776925-652ef718-5c6f-474c-8546-533bd03547cd.png)

## after
![wezterm-fix-composition-pos-after](https://user-images.githubusercontent.com/2226696/168776946-bf7cb3f7-b4b5-4785-a2a2-5848523ab563.png)

