### PR TITLE
docs: fix invalid `server_command` example

### DIFF
--- a/docs/multiplexing.md
+++ b/docs/multiplexing.md
@@ -207,7 +207,7 @@ return {
   unix_domains = {
     {
       name = "wsl",
-      serve_command = ["wsl", "wezterm-mux-server", "--daemonize"],
+      serve_command = {"wsl", "wezterm-mux-server", "--daemonize"},
     }
   },
   default_gui_startup_args = {"connect", "wsl"},


### PR DESCRIPTION
Thank you for creating this awesome project.

I found a tiny typo.
This [Connecting into Windows Subsystem for Linux](https://wezfurlong.org/wezterm/multiplexing.html#connecting-into-windows-subsystem-for-linux) example doesn't  seem to work.