### PR TITLE
Fix that harfbuzz skips the usage of some freetype functions unexpectedly

### DIFF
--- a/deps/harfbuzz/build.rs
+++ b/deps/harfbuzz/build.rs
@@ -92,9 +92,9 @@ fn harfbuzz() {
     // We know that these are present in our vendored freetype
     cfg.define("HAVE_FREETYPE", Some("1"));
 
-    cfg.define("HAVE_FT_Get_Var_Blend_Coordinates", Some("1"));
-    cfg.define("HAVE_FT_Set_Var_Blend_Coordinates", Some("1"));
-    cfg.define("HAVE_FT_Done_MM_Var", Some("1"));
+    cfg.define("HAVE_FT_GET_VAR_BLEND_COORDINATES", Some("1"));
+    cfg.define("HAVE_FT_SET_VAR_BLEND_COORDINATES", Some("1"));
+    cfg.define("HAVE_FT_DONE_MM_VAR", Some("1"));
 
     // Import the include dirs exported from deps/freetype/build.rs
     for inc in std::env::var("DEP_FREETYPE_INCLUDE").unwrap().split(';') {


### PR DESCRIPTION
harfbuzz expects upper case HAVE_FT_XXX macro but the macros defined in build.rs are mixed case HAVE_FT_Xxx.
This PR changes the macro to upper case HAVE_FT_XX to fix that harfbuzz skips the usage of some freetype functions unexpectedly.

```shell
$ grep -r HAVE_FT_ deps/harfbuzz/harfbuzz/
deps/harfbuzz/harfbuzz/util/helper-cairo-ft.hh:#ifdef HAVE_FT_SET_VAR_BLEND_COORDINATES
deps/harfbuzz/harfbuzz/src/hb-ft.cc:#if defined(HAVE_FT_GET_VAR_BLEND_COORDINATES) && !defined(HB_NO_VAR)
deps/harfbuzz/harfbuzz/src/hb-ft.cc:#ifdef HAVE_FT_DONE_MM_VAR
deps/harfbuzz/harfbuzz/src/hb-ft.cc:#if defined(HAVE_FT_GET_VAR_BLEND_COORDINATES) && !defined(HB_NO_VAR)

$ grep -r HAVE_FT_ deps/harfbuzz/build.rs
    cfg.define("HAVE_FT_Get_Var_Blend_Coordinates", Some("1"));
    cfg.define("HAVE_FT_Set_Var_Blend_Coordinates", Some("1"));
    cfg.define("HAVE_FT_Done_MM_Var", Some("1"));
```
