### PR TITLE
x11/wayland: always attempt to use the portal for appearance

### DIFF
--- a/window/src/os/x11/connection.rs
+++ b/window/src/os/x11/connection.rs
@@ -125,6 +125,12 @@ impl ConnectionOps for XConnection {
     }
 
     fn get_appearance(&self) -> Appearance {
+        match promise::spawn::block_on(crate::os::xdg_desktop_portal::get_appearance()) {
+            Ok(appearance) => return appearance,
+            Err(err) => {
+                log::debug!("Unable to resolve appearance using xdg-desktop-portal: {err:#}");
+            }
+        }
         if let Some(XSetting::String(name)) = self.xsettings.borrow().get("Net/ThemeName") {
             let lower = name.to_ascii_lowercase();
             match lower.as_str() {

--- a/window/src/os/x_and_wayland.rs
+++ b/window/src/os/x_and_wayland.rs
@@ -142,12 +142,6 @@ impl ConnectionOps for Connection {
     }
 
     fn get_appearance(&self) -> Appearance {
-        match promise::spawn::block_on(crate::os::xdg_desktop_portal::get_appearance()) {
-            Ok(appearance) => return appearance,
-            Err(err) => {
-                log::debug!("Unable to resolve appearance using xdg-desktop-portal: {err:#}");
-            }
-        }
         match self {
             Self::X11(x) => x.get_appearance(),
             #[cfg(feature = "wayland")]


### PR DESCRIPTION
This fixes a weird problem where sometimes wezterm would disregard the very first XDG desktop portal notification.
Please see the commit message for more details, basically we have to read the appearance at startup from the same connection that we read the Lua API appearance from, otherwise we get an inconsistency in internal state.