### PR TITLE
win32 encoding: fix more inconsistencies

### DIFF
--- a/termwiz/src/input.rs
+++ b/termwiz/src/input.rs
@@ -751,9 +751,6 @@ fn is_ambiguous_ascii_ctrl(c: char) -> bool {
 /// produced in combination with SHIFT) that may not be 100%
 /// the right thing to do here for users with non-US layouts.
 fn ctrl_mapping(c: char) -> Option<char> {
-    // Please also sync with the copy of this function that
-    // lives in wezterm-input-types :-/
-    // FIXME: move this to wezterm-input-types and take a dep on it?
     Some(match c {
         '@' | '`' | ' ' | '2' => '\x00',
         'A' | 'a' => '\x01',

--- a/wezterm-input-types/src/lib.rs
+++ b/wezterm-input-types/src/lib.rs
@@ -1108,6 +1108,10 @@ pub struct KeyEvent {
     /// If true, this is a key down rather than a key up event
     pub key_is_down: bool,
 
+    /// The character code used for win32 keyboard encoding, if available.
+    #[cfg(windows)]
+    pub win32_uni_char: Option<char>,
+
     /// If triggered from a raw key event, here it is.
     pub raw: Option<RawKeyEvent>,
 }

--- a/wezterm-input-types/src/lib.rs
+++ b/wezterm-input-types/src/lib.rs
@@ -1197,7 +1197,13 @@ impl KeyEvent {
         const LEFT_CTRL_PRESSED: usize = 0x08;
         const RIGHT_CTRL_PRESSED: usize = 0x04;
 
-        if self.modifiers.contains(Modifiers::SHIFT) {
+        // Shift normalization sometimes removes the shift modifier from an
+        // event. Luckily we can fall back on the individual left and right
+        // modifiers.
+        if self
+            .modifiers
+            .intersects(Modifiers::SHIFT | Modifiers::LEFT_SHIFT | Modifiers::RIGHT_SHIFT)
+        {
             control_key_state |= SHIFT_PRESSED;
         }
 


### PR DESCRIPTION
While looking into #2196 I was able to find some more inconsistencies in the win32 encoding. I discovered the following differences:

* `CTRL + ALT + key` combinations should be sent with the same character code that would be generated by `AltGr + key`, i.e. either `\x00` or a character depending on the current layout. I fixed the first case for now, which should fix #2196 in most cases.
* `AltGr + key` should be sent with character code `\x00` like above if that combination has no associated character. Right now wezterm falls back on the character code of `key`.
* `SHIFT + ascii_letter` sends the correct character, but misses the SHIFT flag. This is caused by the `normalize_shift` function. I don't know if this is intentional behaviour for non-windows systems, so I didn't want to change that for now.

[Raw test data here](https://gist.github.com/kreudom/87860e7495aab6f6a3269e420c7b1d4e)

While we could try to implement all these different cases, I did some testing and realized the `ToUnicode` function would actually return the correct character in all these cases if the control keys weren't manually removed from the key set before, as it currently happens here: https://github.com/wez/wezterm/blob/d5060ec3c100c01157252381830c4f1d043cd84d/window/src/os/windows/window.rs#L2143-L2153

However, this would change the KeyEvents wezterm generates, possibly breaking existing configurations and keyboard encoding for `allow_win32_input_mode = false`.

One possible idea would be to add a new optional field to the KeyEvent structure which is only used when using the win32 encoding. What's your opinion on all this?