### PR TITLE
Fix minor typo in pad_right.md doc

### DIFF
--- a/docs/config/lua/wezterm/pad_right.md
+++ b/docs/config/lua/wezterm/pad_right.md
@@ -8,7 +8,7 @@ Returns a copy of `string` that is at least `min_width` columns
 If the string is shorter than `min_width`, spaces are added to
 the right end of the string.
 
-For example, `wezterm.pad_righ("o", 3)` returns `"o  "`.
+For example, `wezterm.pad_right("o", 3)` returns `"o  "`.
 
 See also: [wezterm.truncate_left](truncate_left.md), [wezterm.pad_left](pad_left.md).
 


### PR DESCRIPTION
`wezterm.pad_righ` in the example should be `wezterm.pad_right`.

There's another problem, shared with the pad_left page, that `"o  "` is rendered in the HTML with just one space, collapsing the two spaces to one, which is very misleading given what the example for this function does. It needs to be in a `<pre>` tag rather than just a `<code>` tag (or have the equivalent css applied), but I don't know how to fix that from markdown.