### PR TITLE
Fix text cursor position when using multiple panes

### DIFF
--- a/wezterm-gui/src/termwindow/mod.rs
+++ b/wezterm-gui/src/termwindow/mod.rs
@@ -1730,10 +1730,10 @@ impl TermWindow {
         }
     }
 
-    fn update_text_cursor(&mut self, pane: &Rc<dyn Pane>) {
-        let cursor = pane.get_cursor_position();
+    fn update_text_cursor(&mut self, pos: &PositionedPane) {
         if let Some(win) = self.window.as_ref() {
-            let top = pane.get_dimensions().physical_top;
+            let cursor = pos.pane.get_cursor_position();
+            let top = pos.pane.get_dimensions().physical_top;
             let tab_bar_height = if self.show_tab_bar && !self.config.tab_bar_at_bottom {
                 self.tab_bar_pixel_height().unwrap()
             } else {
@@ -1743,9 +1743,11 @@ impl TermWindow {
 
             let r = Rect::new(
                 Point::new(
-                    (cursor.x.max(0) as isize * self.render_metrics.cell_size.width)
+                    (((cursor.x + pos.left) as isize).max(0)
+                        * self.render_metrics.cell_size.width)
                         .add(padding_left as isize),
-                    ((cursor.y - top).max(0) as isize * self.render_metrics.cell_size.height)
+                    ((cursor.y + pos.top as isize - top).max(0)
+                        * self.render_metrics.cell_size.height)
                         .add(tab_bar_height as isize)
                         .add(padding_top as isize),
                 ),

--- a/wezterm-gui/src/termwindow/render.rs
+++ b/wezterm-gui/src/termwindow/render.rs
@@ -1625,7 +1625,7 @@ impl super::TermWindow {
 
         for pos in panes {
             if pos.is_active {
-                self.update_text_cursor(&pos.pane);
+                self.update_text_cursor(&pos);
                 if focused {
                     pos.pane.advise_focus();
                     mux::Mux::get()


### PR DESCRIPTION
This PR is to fix text cursor position when using multiple panes, which causes incorrect IME candidate window position.

The calculating the correct position of text cursor in a pane requires the offset from the tab to the pane,
but the Pane structure argument of `update_text_cursor(&mut self, pane: &Rc<dyn Pane>)` does not have the offset.

So, the offset is got from `Vec<PositionedPane>` returned by `self.get_panes_to_render()` in every `update_text_cursor()` call , which may be high cost and cause performance degradation.

Is there any other good way ?

before:
![スクリーンショット 2022-05-18 014956](https://user-images.githubusercontent.com/171798/168869074-2777137f-0b1b-4fd1-83b5-e3e4d192a7f4.png)

after:
![スクリーンショット 2022-05-18 014738](https://user-images.githubusercontent.com/171798/168869125-d21d12d1-4ec8-4fe9-b958-5f43aca68ba8.png)

