### PR TITLE
Add catppuccin colorschemes

### DIFF
--- a/assets/colors/catppuccin_frappe.toml
+++ b/assets/colors/catppuccin_frappe.toml
@@ -1,0 +1,11 @@
+[colors]
+foreground = "#c6d0f5"
+background = "#303446"
+cursor_bg = "#f2d5cf"
+cursor_border = "#f2d5cf"
+cursor_fg = "#232634"
+selection_bg = "#626880"
+selection_fg = "#c6d0f5"
+
+ansi = [ "#51576d", "#e78284", "#a6d189", "#e5c890", "#8caaee", "#f4b8e4", "#81c8be", "#b5bfe2" ]
+brights = [ "#626880", "#e78284", "#a6d189", "#e5c890", "#8caaee", "#f4b8e4", "#81c8be", "#a5adce" ]

--- a/assets/colors/catppuccin_latte.toml
+++ b/assets/colors/catppuccin_latte.toml
@@ -1,0 +1,11 @@
+[colors]
+foreground = "#4c4f69"
+background = "#eff1f5"
+cursor_bg = "#dc8a78"
+cursor_border = "#dc8a78"
+cursor_fg = "#eff1f5"
+selection_bg = "#acb0be"
+selection_fg = "#4c4f69"
+
+ansi = [ "#5c5f77", "#d20f39", "#40a02b", "#df8e1d", "#1e66f5", "#ea76cb", "#179299", "#acb0be" ]
+brights = [ "#6c6f85", "#d20f39", "#40a02b", "#df8e1d", "#1e66f5", "#ea76cb", "#179299", "#bcc0cc" ]

--- a/assets/colors/catppuccin_macchiato.toml
+++ b/assets/colors/catppuccin_macchiato.toml
@@ -1,0 +1,11 @@
+[colors]
+foreground = "#cad3f5"
+background = "#24273a"
+cursor_bg = "#f4dbd6"
+cursor_border = "#f4dbd6"
+cursor_fg = "#181926"
+selection_bg = "#5b6078"
+selection_fg = "#cad3f5"
+
+ansi = [ "#b8c0e0", "#ed8796", "#a6da95", "#eed49f", "#8aadf4", "#f5bde6", "#8bd5ca", "#b8c0e0" ]
+brights = [ "#5b6078", "#ed8796", "#a6da95", "#eed49f", "#8aadf4", "#f5bde6", "#8bd5ca", "#b8c0e0" ]

--- a/assets/colors/catppuccin_mocha.toml
+++ b/assets/colors/catppuccin_mocha.toml
@@ -1,0 +1,11 @@
+[colors]
+foreground = "#cdd6f4"
+background = "#1e1e2e"
+cursor_bg = "#f5e0dc"
+cursor_border = "#f5e0dc"
+cursor_fg = "#11111b"
+selection_bg = "#585b70"
+selection_fg = "#cdd6f4"
+
+ansi = [ "#45475a", "#f38ba8", "#a6e3a1", "#f9e2af", "#89b4fa", "#f5c2e7", "#94e2d5", "#585b70" ]
+brights = [ "#585b70", "#f38ba8", "#a6e3a1", "#f9e2af", "#89b4fa", "#f5c2e7", "#94e2d5", "#a6adc8" ]


### PR DESCRIPTION
Notes
----
Adding the catppuccin colorscheme with all its variants.

The contents of the .toml files were found [here](https://github.com/catppuccin/wezterm/blob/main/catppuccin.lua).

Caveats
----
- Catppuccin also defines styles for tab_bar, visual bell etc. I have only included the colors here to stay consistent with the existing scheme.
- Some of the color choices are arguable, but I remained consistent with the variants of catppuccin regardless.