### PR TITLE
Add support of IME preedit rendered by system

### DIFF
--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -501,6 +501,8 @@ pub struct Config {
     pub use_ime: bool,
     #[dynamic(default)]
     pub xim_im_name: Option<String>,
+    #[dynamic(default)]
+    pub ime_preedit_rendering: ImePreeditRendering,
 
     #[dynamic(default = "default_true")]
     pub use_dead_keys: bool,
@@ -1478,5 +1480,19 @@ impl DroppedFileQuoting {
             }
             Self::WindowsAlwaysQuoted => format!("\"{}\"", s),
         }
+    }
+}
+
+#[derive(Debug, FromDynamic, ToDynamic, Clone, Copy, PartialEq, Eq)]
+pub enum ImePreeditRendering {
+    /// IME preedit is rendered by WezTerm itself
+    Builtin,
+    /// IME preedit is rendered by system
+    System,
+}
+
+impl Default for ImePreeditRendering {
+    fn default() -> Self {
+        ImePreeditRendering::Builtin
     }
 }

--- a/docs/config/lua/config/ime_preedit_rendering.md
+++ b/docs/config/lua/config/ime_preedit_rendering.md
@@ -1,0 +1,36 @@
+# `ime_preedit_rendering`
+
+*Since: nightly builds only*
+
+Control IME preedit rendering.
+IME preedit is an area that is used to display the string being preedited in IME.
+WezTerm supports the following IME preedit rendering.
+
+* `"Builtin"` - (Default) IME preedit is rendered by WezTerm itself
+
+  "Builtin" rendering provides good look and feel for many IMEs
+
+* `"System"` - IME preedit is rendered by system
+
+  "Builtin" rendering may truncate displaying of IME preedit
+  at the end of window if IME preedit is very long
+  because the rendering does not IME preedit overflow the window
+  and does not wrap IME preedit to the next line.
+  "System" rendering can be useful
+  to avoid the truncated displaying of IME preedit
+  but worse look and feel than "Builtin" rendering.
+
+You can control IME preedit rendering in your configuraiton file:
+
+```lua
+return {
+  ime_preedit_rendering = "System",
+}
+```
+
+Otherwise, the default is `"Builtin"`.
+
+Note:
+* Changing `ime_preedit_rendering` usually requires re-launching WezTerm to take full effect.
+* In macOS, `ime_preedit_rendering` has effected nothing yet.
+  IME preedit is always rendered by WezTerm itself.

--- a/window/src/os/x11/connection.rs
+++ b/window/src/os/x11/connection.rs
@@ -417,12 +417,17 @@ impl XConnection {
         let default_dpi = RefCell::new(compute_default_dpi(&xrm, &xsettings));
         log::trace!("computed initial dpi: {:?}", default_dpi);
 
+        let input_style = match config::configuration().ime_preedit_rendering {
+            config::ImePreeditRendering::Builtin => xcb_imdkit::InputStyle::PREEDIT_CALLBACKS,
+            config::ImePreeditRendering::System => xcb_imdkit::InputStyle::DEFAULT,
+        };
+
         xcb_imdkit::ImeClient::set_logger(|msg| log::debug!("Ime: {}", msg));
         let ime = unsafe {
             xcb_imdkit::ImeClient::unsafe_new(
                 &conn,
                 screen_num,
-                xcb_imdkit::InputStyle::PREEDIT_CALLBACKS,
+                input_style,
                 config::configuration().xim_im_name.as_deref(),
             )
         };
@@ -479,7 +484,7 @@ impl XConnection {
                     }
                 });
         }
-        {
+        if config::configuration().ime_preedit_rendering == config::ImePreeditRendering::Builtin {
             let conn = conn.clone();
             conn.clone()
                 .ime
@@ -494,7 +499,7 @@ impl XConnection {
                     }
                 });
         }
-        {
+        if config::configuration().ime_preedit_rendering == config::ImePreeditRendering::Builtin {
             let conn = conn.clone();
             conn.clone()
                 .ime


### PR DESCRIPTION
This PR is to support OverTheSpot input style on Windows and X11.
Users can choose OnTheSpot or OverTheSpot input style by using ime_input_style in configuration file.
OnTheSpot is default. It's same as before.

Background:
wezterm supports nearly OnTheSpot input style that preedit area is rendered by wezterm itself.
"nearly" means OnTheSpot expects inline input (preedit area does not overlap original text) but it is not so currently.

ref: https://www-archive.mozilla.org/projects/intl/input-method-spec

In wezterm, OnTheSpot input style is suitable in many IMEs but it may not be so in Japanese IME
because preedit area may be very long in Japanese IME but wezterm does not support (or cannot support) to render preedit area beyond the window.

So, I propose to support OverTheSpot input style.
OverTheSpot never support inline input but can support to render preedit area beyond the window.
It may useful to input very long preedit in Japanese IME.

OnTheSpot (default)
![スクリーンショット 2022-05-19 012909](https://user-images.githubusercontent.com/171798/169102443-2a1755fb-abd7-437f-9897-7c7a15ca4f75.png)

OverTheSpot (useful in Japanse IME)
![スクリーンショット 2022-05-19 012441](https://user-images.githubusercontent.com/171798/169102600-7a882473-8e16-437b-86b1-20173be4146b.png)

NOTE:
In above screenshot of OverTheSpot, preedit area is within the window but it can be rendered beyond the window when preedit area is much longer.

This is draft. I think the followings need to be discussed:

* wezterm should support OverTheSpot or not.
* config key (ime_input_style) and values (OnTheSpot and OverTheSpot) are appropriate names or not.

I will write docs after discussion.

@wez, What do you think about ?
