### PR TITLE
fix: properly restore cooked mode in windows

### DIFF
--- a/termwiz/src/terminal/windows.rs
+++ b/termwiz/src/terminal/windows.rs
@@ -711,7 +711,7 @@ impl Terminal for WindowsTerminal {
         let mode = self.input_handle.get_input_mode()?;
 
         self.input_handle.set_input_mode(
-            (mode & !(ENABLE_WINDOW_INPUT | ENABLE_WINDOW_INPUT))
+            (mode & !(ENABLE_MOUSE_INPUT | ENABLE_WINDOW_INPUT))
                 | ENABLE_ECHO_INPUT
                 | ENABLE_LINE_INPUT
                 | ENABLE_PROCESSED_INPUT,


### PR DESCRIPTION
Found a small typo (I think) in `set_cooked_mode` that redundantly turned off `ENABLE_WINDOW_INPUT` twice instead of turning off `ENABLE_MOUSE_INPUT` and `ENABLE_WINDOW_INPUT`