### PR TITLE
Fix install docs for Ubuntu 22

### DIFF
--- a/docs/install/linux.markdown
+++ b/docs/install/linux.markdown
@@ -44,13 +44,13 @@ you can try the AppImage download which should work on most Linux systems.
 |------------|------------------|---------------------|
 |Ubuntu18    |[{{ ubuntu18_deb_stable_asset }}]({{ ubuntu18_deb_stable }}) |[{{ ubuntu18_deb_nightly_asset }}]({{ ubuntu18_deb_nightly }})|
 |Ubuntu20    |[{{ ubuntu20_deb_stable_asset }}]({{ ubuntu20_deb_stable }})  |[{{ ubuntu20_deb_nightly_asset }}]({{ ubuntu20_deb_nightly }})|
-|Ubuntu22    |[{{ ubuntu22_deb_stable_asset }}]({{ ubuntu20_deb_stable }}) |[{{ ubuntu22_deb_nightly_asset }}]({{ ubuntu22_deb_nightly }})|
+|Ubuntu22    |[{{ ubuntu22_deb_stable_asset }}]({{ ubuntu22_deb_stable }}) |[{{ ubuntu22_deb_nightly_asset }}]({{ ubuntu22_deb_nightly }})|
 |Debian9     |[{{ debian9_deb_stable_asset }}]({{ debian9_deb_stable }}) |[{{ debian9_deb_nightly_asset }}]({{ debian9_deb_nightly }})|
 |Debian10    |[{{ debian10_deb_stable_asset }}]({{ debian10_deb_stable }}) |[{{ debian10_deb_nightly_asset }}]({{ debian10_deb_nightly }})|
 |Debian11    |[{{ debian11_deb_stable_asset }}]({{ debian11_deb_stable }}) |[{{ debian11_deb_nightly_asset }}]({{ debian11_deb_nightly }})|
 
 To download and install from the CLI, you can use something like this, which
-shows how to install the Ubuntu 16 package:
+shows how to install the Ubuntu 20 package:
 
 ```bash
 curl -LO {{ ubuntu20_deb_stable }}


### PR DESCRIPTION
The asset linked to for Ubuntu 22 is the Ubuntu 20 package. This commit fixes that by refering to the correct Ubuntu 22 asset instead.

Looking at https://github.com/wez/wezterm/blob/c29a513a441ce301838567d9cde6e1a75cb57eb9/ci/subst-release-info.py, that's all that is needed to fix the link.