### PR TITLE
fix typo

### DIFF
--- a/docs/install/linux.markdown
+++ b/docs/install/linux.markdown
@@ -75,7 +75,7 @@ on most Linux systems.
 |Fedora33    |[{{ fedora33_rpm_stable_asset }}]({{ fedora33_rpm_stable }}) |[{{ fedora33_rpm_nightly_asset }}]({{ fedora33_rpm_nightly }})|
 |Fedora34    |[{{ fedora34_rpm_stable_asset }}]({{ fedora34_rpm_stable }}) |[{{ fedora34_rpm_nightly_asset }}]({{ fedora34_rpm_nightly }})|
 |Fedora35    |[{{ fedora35_rpm_stable_asset }}]({{ fedora35_rpm_stable }}) |[{{ fedora35_rpm_nightly_asset }}]({{ fedora35_rpm_nightly }})|
-|Fedora35    |Nightly builds only |[{{ fedora36_rpm_nightly_asset }}]({{ fedora36_rpm_nightly }})|
+|Fedora36    |Nightly builds only |[{{ fedora36_rpm_nightly_asset }}]({{ fedora36_rpm_nightly }})|
 |openSUSE Leap    |Nighty builds only|[{{ opensuse_leap_rpm_nightly_asset }}]({{ opensuse_leap_rpm_nightly }})|
 |openSUSE Tumbleweed    |Nighty builds only|[{{ opensuse_tumbleweed_rpm_nightly_asset }}]({{ opensuse_tumbleweed_rpm_nightly }})|
 


### PR DESCRIPTION
Thank you very much for your works. This is to fix a typo of Fedora version on the table.