### PR TITLE
Fix IME candidate window position on macOS

### DIFF
--- a/window/src/os/macos/window.rs
+++ b/window/src/os/macos/window.rs
@@ -1714,10 +1714,9 @@ impl WindowView {
             range,
             actual
         );
-        let frame = unsafe {
-            let window: id = msg_send![this, window];
-            NSWindow::frame(window)
-        };
+        let window: id = unsafe { msg_send![this, window] };
+        let frame = unsafe { NSWindow::frame(window) };
+        let content: NSRect = unsafe { msg_send![window, contentRectForFrameRect: frame] };
         let backing_frame: NSRect = unsafe { msg_send![this, convertRectToBacking: frame] };
         let scale = frame.size.width / backing_frame.size.width;
 
@@ -1731,11 +1730,8 @@ impl WindowView {
 
             NSRect::new(
                 NSPoint::new(
-                    frame.origin.x + cursor_pos.origin.x,
-                    // Position below the text so that drop-downs
-                    // don't obscure the text in the terminal
-                    frame.origin.y + frame.size.height
-                        - (cursor_pos.max_y() + cursor_pos.size.height * 2.5),
+                    content.origin.x + cursor_pos.min_x(),
+                    content.origin.y + content.size.height - cursor_pos.max_y(),
                 ),
                 NSSize::new(cursor_pos.size.width, cursor_pos.size.height),
             )


### PR DESCRIPTION
This PR is to fix IME candidate window position on macOS.
Similar to #1976

before:
<img width="871" alt="スクリーンショット 2022-05-24 6 11 27" src="https://user-images.githubusercontent.com/171798/169906773-a18ec354-cf37-4760-a536-9937ab5d6d1f.png">

after:
<img width="871" alt="スクリーンショット 2022-05-24 6 13 06" src="https://user-images.githubusercontent.com/171798/169906997-97bea843-53f5-41d6-a81b-874ce086bf61.png">

