### PR TITLE
x11: allow configuration of repaint delay, fix loss of focus

### DIFF
--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -648,6 +648,9 @@ pub struct Config {
 
     #[dynamic(default)]
     pub quote_dropped_files: DroppedFileQuoting,
+
+    #[dynamic(default = "default_focus_change_repaint_delay")]
+    pub focus_change_repaint_delay: u64,
 }
 impl_lua_conversion_dynamic!(Config);
 
@@ -1344,6 +1347,10 @@ fn default_inactive_pane_hsb() -> HsbTransform {
         saturation: 0.9,
         hue: 1.0,
     }
+}
+
+fn default_focus_change_repaint_delay() -> u64 {
+    100
 }
 
 #[derive(FromDynamic, ToDynamic, Clone, Copy, Debug)]

--- a/docs/config/lua/config/focus_change_repaint_delay.md
+++ b/docs/config/lua/config/focus_change_repaint_delay.md
@@ -1,0 +1,8 @@
+## `focus_change_repaint_delay = 100`
+
+*Since: nightly builds only*
+
+When not set to `0`, WezTerm will wait the specified delay (in milliseconds) before invalidating the geometry and repainting the window after losing or gaining focus.
+
+Using the proprietry NVIDIA drivers and EGL rendering on X11, the `CONFIGURE_NOTIFY` event is sometimes missed. This workaround ensures that the window correctly resizes in these cases.
+

--- a/window/src/os/x11/window.rs
+++ b/window/src/os/x11/window.rs
@@ -564,6 +564,7 @@ impl XWindowInner {
                 async_io::Timer::after(std::time::Duration::from_millis(delay)).await;
                 XConnection::with_window_inner(window_id, |inner| {
                     inner.sure_about_geometry = false;
+                    inner.verify_focus = true;
                     inner.invalidate();
                     Ok(())
                 });


### PR DESCRIPTION
Adds a configuration option, `focus_change_repaint_delay` to allow customisation of the delay added in 9b6329b454a51bc7e11ebaa447500ce049035833.

The default delay remains 100ms, and can be disabled by setting it to `0`, if the workaround is not required on the user's system.

The focus events used to trigger a query of geometry are inaccurate, so the window's focus state should also be queried.

refs: #2063
refs: #1992