### PR TITLE
Implement o & O to move cursor to other end of selection in copy mode

### DIFF
--- a/config/src/keyassignment.rs
+++ b/config/src/keyassignment.rs
@@ -440,6 +440,8 @@ pub enum CopyModeAssignment {
     MoveToEndOfLineContent,
     MoveToStartOfLine,
     MoveToStartOfNextLine,
+    MoveToSelectionOtherEnd,
+    MoveToSelectionOtherEndHoriz,
     MoveBackwardWord,
     MoveForwardWord,
     MoveRight,

--- a/docs/copymode.md
+++ b/docs/copymode.md
@@ -64,6 +64,8 @@ reassignable.
 |                                | `CTRL-b` |
 | Move down one screen           | `PageDown` |
 |                                | `CTRL-f`   |
+| Move to other end of the selection| `o` |
+| Move to other end of the selection horizontaly| `O` (only in Rectangular mode) |
 
 ### Configurable Key Assignments
 
@@ -130,6 +132,10 @@ return {
       {key="M", mods="SHIFT", action=wezterm.action{CopyMode="MoveToViewportMiddle"}},
       {key="L", mods="NONE", action=wezterm.action{CopyMode="MoveToViewportBottom"}},
       {key="L", mods="SHIFT", action=wezterm.action{CopyMode="MoveToViewportBottom"}},
+
+      {key="o", mods="NONE", action=wezterm.action{CopyMode="MoveToSelectionOtherEnd"}},
+      {key="O", mods="NONE", action=wezterm.action{CopyMode="MoveToSelectionOtherEndHoriz"}},
+      {key="O", mods="SHIFT", action=wezterm.action{CopyMode="MoveToSelectionOtherEndHoriz"}},
 
       {key="PageUp", mods="NONE", action=wezterm.action{CopyMode="PageUp"}},
       {key="PageDown", mods="NONE", action=wezterm.action{CopyMode="PageDown"}},

--- a/wezterm-gui/src/overlay/copy.rs
+++ b/wezterm-gui/src/overlay/copy.rs
@@ -606,8 +606,7 @@ impl CopyRenderable {
 
     fn move_to_selection_other_end_horiz(&mut self) {
         if self.selection_mode != SelectionMode::Block {
-            // This action makes sense ONLY in block mode
-            return;
+            return self.move_to_selection_other_end();
         }
         if let Some(old_start) = self.start {
             // Swap X coordinate of cursor & start of selection


### PR DESCRIPTION
Demo :smiley: 

https://user-images.githubusercontent.com/9730330/174689403-4520b080-20f1-4a30-b39d-20e646cf877c.mp4

Inspired from vim:
```
							*v_o*
o			Go to Other end of highlighted text: The current
			cursor position becomes the start of the highlighted
			text and the cursor is moved to the other end of the
			highlighted text.  The highlighted area remains the
			same.

							*v_O*
O			Go to Other end of highlighted text.  This is like
			"o", but in Visual block mode the cursor moves to the
			other corner in the same line.  [...]
```