### PR TITLE
docs: fix key tables example mismatched curly braces

### DIFF
--- a/docs/config/key-tables.md
+++ b/docs/config/key-tables.md
@@ -39,17 +39,17 @@ return {
         name="resize_pane",
         one_shot=false,
       }
-    },
+    }},
 
     -- CTRL|SHIFT+Space, followed by 'a' will put us in activate-pane
     -- mode until we press some other key or until 1 second (1000ms)
     -- of time elapses
     {key="a", mods="LEADER", action=wezterm.action{
       ActivateKeyTable={
-        name="activate_pane"
+        name="activate_pane",
         timeout_milliseconds=1000,
       }
-    },
+    }},
   },
 
   key_tables = {


### PR DESCRIPTION
I noticed that copy-pasting the example was not working.

Thanks for this awesome project :)