### PR TITLE
Added winapi feature "shellapi" to procinfo

### DIFF
--- a/procinfo/Cargo.toml
+++ b/procinfo/Cargo.toml
@@ -18,6 +18,7 @@ winapi = { version = "0.3", features = [
     "memoryapi",
     "psapi",
     "processthreadsapi",
+    "shellapi",
     "tlhelp32",
 ]}
 


### PR DESCRIPTION
Fixes wezterm installation on windows using `cargo install --path ./wezterm` or `cargo install --path ./wezterm-gui` by adding the shellapi feature to the winapi crate dependency.