### PR TITLE
Try implement line selection for CopyMode

### DIFF
--- a/config/src/keyassignment.rs
+++ b/config/src/keyassignment.rs
@@ -434,7 +434,6 @@ pub enum CopyModeAssignment {
     MoveToViewportMiddle,
     MoveToScrollbackTop,
     MoveToScrollbackBottom,
-    ToggleSelectionByCell,
     SetSelectionMode(Option<SelectionMode>),
     MoveToStartOfLineContent,
     MoveToEndOfLineContent,

--- a/docs/copymode.md
+++ b/docs/copymode.md
@@ -32,7 +32,8 @@ reassignable.
 |                | `CTRL-C`   |
 |                | `CTRL-g`   |
 |                | `q`        |
-| Toggle cell selection mode | `v` |
+| Cell selection | `v` |
+| Line selection | `V` |
 | Rectangular selection | `CTRL-v` (*since: nightly builds only*)|
 | Move Left      | `LeftArrow`|
 |                | `h`        |
@@ -118,8 +119,10 @@ return {
       {key="^", mods="NONE", action=wezterm.action{CopyMode="MoveToStartOfLineContent"}},
       {key="^", mods="SHIFT", action=wezterm.action{CopyMode="MoveToStartOfLineContent"}},
 
-      {key=" ", mods="NONE", action=wezterm.action{CopyMode="ToggleSelectionByCell"}},
-      {key="v", mods="NONE", action=wezterm.action{CopyMode="ToggleSelectionByCell"}},
+      {key=" ", mods="NONE", action=wezterm.action{CopyMode={SetSelectionMode="Cell"}}},
+      {key="v", mods="NONE", action=wezterm.action{CopyMode={SetSelectionMode="Cell"}}},
+      {key="V", mods="NONE", action=wezterm.action{CopyMode={SetSelectionMode="Line"}}},
+      {key="V", mods="SHIFT", action=wezterm.action{CopyMode={SetSelectionMode="Line"}}},
       {key="v", mods="CTRL", action=wezterm.action{CopyMode={SetSelectionMode="Block"}}},
 
       {key="G", mods="NONE", action=wezterm.action{CopyMode="MoveToScrollbackBottom"}},


### PR DESCRIPTION
Hello @wez! It's been a while :)

This is a tentative PR to add line selection to copy mode.
I got Shift-v wired up, changed a few things to put the line coordinates, but I'm hitting a few walls..

See the various FIXMEs I left,
:point_right: I'd appreciate some help to understand them / guidance to resolve them.

Also, wondering, if we go with logical line selection, shouldn't `j` & `k` move by logical lines as well?
OR I could just start with physical line selection for now (smaller PR!)

Closes #2083