### PR TITLE
docs: reformat lua code

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -42,6 +42,9 @@ jobs:
       - name: Install mdBook mermaid
         run: |
           (test -x ~/.cargo/bin/mdbook-mermaid || (cd && cargo install mdbook-mermaid --locked))
+      - name: Install gelatyx
+        run: |
+          (test -x ~/.cargo/bin/gelatyx || (cd && cargo install gelatyx --locked))
       - name: Build
         run: |
           source $HOME/.cargo/env

--- a/ci/build-docs.sh
+++ b/ci/build-docs.sh
@@ -7,6 +7,8 @@ python3 ci/subst-release-info.py || exit 1
 python3 ci/generate-docs.py || exit 1
 mdbook-mermaid install docs
 mdbook build docs
+gelatyx lua --file docs/**/*.md --language-config ci/stylua.toml
+gelatyx lua --file docs/**/*.md --language-config ci/stylua.toml --check
 
 rm gh_pages/html/README.markdown
 cp assets/fonts/Symbols-Nerd-Font-Mono.ttf gh_pages/html/fonts/

--- a/ci/stylua.toml
+++ b/ci/stylua.toml
@@ -1,0 +1,8 @@
+# Reference: https://github.com/JohnnyMorganz/StyLua#options
+
+column_width = 78
+line_endings = "Unix"
+indent_type = "Spaces"
+indent_width = 2
+quote_style = "AutoPreferSingle"
+call_parentheses = "None"

--- a/docs/config/appearance.md
+++ b/docs/config/appearance.md
@@ -6,7 +6,7 @@ You can select a color scheme with a line like this:
 
 ```lua
 return {
-  color_scheme = "Batman",
+  color_scheme = 'Batman',
 }
 ```
 
@@ -29,44 +29,62 @@ usual hex notation; eg: `#000000` is equivalent to `black`:
 ```lua
 return {
   colors = {
-      -- The default text color
-      foreground = "silver",
-      -- The default background color
-      background = "black",
+    -- The default text color
+    foreground = 'silver',
+    -- The default background color
+    background = 'black',
 
-      -- Overrides the cell background color when the current cell is occupied by the
-      -- cursor and the cursor style is set to Block
-      cursor_bg = "#52ad70",
-      -- Overrides the text color when the current cell is occupied by the cursor
-      cursor_fg = "black",
-      -- Specifies the border color of the cursor when the cursor style is set to Block,
-      -- or the color of the vertical or horizontal bar when the cursor style is set to
-      -- Bar or Underline.
-      cursor_border = "#52ad70",
+    -- Overrides the cell background color when the current cell is occupied by the
+    -- cursor and the cursor style is set to Block
+    cursor_bg = '#52ad70',
+    -- Overrides the text color when the current cell is occupied by the cursor
+    cursor_fg = 'black',
+    -- Specifies the border color of the cursor when the cursor style is set to Block,
+    -- or the color of the vertical or horizontal bar when the cursor style is set to
+    -- Bar or Underline.
+    cursor_border = '#52ad70',
 
-      -- the foreground color of selected text
-      selection_fg = "black",
-      -- the background color of selected text
-      selection_bg = "#fffacd",
+    -- the foreground color of selected text
+    selection_fg = 'black',
+    -- the background color of selected text
+    selection_bg = '#fffacd',
 
-      -- The color of the scrollbar "thumb"; the portion that represents the current viewport
-      scrollbar_thumb = "#222222",
+    -- The color of the scrollbar "thumb"; the portion that represents the current viewport
+    scrollbar_thumb = '#222222',
 
-      -- The color of the split lines between panes
-      split = "#444444",
+    -- The color of the split lines between panes
+    split = '#444444',
 
-      ansi = {"black", "maroon", "green", "olive", "navy", "purple", "teal", "silver"},
-      brights = {"grey", "red", "lime", "yellow", "blue", "fuchsia", "aqua", "white"},
+    ansi = {
+      'black',
+      'maroon',
+      'green',
+      'olive',
+      'navy',
+      'purple',
+      'teal',
+      'silver',
+    },
+    brights = {
+      'grey',
+      'red',
+      'lime',
+      'yellow',
+      'blue',
+      'fuchsia',
+      'aqua',
+      'white',
+    },
 
-      -- Arbitrary colors of the palette in the range from 16 to 255
-      indexed = {[136] = "#af8700"},
+    -- Arbitrary colors of the palette in the range from 16 to 255
+    indexed = { [136] = '#af8700' },
 
-      -- Since: 20220319-142410-0fcdea07
-      -- When the IME, a dead key or a leader key are being processed and are effectively
-      -- holding input pending the result of input composition, change the cursor
-      -- to this color to give a visual cue about the compose state.
-      compose_cursor = "orange",
-  }
+    -- Since: 20220319-142410-0fcdea07
+    -- When the IME, a dead key or a leader key are being processed and are effectively
+    -- holding input pending the result of input composition, change the cursor
+    -- to this color to give a visual cue about the compose state.
+    compose_cursor = 'orange',
+  },
 }
 ```
 
@@ -77,14 +95,14 @@ You may specify colors in the HSL color space, if you prefer that over RGB, by u
 ```lua
 return {
   colors = {
-      -- the first number is the hue measured in degrees with a range
-      -- of 0-360.
-      -- The second number is the saturation measured in percentage with
-      -- a range of 0-100.
-      -- The third number is the lightness measured in percentage with
-      -- a range of 0-100.
-      foreground = "hsl:235 100 50",
-  }
+    -- the first number is the hue measured in degrees with a range
+    -- of 0-360.
+    -- The second number is the saturation measured in percentage with
+    -- a range of 0-100.
+    -- The third number is the lightness measured in percentage with
+    -- a range of 0-100.
+    foreground = 'hsl:235 100 50',
+  },
 }
 ```
 
@@ -119,12 +137,12 @@ return {
   colors = {
     -- Make the selection text color fully transparent.
     -- When fully transparent, the current text color will be used.
-    selection_fg = "none",
+    selection_fg = 'none',
     -- Set the selection background color with alpha.
     -- When selection_bg is transparent, it will be alpha blended over
     -- the current cell background color, rather than replace it
-    selection_bg = "rgba(50% 50% 50% 50%)"
-  }
+    selection_bg = 'rgba(50% 50% 50% 50%)',
+  },
 }
 ```
 
@@ -178,7 +196,7 @@ will need to instruct wezterm where to look for your scheme files; the
 
 ```lua
 return {
-  color_scheme_dirs = {"/some/path/to/my/color/schemes"},
+  color_scheme_dirs = { '/some/path/to/my/color/schemes' },
 }
 ```
 
@@ -236,7 +254,7 @@ return {
     -- Whatever font is selected here, it will have the
     -- main font setting appended to it to pick up any
     -- fallback fonts you may have used there.
-    font = wezterm.font({family="Roboto", weight="Bold"}),
+    font = wezterm.font { family = 'Roboto', weight = 'Bold' },
 
     -- The size of the font in the tab bar.
     -- Default to 10. on Windows but 12.0 on other systems
@@ -244,17 +262,17 @@ return {
 
     -- The overall background color of the tab bar when
     -- the window is focused
-    active_titlebar_bg = "#333333",
+    active_titlebar_bg = '#333333',
 
     -- The overall background color of the tab bar when
     -- the window is not focused
-    inactive_titlebar_bg = "#333333",
+    inactive_titlebar_bg = '#333333',
   },
 
   colors = {
     tab_bar = {
       -- The color of the inactive tab bar edge/divider
-      inactive_tab_edge = "#575757",
+      inactive_tab_edge = '#575757',
     },
   },
 }
@@ -273,24 +291,24 @@ return {
     tab_bar = {
       -- The color of the strip that goes along the top of the window
       -- (does not apply when fancy tab bar is in use)
-      background = "#0b0022",
+      background = '#0b0022',
 
       -- The active tab is the one that has focus in the window
       active_tab = {
         -- The color of the background area for the tab
-        bg_color = "#2b2042",
+        bg_color = '#2b2042',
         -- The color of the text for the tab
-        fg_color = "#c0c0c0",
+        fg_color = '#c0c0c0',
 
         -- Specify whether you want "Half", "Normal" or "Bold" intensity for the
         -- label shown for this tab.
         -- The default is "Normal"
-        intensity = "Normal",
+        intensity = 'Normal',
 
         -- Specify whether you want "None", "Single" or "Double" underline for
         -- label shown for this tab.
         -- The default is "None"
-        underline = "None",
+        underline = 'None',
 
         -- Specify whether you want the text to be italic (true) or not (false)
         -- for this tab.  The default is false.
@@ -303,8 +321,8 @@ return {
 
       -- Inactive tabs are the tabs that do not have focus
       inactive_tab = {
-        bg_color = "#1b1032",
-        fg_color = "#808080",
+        bg_color = '#1b1032',
+        fg_color = '#808080',
 
         -- The same options that were listed under the `active_tab` section above
         -- can also be used for `inactive_tab`.
@@ -313,8 +331,8 @@ return {
       -- You can configure some alternate styling when the mouse pointer
       -- moves over inactive tabs
       inactive_tab_hover = {
-        bg_color = "#3b3052",
-        fg_color = "#909090",
+        bg_color = '#3b3052',
+        fg_color = '#909090',
         italic = true,
 
         -- The same options that were listed under the `active_tab` section above
@@ -323,8 +341,8 @@ return {
 
       -- The new tab button that let you create new tabs
       new_tab = {
-        bg_color = "#1b1032",
-        fg_color = "#808080",
+        bg_color = '#1b1032',
+        fg_color = '#808080',
 
         -- The same options that were listed under the `active_tab` section above
         -- can also be used for `new_tab`.
@@ -333,15 +351,15 @@ return {
       -- You can configure some alternate styling when the mouse pointer
       -- moves over the new tab button
       new_tab_hover = {
-        bg_color = "#3b3052",
-        fg_color = "#909090",
+        bg_color = '#3b3052',
+        fg_color = '#909090',
         italic = true,
 
         -- The same options that were listed under the `active_tab` section above
         -- can also be used for `new_tab_hover`.
-      }
-    }
-  }
+      },
+    },
+  },
 }
 ```
 
@@ -369,7 +387,7 @@ return {
   inactive_pane_hsb = {
     saturation = 0.9,
     brightness = 0.8,
-  }
+  },
 }
 ```
 
@@ -400,7 +418,7 @@ You can attach an image to the background of the wezterm window:
 
 ```lua
 return {
-  window_background_image = "/path/to/wallpaper.jpg"
+  window_background_image = '/path/to/wallpaper.jpg',
 }
 ```
 
@@ -419,9 +437,8 @@ You can optionally transform the background image by specifying
 a hue, saturation, brightness multiplier:
 
 ```lua
-
 return {
-  window_background_image = "/path/to/wallpaper.jpg",
+  window_background_image = '/path/to/wallpaper.jpg',
 
   window_background_image_hsb = {
     -- Darken the background image by reducing it to 1/3rd

--- a/docs/config/files.md
+++ b/docs/config/files.md
@@ -78,8 +78,7 @@ degree of flexibility.   The script is expected to return a configuration
 table, so a basic empty configuration file will look like this:
 
 ```lua
-return {
-}
+return {}
 ```
 
 Throughout these docs you'll find configuration fragments that demonstrate
@@ -87,16 +86,16 @@ configuration and that look something like this:
 
 ```lua
 return {
-  color_scheme = "Batman",
+  color_scheme = 'Batman',
 }
 ```
 
 and perhaps another one like this:
 
 ```lua
-local wezterm = require 'wezterm';
+local wezterm = require 'wezterm'
 return {
-  font = wezterm.font("JetBrains Mono"),
+  font = wezterm.font 'JetBrains Mono',
 }
 ```
 
@@ -104,10 +103,10 @@ If you wanted to use both of these in the same file, you would merge them togeth
 like this:
 
 ```lua
-local wezterm = require 'wezterm';
+local wezterm = require 'wezterm'
 return {
-  font = wezterm.font("JetBrains Mono"),
-  color_scheme = "Batman",
+  font = wezterm.font 'JetBrains Mono',
+  color_scheme = 'Batman',
 }
 ```
 

--- a/docs/config/font-shaping.md
+++ b/docs/config/font-shaping.md
@@ -21,7 +21,7 @@ use a setting like this:
 
 ```lua
 return {
-  harfbuzz_features = {"calt=0", "clig=0", "liga=0"},
+  harfbuzz_features = { 'calt=0', 'clig=0', 'liga=0' },
 }
 ```
 
@@ -36,7 +36,7 @@ and you can set them in wezterm:
 return {
   -- Use this for a zero with a dot rather than a line through it
   -- when using the Fira Code font
-  harfbuzz_features = {"zero"}
+  harfbuzz_features = { 'zero' },
 }
 ```
 
@@ -48,10 +48,10 @@ globally for all fonts:
 ```lua
 local wezterm = require 'wezterm'
 return {
-  font = wezterm.font({
-    family="JetBrains Mono",
-    harfbuzz_features={"calt=0", "clig=0", "liga=0"}
-  })
+  font = wezterm.font {
+    family = 'JetBrains Mono',
+    harfbuzz_features = { 'calt=0', 'clig=0', 'liga=0' },
+  },
 }
 ```
 
@@ -59,18 +59,18 @@ and this example disables ligatures for JetBrains Mono,
 but keeps the default for the other fonts in the fallback:
 
 ```lua
-local wezterm = require 'wezterm';
+local wezterm = require 'wezterm'
 
 return {
-  font = wezterm.font_with_fallback({
+  font = wezterm.font_with_fallback {
     {
-       family="JetBrains Mono",
-       weight="Medium",
-       harfbuzz_features={"calt=0", "clig=0", "liga=0"}
+      family = 'JetBrains Mono',
+      weight = 'Medium',
+      harfbuzz_features = { 'calt=0', 'clig=0', 'liga=0' },
     },
-    {family="Terminus", weight="Bold"},
-    "Noto Color Emoji"
-  }),
+    { family = 'Terminus', weight = 'Bold' },
+    'Noto Color Emoji',
+  },
 }
 ```
 

--- a/docs/config/fonts.md
+++ b/docs/config/fonts.md
@@ -9,13 +9,13 @@ If you wish to use a different font face, then you can use
 the [wezterm.font](lua/wezterm/font.md) function to specify it:
 
 ```lua
-local wezterm = require 'wezterm';
+local wezterm = require 'wezterm'
 
 return {
-  font = wezterm.font("Fira Code"),
+  font = wezterm.font 'Fira Code',
   -- You can specify some parameters to influence the font selection;
   -- for example, this selects a Bold, Italic font variant.
-  font = wezterm.font("JetBrains Mono", {weight="Bold", italic=true})
+  font = wezterm.font('JetBrains Mono', { weight = 'Bold', italic = true }),
 }
 ```
 
@@ -36,12 +36,12 @@ monospace font, but it doesn't have glyphs for the asian script that you
 sometimes work with:
 
 ```lua
-local wezterm = require 'wezterm';
+local wezterm = require 'wezterm'
 return {
-  font = wezterm.font_with_fallback({
-    "Fira Code",
-    "DengXian",
-  }),
+  font = wezterm.font_with_fallback {
+    'Fira Code',
+    'DengXian',
+  },
 }
 ```
 

--- a/docs/config/key-tables.md
+++ b/docs/config/key-tables.md
@@ -22,31 +22,39 @@ local wezterm = require 'wezterm'
 local act = wezterm.action
 
 -- Show which key table is active in the status area
-wezterm.on("update-right-status", function(window, pane)
+wezterm.on('update-right-status', function(window, pane)
   local name = window:active_key_table()
   if name then
-    name = "TABLE: " .. name
+    name = 'TABLE: ' .. name
   end
-  window:set_right_status(name or "")
+  window:set_right_status(name or '')
 end)
 
 return {
-  leader = {key="Space", mods="CTRL|SHIFT"},
+  leader = { key = 'Space', mods = 'CTRL|SHIFT' },
   keys = {
     -- CTRL+SHIFT+Space, followed by 'r' will put us in resize-pane
     -- mode until we cancel that mode.
-    {key="r", mods="LEADER", action=act.ActivateKeyTable{
-      name="resize_pane",
-      one_shot=false,
-    }},
+    {
+      key = 'r',
+      mods = 'LEADER',
+      action = act.ActivateKeyTable {
+        name = 'resize_pane',
+        one_shot = false,
+      },
+    },
 
     -- CTRL+SHIFT+Space, followed by 'a' will put us in activate-pane
     -- mode until we press some other key or until 1 second (1000ms)
     -- of time elapses
-    {key="a", mods="LEADER", action=act.ActivateKeyTable{
-      name="activate_pane",
-      timeout_milliseconds=1000,
-    }},
+    {
+      key = 'a',
+      mods = 'LEADER',
+      action = act.ActivateKeyTable {
+        name = 'activate_pane',
+        timeout_milliseconds = 1000,
+      },
+    },
   },
 
   key_tables = {
@@ -57,43 +65,40 @@ return {
     -- 'resize_pane' here corresponds to the name="resize_pane" in
     -- the key assignments above.
     resize_pane = {
-      {key="LeftArrow", action=act.AdjustPaneSize{"Left", 1}},
-      {key="h",         action=act.AdjustPaneSize{"Left", 1}},
+      { key = 'LeftArrow', action = act.AdjustPaneSize { 'Left', 1 } },
+      { key = 'h', action = act.AdjustPaneSize { 'Left', 1 } },
 
-      {key="RightArrow", action=act.AdjustPaneSize{"Right", 1}},
-      {key="l",          action=act.AdjustPaneSize{"Right", 1}},
+      { key = 'RightArrow', action = act.AdjustPaneSize { 'Right', 1 } },
+      { key = 'l', action = act.AdjustPaneSize { 'Right', 1 } },
 
-      {key="UpArrow", action=act.AdjustPaneSize{"Up", 1}},
-      {key="k",       action=act.AdjustPaneSize{"Up", 1}},
+      { key = 'UpArrow', action = act.AdjustPaneSize { 'Up', 1 } },
+      { key = 'k', action = act.AdjustPaneSize { 'Up', 1 } },
 
-      {key="DownArrow", action=act.AdjustPaneSize{"Down", 1}},
-      {key="j",         action=act.AdjustPaneSize{"Down", 1}},
+      { key = 'DownArrow', action = act.AdjustPaneSize { 'Down', 1 } },
+      { key = 'j', action = act.AdjustPaneSize { 'Down', 1 } },
 
       -- Cancel the mode by pressing escape
-      {key="Escape", action="PopKeyTable"},
-
+      { key = 'Escape', action = 'PopKeyTable' },
     },
 
     -- Defines the keys that are active in our activate-pane mode.
     -- 'activate_pane' here corresponds to the name="activate_pane" in
     -- the key assignments above.
     activate_pane = {
-      {key="LeftArrow", action=act.ActivatePaneDirection("Left")},
-      {key="h",         action=act.ActivatePaneDirection("Left")},
+      { key = 'LeftArrow', action = act.ActivatePaneDirection 'Left' },
+      { key = 'h', action = act.ActivatePaneDirection 'Left' },
 
-      {key="RightArrow", action=act.ActivatePaneDirection("Right")},
-      {key="l",          action=act.ActivatePaneDirection("Right")},
+      { key = 'RightArrow', action = act.ActivatePaneDirection 'Right' },
+      { key = 'l', action = act.ActivatePaneDirection 'Right' },
 
-      {key="UpArrow", action=act.ActivatePaneDirection("Up")},
-      {key="k",       action=act.ActivatePaneDirection("Up")},
+      { key = 'UpArrow', action = act.ActivatePaneDirection 'Up' },
+      { key = 'k', action = act.ActivatePaneDirection 'Up' },
 
-      {key="DownArrow", action=act.ActivatePaneDirection("Down")},
-      {key="j",         action=act.ActivatePaneDirection("Down")},
+      { key = 'DownArrow', action = act.ActivatePaneDirection 'Down' },
+      { key = 'j', action = act.ActivatePaneDirection 'Down' },
     },
-
   },
 }
-
 ```
 
 ### Key Table Activation Stack

--- a/docs/config/keyboard-concepts.md
+++ b/docs/config/keyboard-concepts.md
@@ -108,8 +108,8 @@ You can control this behavior in your configuration:
 
 ```lua
 return {
-  send_composed_key_when_left_alt_is_pressed=false,
-  send_composed_key_when_right_alt_is_pressed=true,
+  send_composed_key_when_left_alt_is_pressed = false,
+  send_composed_key_when_right_alt_is_pressed = true,
 }
 ```
 
@@ -152,7 +152,7 @@ file:
 
 ```lua
 return {
-  use_dead_keys = false
+  use_dead_keys = false,
 }
 ```
 

--- a/docs/config/keys.md
+++ b/docs/config/keys.md
@@ -5,14 +5,14 @@ The default key table assignments can be overridden or extended using the
 disable a default assignment like this:
 
 ```lua
-local wezterm = require 'wezterm';
+local wezterm = require 'wezterm'
 
 return {
   keys = {
     -- Turn off the default CMD-m Hide action, allowing CMD-m to
     -- be potentially recognized and handled by the tab
-    {key="m", mods="CMD", action="DisableDefaultAssignment"}
-  }
+    { key = 'm', mods = 'CMD', action = 'DisableDefaultAssignment' },
+  },
 }
 ```
 
@@ -137,16 +137,24 @@ milliseconds).  While `LEADER` is active, the `|` key (with no other modifiers)
 will trigger the current pane to be split.
 
 ```lua
-local wezterm = require 'wezterm';
+local wezterm = require 'wezterm'
 
 return {
   -- timeout_milliseconds defaults to 1000 and can be omitted
-  leader = { key="a", mods="CTRL", timeout_milliseconds=1000 },
+  leader = { key = 'a', mods = 'CTRL', timeout_milliseconds = 1000 },
   keys = {
-    {key="|", mods="LEADER|SHIFT", action=wezterm.action.SplitHorizontal{domain="CurrentPaneDomain"}},
+    {
+      key = '|',
+      mods = 'LEADER|SHIFT',
+      action = wezterm.action.SplitHorizontal { domain = 'CurrentPaneDomain' },
+    },
     -- Send "CTRL-A" to the terminal when pressing CTRL-A, CTRL-A
-    {key="a", mods="LEADER|CTRL", action=wezterm.action.SendString("\x01")},
-  }
+    {
+      key = 'a',
+      mods = 'LEADER|CTRL',
+      action = wezterm.action.SendString '\x01',
+    },
+  },
 }
 ```
 
@@ -161,16 +169,24 @@ uses `CapsLock` as a `LEADER` without it affecting the shift / capital state as
 long as you have `setxkbmap -option caps:none` configured.
 
 ```lua
-local wezterm = require 'wezterm';
+local wezterm = require 'wezterm'
 
 return {
   -- timeout_milliseconds defaults to 1000 and can be omitted
   -- for this example use `setxkbmap -option caps:none` in your terminal.
-  leader = { key="VoidSymbol", mods="", timeout_milliseconds=1000 },
+  leader = { key = 'VoidSymbol', mods = '', timeout_milliseconds = 1000 },
   keys = {
-    {key="|", mods="LEADER|SHIFT", action=wezterm.action.SplitHorizontal{domain="CurrentPaneDomain"}},
-    {key="-", mods="LEADER", action=wezterm.action.SplitVertical{domain="CurrentPaneDomain"}},
-  }
+    {
+      key = '|',
+      mods = 'LEADER|SHIFT',
+      action = wezterm.action.SplitHorizontal { domain = 'CurrentPaneDomain' },
+    },
+    {
+      key = '-',
+      mods = 'LEADER',
+      action = wezterm.action.SplitVertical { domain = 'CurrentPaneDomain' },
+    },
+  },
 }
 ```
 

--- a/docs/config/launch.md
+++ b/docs/config/launch.md
@@ -37,7 +37,7 @@ portably:
 ```lua
 return {
   -- Spawn a fish shell in login mode
-  default_prog = {"/usr/local/bin/fish", "-l"},
+  default_prog = { '/usr/local/bin/fish', '-l' },
 }
 ```
 
@@ -110,7 +110,7 @@ return {
     -- This changes the default prompt for cmd.exe to report the
     -- current directory using OSC 7, show the current time and
     -- the current directory colored in the prompt.
-    prompt = "$E]7;file://localhost/$P$E\\$E[32m$T$E[0m $E[35m$P$E[36m$_$G$E[0m "
+    prompt = '$E]7;file://localhost/$P$E\\$E[32m$T$E[0m $E[35m$P$E[36m$_$G$E[0m ',
   },
 }
 ```
@@ -140,15 +140,15 @@ Each entry in `launch_menu` is an instance of a
 return {
   launch_menu = {
     {
-      args = {"top"},
+      args = { 'top' },
     },
     {
       -- Optional label to show in the launcher. If omitted, a label
       -- is derived from the `args`
-      label = "Bash",
+      label = 'Bash',
       -- The argument array to spawn.  If omitted the default program
       -- will be used as described in the documentation above
-      args = {"bash", "-l"},
+      args = { 'bash', '-l' },
 
       -- You can specify an alternative current working directory;
       -- if you don't specify one then a default based on the OSC 7
@@ -161,7 +161,7 @@ return {
       -- set_environment_variables configuration option described above
       -- set_environment_variables = { FOO = "bar" },
     },
-  }
+  },
 }
 ```
 
@@ -175,28 +175,39 @@ entries by default, unless disabled using `add_wsl_distributions_to_launch_menu 
 
 
 ```lua
-local wezterm = require 'wezterm';
+local wezterm = require 'wezterm'
 
 local launch_menu = {}
 
-if wezterm.target_triple == "x86_64-pc-windows-msvc" then
+if wezterm.target_triple == 'x86_64-pc-windows-msvc' then
   table.insert(launch_menu, {
-    label = "PowerShell",
-    args = {"powershell.exe", "-NoLogo"},
+    label = 'PowerShell',
+    args = { 'powershell.exe', '-NoLogo' },
   })
 
   -- Find installed visual studio version(s) and add their compilation
   -- environment command prompts to the menu
-  for _, vsvers in ipairs(wezterm.glob("Microsoft Visual Studio/20*", "C:/Program Files (x86)")) do
-    local year = vsvers:gsub("Microsoft Visual Studio/", "")
+  for _, vsvers in
+    ipairs(
+      wezterm.glob('Microsoft Visual Studio/20*', 'C:/Program Files (x86)')
+    )
+  do
+    local year = vsvers:gsub('Microsoft Visual Studio/', '')
     table.insert(launch_menu, {
-      label = "x64 Native Tools VS " .. year,
-      args = {"cmd.exe", "/k", "C:/Program Files (x86)/" .. vsvers .. "/BuildTools/VC/Auxiliary/Build/vcvars64.bat"},
+      label = 'x64 Native Tools VS ' .. year,
+      args = {
+        'cmd.exe',
+        '/k',
+        'C:/Program Files (x86)/'
+          .. vsvers
+          .. '/BuildTools/VC/Auxiliary/Build/vcvars64.bat',
+      },
     })
   end
 
   -- Enumerate any WSL distributions that are installed and add those to the menu
-  local success, wsl_list, wsl_err = wezterm.run_child_process({"wsl.exe", "-l"})
+  local success, wsl_list, wsl_err =
+    wezterm.run_child_process { 'wsl.exe', '-l' }
   -- `wsl.exe -l` has a bug where it always outputs utf16:
   -- https://github.com/microsoft/WSL/issues/4607
   -- So we get to convert it
@@ -207,20 +218,27 @@ if wezterm.target_triple == "x86_64-pc-windows-msvc" then
     if idx > 1 then
       -- Remove the "(Default)" marker from the default line to arrive
       -- at the distribution name on its own
-      local distro = line:gsub(" %(Default%)", "")
+      local distro = line:gsub(' %(Default%)', '')
 
       -- Add an entry that will spawn into the distro with the default shell
       table.insert(launch_menu, {
-        label = distro .. " (WSL default shell)",
-        args = {"wsl.exe", "--distribution", distro},
+        label = distro .. ' (WSL default shell)',
+        args = { 'wsl.exe', '--distribution', distro },
       })
 
       -- Here's how to jump directly into some other program; in this example
       -- its a shell that probably isn't the default, but it could also be
       -- any other program that you want to run in that environment
       table.insert(launch_menu, {
-        label = distro .. " (WSL zsh login shell)",
-        args = {"wsl.exe", "--distribution", distro, "--exec", "/bin/zsh", "-l"},
+        label = distro .. ' (WSL zsh login shell)',
+        args = {
+          'wsl.exe',
+          '--distribution',
+          distro,
+          '--exec',
+          '/bin/zsh',
+          '-l',
+        },
       })
     end
   end

--- a/docs/config/lua/ExecDomain.md
+++ b/docs/config/lua/ExecDomain.md
@@ -83,7 +83,7 @@ local wezterm = require 'wezterm'
 -- Given "/foo/bar" returns "bar"
 -- Given "c:\\foo\\bar" returns "bar"
 local function basename(s)
-  return string.gsub(s, "(.*[/\\])(.*)", "%2")
+  return string.gsub(s, '(.*[/\\])(.*)', '%2')
 end
 
 return {
@@ -93,7 +93,7 @@ return {
     -- This defines a strong boundary for resource control and can
     -- help to avoid OOMs in one pane causing other panes to be
     -- killed.
-    wezterm.exec_domain("scoped", function(cmd)
+    wezterm.exec_domain('scoped', function(cmd)
       -- The "cmd" parameter is a SpawnCommand object.
       -- You can log it to see what's inside:
       wezterm.log_info(cmd)
@@ -104,7 +104,10 @@ return {
       -- WEZTERM_UNIX_SOCKET is associated with the wezterm
       -- process id.
       local env = cmd.set_environment_variables
-      local ident = "wezterm-pane-" .. env.WEZTERM_PANE .. "-on-" .. basename(env.WEZTERM_UNIX_SOCKET)
+      local ident = 'wezterm-pane-'
+        .. env.WEZTERM_PANE
+        .. '-on-'
+        .. basename(env.WEZTERM_UNIX_SOCKET)
 
       -- Generate a new argument array that will launch a
       -- program via systemd-run
@@ -122,7 +125,7 @@ return {
       -- Note that cmd.args may be nil; that indicates that the
       -- default program should be used. Here we're using the
       -- shell defined by the SHELL environment variable.
-      for _, arg in ipairs(cmd.args or {os.getenv("SHELL")}) do
+      for _, arg in ipairs(cmd.args or { os.getenv 'SHELL' }) do
         table.insert(wrapped, arg)
       end
 
@@ -136,7 +139,7 @@ return {
 
   -- Making the domain the default means that every pane/tab/window
   -- spawned by wezterm will have its own scope
-  default_domain = "scoped",
+  default_domain = 'scoped',
 }
 ```
 
@@ -156,11 +159,11 @@ end
 
 function make_docker_fixup_func(id)
   return function(cmd)
-    cmd.args = cmd.args or {"/bin/bash"}
+    cmd.args = cmd.args or { '/bin/bash' }
     local wrapped = {
-      "docker",
-      "exec",
-      "-it",
+      'docker',
+      'exec',
+      '-it',
       id,
     }
     for _, arg in ipairs(cmd.args) do
@@ -178,17 +181,19 @@ function make_docker_label_func(id)
     -- whether it is running or stopped.
     -- If it stopped, you may wish to change the color to red
     -- to make it stand out
-    return wezterm.format{
-      {Foreground={AnsiColor="Red"}},
-      {Text="docker container named " .. name}
+    return wezterm.format {
+      { Foreground = { AnsiColor = 'Red' } },
+      { Text = 'docker container named ' .. name },
     }
   end
 end
 
 local exec_domains = {}
 for id, name in pairs(docker_list()) do
-  table.insert(exec_domains,
-    wezterm.exec_domain("docker: " .. name,
+  table.insert(
+    exec_domains,
+    wezterm.exec_domain(
+      'docker: ' .. name,
       make_docker_fixup_func(id),
       make_docker_label_func(id)
     )
@@ -196,7 +201,7 @@ for id, name in pairs(docker_list()) do
 end
 
 return {
-  exec_domains = exec_domains
+  exec_domains = exec_domains,
 }
 ```
 

--- a/docs/config/lua/MuxPane.md
+++ b/docs/config/lua/MuxPane.md
@@ -16,7 +16,7 @@ Splits `pane` and spawns a program into the split, returning the
 `MuxPane` object associated with it:
 
 ```lua
-local new_pane = pane:split{}
+local new_pane = pane:split {}
 ```
 
 When no arguments are passed, the pane is split in half left/right and the
@@ -30,7 +30,7 @@ Specifies the argument array for the command that should be spawned.
 If omitted the default program for the domain will be spawned.
 
 ```lua
-pane:split{args={"top"}}
+pane:split { args = { 'top' } }
 ```
 
 ### cwd
@@ -41,7 +41,7 @@ the program.
 If unspecified, follows the rules from [default_cwd](config/default_cwd.md)
 
 ```lua
-pane:split{cwd="/tmp"}
+pane:split { cwd = '/tmp' }
 ```
 
 ### set_environment_variables
@@ -63,13 +63,13 @@ You may specify the name of one of the multiplexer domains
 defined in your configuration using the following:
 
 ```lua
-pane:split{domain={DomainName="my.name"}}
+pane:split { domain = { DomainName = 'my.name' } }
 ```
 
 Or you may use the default domain:
 
 ```lua
-pane:split{domain="DefaultDomain"}
+pane:split { domain = 'DefaultDomain' }
 ```
 
 ### direction
@@ -82,7 +82,7 @@ Specifies where the new pane should be placed.  Possible values are:
 * `"Bottom"` - splits the pane top/bottom and places the new pane on the bottom.
 
 ```lua
-pane:split{direction="Top"}
+pane:split { direction = 'Top' }
 ```
 
 ### top_level
@@ -91,7 +91,7 @@ If `true`, rather than splitting `pane` in half, the tab that contains it
 is split and the new pane runs the full extent of the tab dimensions.
 
 ```lua
-pane:split{direction="Bottom", top_level=true}
+pane:split { direction = 'Bottom', top_level = true }
 ```
 
 ### size
@@ -110,8 +110,8 @@ This creates two additional splits within `pane`, creating three
 total splits that each occupy 1/3 of the available space:
 
 ```lua
-pane:split{direction="Top", size=0.333}
-pane:split{direction="Top", size=0.5}
+pane:split { direction = 'Top', size = 0.333 }
+pane:split { direction = 'Top', size = 0.5 }
 ```
 
 ## `pane:send_paste(text)`

--- a/docs/config/lua/MuxTab.md
+++ b/docs/config/lua/MuxTab.md
@@ -24,7 +24,7 @@ Returns the tab title as set by `tab:set_title()`.
 Sets the tab title to the provided string.
 
 ```lua
-tab:set_title("my title")
+tab:set_title 'my title'
 ```
 
 ## tab:window()

--- a/docs/config/lua/PaneInformation.md
+++ b/docs/config/lua/PaneInformation.md
@@ -39,24 +39,28 @@ local wezterm = require 'wezterm'
 -- Given "/foo/bar" returns "bar"
 -- Given "c:\\foo\\bar" returns "bar"
 function basename(s)
-  return string.gsub(s, "(.*[/\\])(.*)", "%2")
+  return string.gsub(s, '(.*[/\\])(.*)', '%2')
 end
 
-wezterm.on("format-tab-title", function(tab, tabs, panes, config, hover, max_width)
-  local pane = tab.active_pane
-  local title = basename(pane.foreground_process_name) .. " " .. pane.pane_id
-  local color = "navy"
-  if tab.is_active then
-    color = "blue"
+wezterm.on(
+  'format-tab-title',
+  function(tab, tabs, panes, config, hover, max_width)
+    local pane = tab.active_pane
+    local title = basename(pane.foreground_process_name)
+      .. ' '
+      .. pane.pane_id
+    local color = 'navy'
+    if tab.is_active then
+      color = 'blue'
+    end
+    return {
+      { Background = { Color = color } },
+      { Text = ' ' .. title .. ' ' },
+    }
   end
-  return {
-    {Background={Color=color}},
-    {Text=" " .. title .. " "},
-  }
-end)
+)
 
-return {
-}
+return {}
 ```
 
 *Since: 20220319-142410-0fcdea07*
@@ -70,31 +74,33 @@ tab in the tab bar when there is unseen output.
 ```lua
 local wezterm = require 'wezterm'
 
-wezterm.on("format-tab-title", function(tab, tabs, panes, config, hover, max_width)
-  if tab.is_active then
-    return {
-      {Background={Color="blue"}},
-      {Text=" " .. tab.active_pane.title .. " "},
-    }
-  end
-  local has_unseen_output = false
-  for _, pane in ipairs(tab.panes) do
-    if pane.has_unseen_output then
-      has_unseen_output = true
-      break;
+wezterm.on(
+  'format-tab-title',
+  function(tab, tabs, panes, config, hover, max_width)
+    if tab.is_active then
+      return {
+        { Background = { Color = 'blue' } },
+        { Text = ' ' .. tab.active_pane.title .. ' ' },
+      }
     end
+    local has_unseen_output = false
+    for _, pane in ipairs(tab.panes) do
+      if pane.has_unseen_output then
+        has_unseen_output = true
+        break
+      end
+    end
+    if has_unseen_output then
+      return {
+        { Background = { Color = 'Orange' } },
+        { Text = ' ' .. tab.active_pane.title .. ' ' },
+      }
+    end
+    return tab.active_pane.title
   end
-  if has_unseen_output then
-    return {
-      {Background={Color="Orange"}},
-      {Text=" " .. tab.active_pane.title .. " "},
-    }
-  end
-  return tab.active_pane.title
-end)
+)
 
-return {
-}
+return {}
 ```
 
 *Since: 20220624-141144-bd1b7c5d*
@@ -115,7 +121,6 @@ wezterm.on('format-tab-title', function(tab)
   return title
 end)
 
-return {
-}
+return {}
 ```
 

--- a/docs/config/lua/SshDomain.md
+++ b/docs/config/lua/SshDomain.md
@@ -44,13 +44,13 @@ You may now specify a table with ssh config overrides:
 return {
   ssh_domains = {
     {
-      name = "my.server",
-      remote_address = "192.168.1.1",
+      name = 'my.server',
+      remote_address = '192.168.1.1',
       ssh_option = {
-        identityfile = "/path/to/id_rsa.pub",
-      }
-    }
-  }
+        identityfile = '/path/to/id_rsa.pub',
+      },
+    },
+  },
 }
 ```
 
@@ -84,27 +84,27 @@ panes and tabs.  The following values are recognized for `assume_shell`:
 return {
   ssh_domains = {
     {
-      name = "my.server",
-      remote_address = "192.168.1.1",
-      multiplexing = "None",
+      name = 'my.server',
+      remote_address = '192.168.1.1',
+      multiplexing = 'None',
 
       -- When multiplexing == "None", default_prog can be used
       -- to specify the default program to run in new tabs/panes.
       -- Due to the way that ssh works, you cannot specify default_cwd,
       -- but you could instead change your default_prog to put you
       -- in a specific directory.
-      default_prog = {"fish"},
+      default_prog = { 'fish' },
 
       -- assume that we can use syntax like:
       -- "env -C /some/where $SHELL"
       -- using whatever the default command shell is on this
       -- remote host, so that shell integration will respect
       -- the current directory on the remote host.
-      assume_shell = "Posix",
-    }
+      assume_shell = 'Posix',
+    },
   },
 
-  default_domain = "my.server",
+  default_domain = 'my.server',
 }
 ```
 
@@ -119,10 +119,10 @@ user. This option only applies when `multiplexing = "WezTerm"`.
 return {
   ssh_domains = {
     {
-      name = "my.server",
-      remote_address = "192.168.1.1",
+      name = 'my.server',
+      remote_address = '192.168.1.1',
       local_echo_threshold_ms = 10,
-    }
+    },
   },
 }
 ```

--- a/docs/config/lua/TlsDomainClient.md
+++ b/docs/config/lua/TlsDomainClient.md
@@ -79,11 +79,11 @@ user. This option only applies when `multiplexing = "WezTerm"`.
 return {
   tls_domains = {
     {
-      name = "server,name",
-      bootstrap_via_ssh = "server.hostname",
-      remote_address = "server.hostname:8080",
+      name = 'server,name',
+      bootstrap_via_ssh = 'server.hostname',
+      remote_address = 'server.hostname:8080',
       local_echo_threshold_ms = 10,
-    }
+    },
   },
 }
 ```

--- a/docs/config/lua/config/animation_fps.md
+++ b/docs/config/lua/config/animation_fps.md
@@ -16,8 +16,8 @@ transitions:
 ```lua
 return {
   animation_fps = 1,
-  cursor_blink_ease_in = "Constant",
-  cursor_blink_ease_out = "Constant",
+  cursor_blink_ease_in = 'Constant',
+  cursor_blink_ease_out = 'Constant',
 }
 ```
 

--- a/docs/config/lua/config/automatically_reload_config.md
+++ b/docs/config/lua/config/automatically_reload_config.md
@@ -11,6 +11,6 @@ For example, to disable auto config reload:
 
 ```lua
 return {
-  automatically_reload_config = false
+  automatically_reload_config = false,
 }
 ```

--- a/docs/config/lua/config/background.md
+++ b/docs/config/lua/config/background.md
@@ -102,75 +102,85 @@ The video at the top of this page demonstrate this configuration in action.
 ```lua
 -- The art is a bit too bright and colorful to be useful as a backdrop
 -- for text, so we're going to dim it down to 10% of its normal brightness
-local dimmer = {brightness=0.1}
+local dimmer = { brightness = 0.1 }
 
 return {
   enable_scroll_bar = true,
-  min_scroll_bar_height = "2cell",
+  min_scroll_bar_height = '2cell',
   colors = {
-    scrollbar_thumb = "white",
+    scrollbar_thumb = 'white',
   },
   background = {
     -- This is the deepest/back-most layer. It will be rendered first
     {
-      source = {File="/Alien_Ship_bg_vert_images/Backgrounds/spaceship_bg_1.png"},
+      source = {
+        File = '/Alien_Ship_bg_vert_images/Backgrounds/spaceship_bg_1.png',
+      },
       -- The texture tiles vertically but not horizontally.
       -- When we repeat it, mirror it so that it appears "more seamless".
       -- An alternative to this is to set `width = "100%"` and have
       -- it stretch across the display
-      repeat_x = "Mirror",
+      repeat_x = 'Mirror',
       hsb = dimmer,
       -- When the viewport scrolls, move this layer 10% of the number of
       -- pixels moved by the main viewport. This makes it appear to be
       -- further behind the text.
-      attachment = {Parallax=0.1},
+      attachment = { Parallax = 0.1 },
     },
     -- Subsequent layers are rendered over the top of each other
     {
-      source = {File="/Alien_Ship_bg_vert_images/Overlays/overlay_1_spines.png"},
-      width = "100%",
-      repeat_x = "NoRepeat",
+      source = {
+        File = '/Alien_Ship_bg_vert_images/Overlays/overlay_1_spines.png',
+      },
+      width = '100%',
+      repeat_x = 'NoRepeat',
 
       -- position the spins starting at the bottom, and repeating every
       -- two screens.
-      vertical_align = "Bottom",
-      repeat_y_size = "200%",
+      vertical_align = 'Bottom',
+      repeat_y_size = '200%',
       hsb = dimmer,
 
       -- The parallax factor is higher than the background layer, so this
       -- one will appear to be closer when we scroll
-      attachment = {Parallax=0.2},
+      attachment = { Parallax = 0.2 },
     },
     {
-      source = {File="/Alien_Ship_bg_vert_images/Overlays/overlay_2_alienball.png"},
-      width = "100%",
-      repeat_x = "NoRepeat",
+      source = {
+        File = '/Alien_Ship_bg_vert_images/Overlays/overlay_2_alienball.png',
+      },
+      width = '100%',
+      repeat_x = 'NoRepeat',
 
       -- start at 10% of the screen and repeat every 2 screens
-      vertical_offset = "10%",
-      repeat_y_size = "200%",
+      vertical_offset = '10%',
+      repeat_y_size = '200%',
       hsb = dimmer,
-      attachment = {Parallax=0.3},
+      attachment = { Parallax = 0.3 },
     },
     {
-      source = {File="/Alien_Ship_bg_vert_images/Overlays/overlay_3_lobster.png"},
-      width = "100%",
-      repeat_x = "NoRepeat",
+      source = {
+        File = '/Alien_Ship_bg_vert_images/Overlays/overlay_3_lobster.png',
+      },
+      width = '100%',
+      repeat_x = 'NoRepeat',
 
-      vertical_offset = "30%",
-      repeat_y_size = "200%",
+      vertical_offset = '30%',
+      repeat_y_size = '200%',
       hsb = dimmer,
-      attachment = {Parallax=0.4},
+      attachment = { Parallax = 0.4 },
     },
     {
-      source = {File="/Alien_Ship_bg_vert_images/Overlays/overlay_4_spiderlegs.png"},
-      width = "100%",
-      repeat_x = "NoRepeat",
+      source = {
+        File = '/Alien_Ship_bg_vert_images/Overlays/overlay_4_spiderlegs.png',
+      },
+      width = '100%',
+      repeat_x = 'NoRepeat',
 
-      vertical_offset = "50%",
-      repeat_y_size = "150%",
+      vertical_offset = '50%',
+      repeat_y_size = '150%',
       hsb = dimmer,
-      attachment = {Parallax=0.5},
+      attachment = { Parallax = 0.5 },
     },
   },
 }

--- a/docs/config/lua/config/bypass_mouse_reporting_modifiers.md
+++ b/docs/config/lua/config/bypass_mouse_reporting_modifiers.md
@@ -18,6 +18,6 @@ assignments.
 ```lua
 return {
   -- Use ALT instead of SHIFT to bypass application mouse reporting
-  bypass_mouse_reporting_modifiers = "ALT"
+  bypass_mouse_reporting_modifiers = 'ALT',
 }
 ```

--- a/docs/config/lua/config/clean_exit_codes.md
+++ b/docs/config/lua/config/clean_exit_codes.md
@@ -16,7 +16,7 @@ to set this config to treat `130` as OK:
 
 ```lua
 return {
-  clean_exit_codes = {130},
+  clean_exit_codes = { 130 },
 }
 ```
 

--- a/docs/config/lua/config/daemon_options.md
+++ b/docs/config/lua/config/daemon_options.md
@@ -14,9 +14,9 @@ There are three fields supported:
 ```lua
 return {
   daemon_options = {
-    stdout = "/some/where/stdout",
-    stderr = "/some/where/stderr",
-    pid_file = "/some/where/pid_file",
-  }
+    stdout = '/some/where/stdout',
+    stderr = '/some/where/stderr',
+    pid_file = '/some/where/pid_file',
+  },
 }
 ```

--- a/docs/config/lua/config/default_cursor_style.md
+++ b/docs/config/lua/config/default_cursor_style.md
@@ -12,7 +12,7 @@ and `BlinkingBar`.
 
 ```lua
 return {
-  default_cursor_style = "SteadyBlock",
+  default_cursor_style = 'SteadyBlock',
 }
 ```
 

--- a/docs/config/lua/config/default_domain.md
+++ b/docs/config/lua/config/default_domain.md
@@ -28,7 +28,7 @@ and if I set my config like this:
 
 ```lua
 return {
-  default_domain = "WSL:Ubuntu-18.04",
+  default_domain = 'WSL:Ubuntu-18.04',
 }
 ```
 

--- a/docs/config/lua/config/default_gui_startup_args.md
+++ b/docs/config/lua/config/default_gui_startup_args.md
@@ -14,7 +14,7 @@ particular host, then you might consider using this configuration:
 
 ```lua
 return {
-  default_gui_startup_args = {"ssh", "some-host"},
+  default_gui_startup_args = { 'ssh', 'some-host' },
 }
 ```
 

--- a/docs/config/lua/config/default_prog.md
+++ b/docs/config/lua/config/default_prog.md
@@ -8,7 +8,7 @@ you'd use this:
 
 ```lua
 return {
-  default_prog = {"top"}
+  default_prog = { 'top' },
 }
 ```
 

--- a/docs/config/lua/config/exit_behavior.md
+++ b/docs/config/lua/config/exit_behavior.md
@@ -11,7 +11,7 @@ There are three possible values:
 
 ```lua
 return {
-  exit_behavior = "Hold",
+  exit_behavior = 'Hold',
 }
 ```
 

--- a/docs/config/lua/config/font_dirs.md
+++ b/docs/config/lua/config/font_dirs.md
@@ -11,7 +11,7 @@ return {
   -- `fonts` that is found alongside your `wezterm.lua` file.
   -- As this option is an array, you may list multiple locations if
   -- you wish.
-  font_dirs = {"fonts"},
+  font_dirs = { 'fonts' },
 }
 ```
 

--- a/docs/config/lua/config/font_rules.md
+++ b/docs/config/lua/config/font_rules.md
@@ -10,7 +10,7 @@ If you do specify `font_rules`, they are applied in the order that they are
 specified in the configuration file, stopping with the first matching rule:
 
 ```lua
-local wezterm = require 'wezterm';
+local wezterm = require 'wezterm'
 return {
   font_rules = {
     -- Define a rule that matches when italic text is shown
@@ -39,49 +39,52 @@ return {
       -- invisible = false,
 
       -- When the above attributes match, apply this font styling
-      font = wezterm.font("Operator Mono SSm Lig Medium", {italic=true}),
-    }
-  }
+      font = wezterm.font('Operator Mono SSm Lig Medium', { italic = true }),
+    },
+  },
 }
 ```
 
 Here's an example from my configuration file;
 
 ```lua
-local wezterm = require 'wezterm';
+local wezterm = require 'wezterm'
 
 -- A helper function for my fallback fonts
 function font_with_fallback(name, params)
-  local names = {name, "Noto Color Emoji", "JetBrains Mono"}
+  local names = { name, 'Noto Color Emoji', 'JetBrains Mono' }
   return wezterm.font_with_fallback(names, params)
 end
 
 return {
-  font = font_with_fallback("Operator Mono SSm Lig Medium"),
-  font_rules= {
+  font = font_with_fallback 'Operator Mono SSm Lig Medium',
+  font_rules = {
     -- Select a fancy italic font for italic text
     {
       italic = true,
-      font = font_with_fallback("Operator Mono SSm Lig Medium Italic"),
+      font = font_with_fallback 'Operator Mono SSm Lig Medium Italic',
     },
 
     -- Similarly, a fancy bold+italic font
     {
       italic = true,
-      intensity = "Bold",
-      font = font_with_fallback("Operator Mono SSm Lig Book Italic"),
+      intensity = 'Bold',
+      font = font_with_fallback 'Operator Mono SSm Lig Book Italic',
     },
 
     -- Make regular bold text a different color to make it stand out even more
     {
-      intensity = "Bold",
-      font = font_with_fallback("Operator Mono SSm Lig Bold", {foreground = "tomato"}),
+      intensity = 'Bold',
+      font = font_with_fallback(
+        'Operator Mono SSm Lig Bold',
+        { foreground = 'tomato' }
+      ),
     },
 
     -- For half-intensity text, use a lighter weight font
     {
-      intensity = "Half",
-      font = font_with_fallback("Operator Mono SSm Lig Light"),
+      intensity = 'Half',
+      font = font_with_fallback 'Operator Mono SSm Lig Light',
     },
   },
 }

--- a/docs/config/lua/config/foreground_text_hsb.md
+++ b/docs/config/lua/config/foreground_text_hsb.md
@@ -29,7 +29,7 @@ return {
     hue = 1.0,
     saturation = 1.5,
     brightness = 1.0,
-  }
+  },
 }
 ```
 

--- a/docs/config/lua/config/freetype_load_flags.md
+++ b/docs/config/lua/config/freetype_load_flags.md
@@ -24,7 +24,7 @@ Available flags are:
 return {
   -- You probably don't want to do this, but this demonstrates
   -- that the flags can be combined
-  freetype_load_flags = "NO_HINTING|MONOCHROME"
+  freetype_load_flags = 'NO_HINTING|MONOCHROME',
 }
 ```
 

--- a/docs/config/lua/config/freetype_render_target.md
+++ b/docs/config/lua/config/freetype_render_target.md
@@ -14,8 +14,8 @@ subpixel-antialiased glyph bitmaps:
 
 ```lua
 return {
-  freetype_load_target = "Light",
-  freetype_render_target = "HorizontalLcd",
+  freetype_load_target = 'Light',
+  freetype_render_target = 'HorizontalLcd',
 }
 ```
 

--- a/docs/config/lua/config/ime_preedit_rendering.md
+++ b/docs/config/lua/config/ime_preedit_rendering.md
@@ -26,7 +26,7 @@ You can control IME preedit rendering in your configuraiton file:
 
 ```lua
 return {
-  ime_preedit_rendering = "System",
+  ime_preedit_rendering = 'System',
 }
 ```
 

--- a/docs/config/lua/config/launch_menu.md
+++ b/docs/config/lua/config/launch_menu.md
@@ -14,15 +14,15 @@ Each entry in `launch_menu` is an instance of a
 return {
   launch_menu = {
     {
-      args = {"top"},
+      args = { 'top' },
     },
     {
       -- Optional label to show in the launcher. If omitted, a label
       -- is derived from the `args`
-      label = "Bash",
+      label = 'Bash',
       -- The argument array to spawn.  If omitted the default program
       -- will be used as described in the documentation above
-      args = {"bash", "-l"},
+      args = { 'bash', '-l' },
 
       -- You can specify an alternative current working directory;
       -- if you don't specify one then a default based on the OSC 7
@@ -35,7 +35,7 @@ return {
       -- set_environment_variables configuration option described above
       -- set_environment_variables = { FOO = "bar" },
     },
-  }
+  },
 }
 ```
 

--- a/docs/config/lua/config/mux_env_remove.md
+++ b/docs/config/lua/config/mux_env_remove.md
@@ -14,9 +14,9 @@ The default value for this is:
 ```lua
 return {
   mux_env_remove = {
-    "SSH_AUTH_SOCK",
-    "SSH_CLIENT",
-    "SSH_CONNECTION",
-  }
+    'SSH_AUTH_SOCK',
+    'SSH_CLIENT',
+    'SSH_CONNECTION',
+  },
 }
 ```

--- a/docs/config/lua/config/quick_select_patterns.md
+++ b/docs/config/lua/config/quick_select_patterns.md
@@ -10,8 +10,8 @@ return {
   quick_select_patterns = {
     -- match things that look like sha1 hashes
     -- (this is actually one of the default patterns)
-    "[0-9a-f]{7,40}",
-  }
+    '[0-9a-f]{7,40}',
+  },
 }
 ```
 

--- a/docs/config/lua/config/selection_word_boundary.md
+++ b/docs/config/lua/config/selection_word_boundary.md
@@ -11,6 +11,6 @@ Defaults to ``" \t\n{}[]()\"'`"``.
 For example, to always include spaces and newline when selecting a word, but stop on punctuations:
 ```lua
 return {
-  selection_word_boundary = "{}[]()\"'`.,;:"
+  selection_word_boundary = '{}[]()"\'`.,;:',
 }
 ```

--- a/docs/config/lua/config/skip_close_confirmation_for_processes_named.md
+++ b/docs/config/lua/config/skip_close_confirmation_for_processes_named.md
@@ -17,8 +17,12 @@ The default value for this setting is shown below:
 ```lua
 return {
   skip_close_confirmation_for_processes_named = {
-    "bash", "sh", "zsh", "fish", "tmux"
-  }
+    'bash',
+    'sh',
+    'zsh',
+    'fish',
+    'tmux',
+  },
 }
 ```
 
@@ -31,16 +35,16 @@ processes:
 ```lua
 return {
   skip_close_confirmation_for_processes_named = {
-        "bash",
-        "sh",
-        "zsh",
-        "fish",
-        "tmux",
-        "nu",
-        "cmd.exe",
-        "pwsh.exe",
-        "powershell.exe"
-  }
+    'bash',
+    'sh',
+    'zsh',
+    'fish',
+    'tmux',
+    'nu',
+    'cmd.exe',
+    'pwsh.exe',
+    'powershell.exe',
+  },
 }
 ```
 

--- a/docs/config/lua/config/tab_bar_style.md
+++ b/docs/config/lua/config/tab_bar_style.md
@@ -39,7 +39,7 @@ This example changes the tab edges to the PowerLine arrow symbols:
   alt="Demonstrating setting the styling of the left and right tab edges">
 
 ```lua
-local wezterm = require 'wezterm';
+local wezterm = require 'wezterm'
 
 -- The filled in variant of the < symbol
 local SOLID_LEFT_ARROW = utf8.char(0xe0b2)
@@ -49,27 +49,27 @@ local SOLID_RIGHT_ARROW = utf8.char(0xe0b0)
 
 return {
   tab_bar_style = {
-    active_tab_left = wezterm.format({
-      {Background={Color="#0b0022"}},
-      {Foreground={Color="#2b2042"}},
-      {Text=SOLID_LEFT_ARROW},
-    }),
-    active_tab_right = wezterm.format({
-      {Background={Color="#0b0022"}},
-      {Foreground={Color="#2b2042"}},
-      {Text=SOLID_RIGHT_ARROW},
-    }),
-    inactive_tab_left = wezterm.format({
-      {Background={Color="#0b0022"}},
-      {Foreground={Color="#1b1032"}},
-      {Text=SOLID_LEFT_ARROW},
-    }),
-    inactive_tab_right = wezterm.format({
-      {Background={Color="#0b0022"}},
-      {Foreground={Color="#1b1032"}},
-      {Text=SOLID_RIGHT_ARROW},
-    }),
-  }
+    active_tab_left = wezterm.format {
+      { Background = { Color = '#0b0022' } },
+      { Foreground = { Color = '#2b2042' } },
+      { Text = SOLID_LEFT_ARROW },
+    },
+    active_tab_right = wezterm.format {
+      { Background = { Color = '#0b0022' } },
+      { Foreground = { Color = '#2b2042' } },
+      { Text = SOLID_RIGHT_ARROW },
+    },
+    inactive_tab_left = wezterm.format {
+      { Background = { Color = '#0b0022' } },
+      { Foreground = { Color = '#1b1032' } },
+      { Text = SOLID_LEFT_ARROW },
+    },
+    inactive_tab_right = wezterm.format {
+      { Background = { Color = '#0b0022' } },
+      { Foreground = { Color = '#1b1032' } },
+      { Text = SOLID_RIGHT_ARROW },
+    },
+  },
 }
 ```
 

--- a/docs/config/lua/config/text_blink_rate.md
+++ b/docs/config/lua/config/text_blink_rate.md
@@ -10,7 +10,7 @@ interval specified with some degree of slop.
 
 ```lua
 return {
-  text_blink_rate = 500
+  text_blink_rate = 500,
 }
 ```
 

--- a/docs/config/lua/config/text_blink_rate_rapid.md
+++ b/docs/config/lua/config/text_blink_rate_rapid.md
@@ -10,7 +10,7 @@ interval specified with some degree of slop.
 
 ```lua
 return {
-  text_blink_rate_rapid = 250
+  text_blink_rate_rapid = 250,
 }
 ```
 

--- a/docs/config/lua/config/treat_left_ctrlalt_as_altgr.md
+++ b/docs/config/lua/config/treat_left_ctrlalt_as_altgr.md
@@ -12,6 +12,6 @@ bindings using separate Ctrl and Alt won't be triggered anymore.
 
 ```lua
 return {
-  treat_left_ctrlalt_as_altgr = true
+  treat_left_ctrlalt_as_altgr = true,
 }
 ```

--- a/docs/config/lua/config/visual_bell.md
+++ b/docs/config/lua/config/visual_bell.md
@@ -34,13 +34,13 @@ The following configuration enables a low intensity visual bell that takes a tot
 ```lua
 return {
   visual_bell = {
-    fade_in_function = "EaseIn",
+    fade_in_function = 'EaseIn',
     fade_in_duration_ms = 150,
-    fade_out_function = "EaseOut",
+    fade_out_function = 'EaseOut',
     fade_out_duration_ms = 150,
   },
   colors = {
-    visual_bell = "#202020"
+    visual_bell = '#202020',
   },
 }
 ```
@@ -52,7 +52,7 @@ return {
   visual_bell = {
     fade_in_duration_ms = 75,
     fade_out_duration_ms = 75,
-    target = "CursorColor",
+    target = 'CursorColor',
   },
 }
 ```

--- a/docs/config/lua/config/window_background_gradient.md
+++ b/docs/config/lua/config/window_background_gradient.md
@@ -16,15 +16,15 @@ return {
     -- with the gradient going from left-to-right.
     -- Linear and Radial gradients are also supported; see the other
     -- examples below
-    orientation = "Vertical",
+    orientation = 'Vertical',
 
     -- Specifies the set of colors that are interpolated in the gradient.
     -- Accepts CSS style color specs, from named colors, through rgb
     -- strings and more
     colors = {
-      "#0f0c29",
-      "#302b63",
-      "#24243e"
+      '#0f0c29',
+      '#302b63',
+      '#24243e',
     },
 
     -- Instead of specifying `colors`, you can use one of a number of
@@ -35,12 +35,12 @@ return {
     -- Specifies the interpolation style to be used.
     -- "Linear", "Basis" and "CatmullRom" as supported.
     -- The default is "Linear".
-    interpolation = "Linear",
+    interpolation = 'Linear',
 
     -- How the colors are blended in the gradient.
     -- "Rgb", "LinearRgb", "Hsv" and "Oklab" are supported.
     -- The default is "Rgb".
-    blend = "Rgb",
+    blend = 'Rgb',
 
     -- To avoid vertical color banding for horizontal gradients, the
     -- gradient position is randomly shifted by up to the `noise` value
@@ -88,10 +88,10 @@ that is moving from the top left corner down to the bottom right corner.
 ```lua
 return {
   window_background_gradient = {
-    colors = { "#EEBD89", "#D13ABD" },
+    colors = { '#EEBD89', '#D13ABD' },
     -- Specifices a Linear gradient starting in the top left corner.
     orientation = { Linear = { angle = -45.0 } },
-  }
+  },
 }
 ```
 
@@ -104,30 +104,30 @@ subsequently stretched to fill the dimensions of the window.
 
 ```lua
 return {
-  color_scheme = "Github",
+  color_scheme = 'Github',
   window_background_gradient = {
-     colors = {"deeppink", "gold"},
-     orientation = {
-       Radial={
-         -- Specifies the x coordinate of the center of the circle,
-         -- in the range 0.0 through 1.0.  The default is 0.5 which
-         -- is centered in the X dimension.
-         cx = 0.75,
+    colors = { 'deeppink', 'gold' },
+    orientation = {
+      Radial = {
+        -- Specifies the x coordinate of the center of the circle,
+        -- in the range 0.0 through 1.0.  The default is 0.5 which
+        -- is centered in the X dimension.
+        cx = 0.75,
 
-         -- Specifies the y coordinate of the center of the circle,
-         -- in the range 0.0 through 1.0.  The default is 0.5 which
-         -- is centered in the Y dimension.
-         cy = 0.75,
+        -- Specifies the y coordinate of the center of the circle,
+        -- in the range 0.0 through 1.0.  The default is 0.5 which
+        -- is centered in the Y dimension.
+        cy = 0.75,
 
-         -- Specifies the radius of the notional circle.
-         -- The default is 0.5, which combined with the default cx
-         -- and cy values places the circle in the center of the
-         -- window, with the edges touching the window edges.
-         -- Values larger than 1 are possible.
-         radius = 1.25,
-       }
-     },
-  }
+        -- Specifies the radius of the notional circle.
+        -- The default is 0.5, which combined with the default cx
+        -- and cy values places the circle in the center of the
+        -- window, with the edges touching the window edges.
+        -- Values larger than 1 are possible.
+        radius = 1.25,
+      },
+    },
+  },
 }
 ```
 

--- a/docs/config/lua/config/window_close_confirmation.md
+++ b/docs/config/lua/config/window_close_confirmation.md
@@ -9,7 +9,7 @@ windows every time.
 
 ```lua
 return {
-  window_close_confirmation = "AlwaysPrompt",
+  window_close_confirmation = 'AlwaysPrompt',
 }
 ```
 

--- a/docs/config/lua/config/window_frame.md
+++ b/docs/config/lua/config/window_frame.md
@@ -9,16 +9,16 @@ It allows you to customize the colors of the window frame.
 ```lua
 return {
   window_frame = {
-    inactive_titlebar_bg = "#353535",
-    active_titlebar_bg = "#2b2042",
-    inactive_titlebar_fg = "#cccccc",
-    active_titlebar_fg = "#ffffff",
-    inactive_titlebar_border_bottom = "#2b2042",
-    active_titlebar_border_bottom = "#2b2042",
-    button_fg = "#cccccc",
-    button_bg = "#2b2042",
-    button_hover_fg = "#ffffff",
-    button_hover_bg = "#3b3052",
-  }
+    inactive_titlebar_bg = '#353535',
+    active_titlebar_bg = '#2b2042',
+    inactive_titlebar_fg = '#cccccc',
+    active_titlebar_fg = '#ffffff',
+    inactive_titlebar_border_bottom = '#2b2042',
+    active_titlebar_border_bottom = '#2b2042',
+    button_fg = '#cccccc',
+    button_bg = '#2b2042',
+    button_hover_fg = '#ffffff',
+    button_hover_bg = '#3b3052',
+  },
 }
 ```

--- a/docs/config/lua/config/window_padding.md
+++ b/docs/config/lua/config/window_padding.md
@@ -17,7 +17,7 @@ return {
     right = 2,
     top = 0,
     bottom = 0,
-  }
+  },
 }
 ```
 
@@ -38,11 +38,11 @@ The default padding is shown below.  In earlier releases, the default padding wa
 ```lua
 return {
   window_padding = {
-    left = "1cell",
-    right = "1cell",
-    top = "0.5cell",
-    bottom = "0.5cell",
-  }
+    left = '1cell',
+    right = '1cell',
+    top = '0.5cell',
+    bottom = '0.5cell',
+  },
 }
 ```
 

--- a/docs/config/lua/config/xim_im_name.md
+++ b/docs/config/lua/config/xim_im_name.md
@@ -14,7 +14,7 @@ update your config to specify it explicitly:
 
 ```lua
 return {
-  xim_im_name = "fcitx",
+  xim_im_name = 'fcitx',
 }
 ```
 

--- a/docs/config/lua/general.md
+++ b/docs/config/lua/general.md
@@ -5,9 +5,9 @@ the configuration file.  These are provided by the `wezterm` module that must
 be imported into your configuration file:
 
 ```lua
-local wezterm = require 'wezterm';
+local wezterm = require 'wezterm'
 return {
-  font = wezterm.font("JetBrains Mono"),
+  font = wezterm.font 'JetBrains Mono',
 }
 ```
 
@@ -29,7 +29,7 @@ you would place it in `~/.config/wezterm/helpers.lua` with contents like this:
 ```lua
 -- I am helpers.lua and I should live in ~/.config/wezterm/helpers.lua
 
-local wezterm = require 'wezterm';
+local wezterm = require 'wezterm'
 
 -- This is the module table that we will export
 local module = {}
@@ -37,7 +37,7 @@ local module = {}
 -- This function is private to this module and is not visible
 -- outside.
 local function private_helper()
-  wezterm.log_error("hello!")
+  wezterm.log_error 'hello!'
 end
 
 -- define a function in the module table.
@@ -55,6 +55,6 @@ and then in your `wezterm.lua`
 you would use it like this:
 
 ```lua
-local helpers = require 'helpers';
+local helpers = require 'helpers'
 helpers.my_function()
 ```

--- a/docs/config/lua/gui-events/gui-startup.md
+++ b/docs/config/lua/gui-events/gui-startup.md
@@ -21,14 +21,14 @@ This basic example splits an initial window into thirds:
 local wezterm = require 'wezterm'
 local mux = wezterm.mux
 
-wezterm.on("gui-startup", function()
-  local tab, pane, window = mux.spawn_window{}
+wezterm.on('gui-startup', function()
+  local tab, pane, window = mux.spawn_window {}
   -- Create a split occupying the right 1/3 of the screen
-  pane:split{size=0.3}
+  pane:split { size = 0.3 }
   -- Create another split in the right of the remaining 2/3
   -- of the space; the resultant split is in the middle
   -- 1/3 of the display and has the focus.
-  pane:split{size=0.5}
+  pane:split { size = 0.5 }
 end)
 
 return {}
@@ -40,8 +40,8 @@ This example creates a default window but makes it maximize on startup:
 local wezterm = require 'wezterm'
 local mux = wezterm.mux
 
-wezterm.on("gui-startup", function()
-  local tab, pane, window = mux.spawn_window{}
+wezterm.on('gui-startup', function()
+  local tab, pane, window = mux.spawn_window {}
   window:gui_window():maximize()
 end)
 
@@ -54,31 +54,31 @@ Here's a more elaborate example that configures two workspaces:
 local wezterm = require 'wezterm'
 local mux = wezterm.mux
 
-wezterm.on("gui-startup", function()
+wezterm.on('gui-startup', function()
   -- Set a workspace for coding on a current project
   -- Top pane is for the editor, bottom pane is for the build tool
-  local project_dir = wezterm.home_dir .. "/wezterm"
-  local tab, build_pane, window = mux.spawn_window{
-    workspace="coding",
-    cwd=project_dir,
+  local project_dir = wezterm.home_dir .. '/wezterm'
+  local tab, build_pane, window = mux.spawn_window {
+    workspace = 'coding',
+    cwd = project_dir,
   }
-  local editor_pane = build_pane:split{
-    direction="Top",
-    size=0.6,
-    cwd=project_dir
+  local editor_pane = build_pane:split {
+    direction = 'Top',
+    size = 0.6,
+    cwd = project_dir,
   }
   -- may as well kick off a build in that pane
-  build_pane:send_text("cargo build\n")
+  build_pane:send_text 'cargo build\n'
 
   -- A workspace for interacting with a local machine that
   -- runs some docker containners for home automation
-  local tab, pane, window = mux.spawn_window{
-    workspace="automation",
-    args={"ssh", "vault"},
+  local tab, pane, window = mux.spawn_window {
+    workspace = 'automation',
+    args = { 'ssh', 'vault' },
   }
 
   -- We want to startup in the coding workspace
-  mux.set_active_workspace("coding")
+  mux.set_active_workspace 'coding'
 end)
 
 return {}

--- a/docs/config/lua/keyassignment/ActivateCopyMode.md
+++ b/docs/config/lua/keyassignment/ActivateCopyMode.md
@@ -7,8 +7,8 @@ Activates copy mode!
 ```lua
 return {
   keys = {
-    {key="X", mods="CTRL", action=wezterm.action.ActivateCopyMode},
-  }
+    { key = 'X', mods = 'CTRL', action = wezterm.action.ActivateCopyMode },
+  },
 }
 ```
 

--- a/docs/config/lua/keyassignment/ActivateLastTab.md
+++ b/docs/config/lua/keyassignment/ActivateLastTab.md
@@ -6,11 +6,15 @@ Activate the last active tab. If there is none, it will do nothing.
 
 ```lua
 return {
-  leader = { key="a", mods="CTRL" },
+  leader = { key = 'a', mods = 'CTRL' },
   keys = {
     -- CTRL-a, followed by CTRL-o will switch back to the last active tab
-    {key="o", mods="LEADER|CTRL", action=wezterm.action.ActivateLastTab},
-  }
+    {
+      key = 'o',
+      mods = 'LEADER|CTRL',
+      action = wezterm.action.ActivateLastTab,
+    },
+  },
 }
 ```
 

--- a/docs/config/lua/keyassignment/ActivatePaneByIndex.md
+++ b/docs/config/lua/keyassignment/ActivatePaneByIndex.md
@@ -14,9 +14,9 @@ local act = wezterm.action
 
 return {
   keys = {
-    {key="a", mods="ALT", action=act.ActivatePaneByIndex(0)},
-    {key="b", mods="ALT", action=act.ActivatePaneByIndex(1)},
-    {key="c", mods="ALT", action=act.ActivatePaneByIndex(2)},
-  }
+    { key = 'a', mods = 'ALT', action = act.ActivatePaneByIndex(0) },
+    { key = 'b', mods = 'ALT', action = act.ActivatePaneByIndex(1) },
+    { key = 'c', mods = 'ALT', action = act.ActivatePaneByIndex(2) },
+  },
 }
 ```

--- a/docs/config/lua/keyassignment/ActivatePaneDirection.md
+++ b/docs/config/lua/keyassignment/ActivatePaneDirection.md
@@ -15,15 +15,27 @@ local act = wezterm.action
 
 return {
   keys = {
-    { key = "LeftArrow", mods="CTRL|SHIFT",
-      action=act.ActivatePaneDirection("Left")},
-    { key = "RightArrow", mods="CTRL|SHIFT",
-      action=act.ActivatePaneDirection("Right")},
-    { key = "UpArrow", mods="CTRL|SHIFT",
-      action=act.ActivatePaneDirection("Up")},
-    { key = "DownArrow", mods="CTRL|SHIFT",
-      action=act.ActivatePaneDirection("Down")},
-  }
+    {
+      key = 'LeftArrow',
+      mods = 'CTRL|SHIFT',
+      action = act.ActivatePaneDirection 'Left',
+    },
+    {
+      key = 'RightArrow',
+      mods = 'CTRL|SHIFT',
+      action = act.ActivatePaneDirection 'Right',
+    },
+    {
+      key = 'UpArrow',
+      mods = 'CTRL|SHIFT',
+      action = act.ActivatePaneDirection 'Up',
+    },
+    {
+      key = 'DownArrow',
+      mods = 'CTRL|SHIFT',
+      action = act.ActivatePaneDirection 'Down',
+    },
+  },
 }
 ```
 

--- a/docs/config/lua/keyassignment/ActivateTab.md
+++ b/docs/config/lua/keyassignment/ActivateTab.md
@@ -18,14 +18,14 @@ local mykeys = {}
 for i = 1, 8 do
   -- CTRL+ALT + number to activate that tab
   table.insert(mykeys, {
-    key=tostring(i),
-    mods="CTRL|ALT",
-    action=act.ActivateTab(i-1),
+    key = tostring(i),
+    mods = 'CTRL|ALT',
+    action = act.ActivateTab(i - 1),
   })
   -- F1 through F8 to activate that tab
   table.insert(mykeys, {
-    key="F" .. tostring(i),
-    action=act.ActivateTab(i-1),
+    key = 'F' .. tostring(i),
+    action = act.ActivateTab(i - 1),
   })
 end
 

--- a/docs/config/lua/keyassignment/ActivateTabRelative.md
+++ b/docs/config/lua/keyassignment/ActivateTabRelative.md
@@ -10,9 +10,9 @@ local act = wezterm.action
 
 return {
   keys = {
-    {key="{", mods="ALT", action=act.ActivateTabRelative(-1)},
-    {key="}", mods="ALT", action=act.ActivateTabRelative(1)},
-  }
+    { key = '{', mods = 'ALT', action = act.ActivateTabRelative(-1) },
+    { key = '}', mods = 'ALT', action = act.ActivateTabRelative(1) },
+  },
 }
 ```
 

--- a/docs/config/lua/keyassignment/ActivateTabRelativeNoWrap.md
+++ b/docs/config/lua/keyassignment/ActivateTabRelativeNoWrap.md
@@ -17,9 +17,9 @@ local act = wezterm.action
 
 return {
   keys = {
-    {key="{", mods="ALT", action=act.ActivateTabRelativeNoWrap(-1)},
-    {key="}", mods="ALT", action=act.ActivateTabRelativeNoWrap(1)},
-  }
+    { key = '{', mods = 'ALT', action = act.ActivateTabRelativeNoWrap(-1) },
+    { key = '}', mods = 'ALT', action = act.ActivateTabRelativeNoWrap(1) },
+  },
 }
 ```
 

--- a/docs/config/lua/keyassignment/AdjustPaneSize.md
+++ b/docs/config/lua/keyassignment/AdjustPaneSize.md
@@ -21,12 +21,24 @@ local wezterm = require 'wezterm'
 local act = wezterm.action
 
 return {
-  leader = { key="a", mods="CTRL" },
+  leader = { key = 'a', mods = 'CTRL' },
   keys = {
-    { key = "H", mods = "LEADER", action=act.AdjustPaneSize{"Left", 5} },
-    { key = "J", mods = "LEADER", action=act.AdjustPaneSize{"Down", 5} },
-    { key = "K", mods = "LEADER", action=act.AdjustPaneSize{"Up", 5} },
-    { key = "L", mods = "LEADER", action=act.AdjustPaneSize{"Right", 5} },
- }
+    {
+      key = 'H',
+      mods = 'LEADER',
+      action = act.AdjustPaneSize { 'Left', 5 },
+    },
+    {
+      key = 'J',
+      mods = 'LEADER',
+      action = act.AdjustPaneSize { 'Down', 5 },
+    },
+    { key = 'K', mods = 'LEADER', action = act.AdjustPaneSize { 'Up', 5 } },
+    {
+      key = 'L',
+      mods = 'LEADER',
+      action = act.AdjustPaneSize { 'Right', 5 },
+    },
+  },
 }
 ```

--- a/docs/config/lua/keyassignment/AttachDomain.md
+++ b/docs/config/lua/keyassignment/AttachDomain.md
@@ -24,12 +24,16 @@ local wezterm = require 'wezterm'
 return {
   ssh_domains = {
     {
-      name = "devhost",
-      remote_address = "devhost.example.com",
-    }
+      name = 'devhost',
+      remote_address = 'devhost.example.com',
+    },
   },
   keys = {
-    {key="U", mods="CTRL|SHIFT", action=wezterm.action.AttachDomain("devhost")},
+    {
+      key = 'U',
+      mods = 'CTRL|SHIFT',
+      action = wezterm.action.AttachDomain 'devhost',
+    },
   },
 }
 ```

--- a/docs/config/lua/keyassignment/ClearScrollback.md
+++ b/docs/config/lua/keyassignment/ClearScrollback.md
@@ -15,9 +15,17 @@ return {
   keys = {
     -- Clears only the scrollback and leaves the viewport intact.
     -- This is the default behavior.
-    {key="K", mods="CTRL|SHIFT", action=act.ClearScrollback("ScrollbackOnly")},
+    {
+      key = 'K',
+      mods = 'CTRL|SHIFT',
+      action = act.ClearScrollback 'ScrollbackOnly',
+    },
     -- Clears the scrollback and viewport leaving the prompt line the new first line.
-    {key="K", mods="CTRL|SHIFT", action=act.ClearScrollback("ScrollbackAndViewport")},
-  }
+    {
+      key = 'K',
+      mods = 'CTRL|SHIFT',
+      action = act.ClearScrollback 'ScrollbackAndViewport',
+    },
+  },
 }
 ```

--- a/docs/config/lua/keyassignment/CloseCurrentPane.md
+++ b/docs/config/lua/keyassignment/CloseCurrentPane.md
@@ -12,8 +12,12 @@ local wezterm = require 'wezterm'
 
 return {
   keys = {
-    {key="w", mods="CMD", action=wezterm.action.CloseCurrentPane{confirm=true}},
-  }
+    {
+      key = 'w',
+      mods = 'CMD',
+      action = wezterm.action.CloseCurrentPane { confirm = true },
+    },
+  },
 }
 ```
 

--- a/docs/config/lua/keyassignment/CloseCurrentTab.md
+++ b/docs/config/lua/keyassignment/CloseCurrentTab.md
@@ -6,8 +6,12 @@ tab, closes that window.  If that was the last window, wezterm terminates.
 ```lua
 return {
   keys = {
-    {key="w", mods="CMD", action=wezterm.action.CloseCurrentTab{confirm=true}},
-  }
+    {
+      key = 'w',
+      mods = 'CMD',
+      action = wezterm.action.CloseCurrentTab { confirm = true },
+    },
+  },
 }
 ```
 

--- a/docs/config/lua/keyassignment/CompleteSelection.md
+++ b/docs/config/lua/keyassignment/CompleteSelection.md
@@ -11,7 +11,7 @@ which clipboard buffer the selection will populate; the copy action
 is now equivalent to [CopyTo](CopyTo.md).
 
 ```lua
-local wezterm = require 'wezterm';
+local wezterm = require 'wezterm'
 
 return {
   mouse_bindings = {
@@ -20,11 +20,10 @@ return {
     -- the Clipboard rather the PrimarySelection which is part
     -- of the default assignment for a left mouse click.
     {
-      event={Up={streak=1, button="Left"}},
-      mods="NONE",
-      action=wezterm.action.CompleteSelection("Clipboard"),
+      event = { Up = { streak = 1, button = 'Left' } },
+      mods = 'NONE',
+      action = wezterm.action.CompleteSelection 'Clipboard',
     },
   },
 }
-
 ```

--- a/docs/config/lua/keyassignment/CompleteSelectionOrOpenLinkAtMouseCursor.md
+++ b/docs/config/lua/keyassignment/CompleteSelectionOrOpenLinkAtMouseCursor.md
@@ -12,18 +12,17 @@ which clipboard buffer the selection will populate. The copy action
 is now equivalent to [CopyTo](CopyTo.md).
 
 ```lua
-local wezterm = require 'wezterm';
+local wezterm = require 'wezterm'
 
 return {
   mouse_bindings = {
     -- Change the default click behavior so that it populates
     -- the Clipboard rather the PrimarySelection.
     {
-      event={Up={streak=1, button="Left"}},
-      mods="NONE",
-      action=wezterm.action.CompleteSelectionOrOpenLinkAtMouseCursor("Clipboard"),
+      event = { Up = { streak = 1, button = 'Left' } },
+      mods = 'NONE',
+      action = wezterm.action.CompleteSelectionOrOpenLinkAtMouseCursor 'Clipboard',
     },
   },
 }
-
 ```

--- a/docs/config/lua/keyassignment/Copy.md
+++ b/docs/config/lua/keyassignment/Copy.md
@@ -14,8 +14,8 @@ a future release; please use [CopyTo](CopyTo.md) instead.
 local wezterm = require 'wezterm'
 return {
   keys = {
-    {key="C", mods="CTRL", action=wezterm.action.Copy},
-  }
+    { key = 'C', mods = 'CTRL', action = wezterm.action.Copy },
+  },
 }
 ```
 

--- a/docs/config/lua/keyassignment/CopyTo.md
+++ b/docs/config/lua/keyassignment/CopyTo.md
@@ -13,8 +13,12 @@ local wezterm = require 'wezterm'
 
 return {
   keys = {
-    {key="C", mods="CTRL", action=wezterm.action.CopyTo("ClipboardAndPrimarySelection")},
-  }
+    {
+      key = 'C',
+      mods = 'CTRL',
+      action = wezterm.action.CopyTo 'ClipboardAndPrimarySelection',
+    },
+  },
 }
 ```
 

--- a/docs/config/lua/keyassignment/DecreaseFontSize.md
+++ b/docs/config/lua/keyassignment/DecreaseFontSize.md
@@ -7,8 +7,8 @@ local wezterm = require 'wezterm'
 
 return {
   keys = {
-    {key="-", mods="CTRL", action=wezterm.action.DecreaseFontSize},
-  }
+    { key = '-', mods = 'CTRL', action = wezterm.action.DecreaseFontSize },
+  },
 }
 ```
 

--- a/docs/config/lua/keyassignment/DetachDomain.md
+++ b/docs/config/lua/keyassignment/DetachDomain.md
@@ -17,19 +17,26 @@ local act = wezterm.action
 return {
   ssh_domains = {
     {
-      name = "devhost",
-      remote_address = "devhost.example.com",
-    }
+      name = 'devhost',
+      remote_address = 'devhost.example.com',
+    },
   },
   keys = {
-    {key="U", mods="CTRL|SHIFT", action=act.AttachDomain("devhost")},
+    { key = 'U', mods = 'CTRL|SHIFT', action = act.AttachDomain 'devhost' },
     -- Detaches the domain associated with the current pane
-    {key="D", mods="CTRL|SHIFT", action=act.DetachDomain("CurrentPaneDomain")},
+    {
+      key = 'D',
+      mods = 'CTRL|SHIFT',
+      action = act.DetachDomain 'CurrentPaneDomain',
+    },
     -- Detaches the "devhost" domain
-    {key="E", mods="CTRL|SHIFT", action=act.DetachDomain{DomainName="devhost"}},
+    {
+      key = 'E',
+      mods = 'CTRL|SHIFT',
+      action = act.DetachDomain { DomainName = 'devhost' },
+    },
   },
 }
-
 ```
 
 See also: [AttachDomain](AttachDomain.md)

--- a/docs/config/lua/keyassignment/DisableDefaultAssignment.md
+++ b/docs/config/lua/keyassignment/DisableDefaultAssignment.md
@@ -12,8 +12,12 @@ return {
   keys = {
     -- Turn off the default CMD-m Hide action, allowing CMD-m to
     -- be potentially recognized and handled by the tab
-    {key="m", mods="CMD", action=wezterm.action.DisableDefaultAssignment},
-  }
+    {
+      key = 'm',
+      mods = 'CMD',
+      action = wezterm.action.DisableDefaultAssignment,
+    },
+  },
 }
 ```
 

--- a/docs/config/lua/keyassignment/ExtendSelectionToMouseCursor.md
+++ b/docs/config/lua/keyassignment/ExtendSelectionToMouseCursor.md
@@ -9,16 +9,16 @@ the scope of the selection.
 The mode argument can also be `"Block"` to enable a rectangular block selection.
 
 ```lua
-local wezterm = require "wezterm"
+local wezterm = require 'wezterm'
 
 return {
   mouse_bindings = {
     {
-      event={Up={streak=1, button="Left"}},
-      mods="SHIFT",
-      action=wezterm.action.ExtendSelectionToMouseCursor("Word"),
+      event = { Up = { streak = 1, button = 'Left' } },
+      mods = 'SHIFT',
+      action = wezterm.action.ExtendSelectionToMouseCursor 'Word',
     },
-  }
+  },
 }
 ```
 

--- a/docs/config/lua/keyassignment/Hide.md
+++ b/docs/config/lua/keyassignment/Hide.md
@@ -7,7 +7,7 @@ local wezterm = require 'wezterm'
 
 return {
   keys = {
-    {key="h", mods="CMD", action=wezterm.action.Hide},
-  }
+    { key = 'h', mods = 'CMD', action = wezterm.action.Hide },
+  },
 }
 ```

--- a/docs/config/lua/keyassignment/HideApplication.md
+++ b/docs/config/lua/keyassignment/HideApplication.md
@@ -7,7 +7,7 @@ local wezterm = require 'wezterm'
 
 return {
   keys = {
-    {key="h", mods="CMD", action=wezterm.action.HideApplication},
-  }
+    { key = 'h', mods = 'CMD', action = wezterm.action.HideApplication },
+  },
 }
 ```

--- a/docs/config/lua/keyassignment/IncreaseFontSize.md
+++ b/docs/config/lua/keyassignment/IncreaseFontSize.md
@@ -7,7 +7,7 @@ local wezterm = require 'wezterm'
 
 return {
   keys = {
-    {key="=", mods="CTRL", action=wezterm.action.IncreaseFontSize},
-  }
+    { key = '=', mods = 'CTRL', action = wezterm.action.IncreaseFontSize },
+  },
 }
 ```

--- a/docs/config/lua/keyassignment/MoveTab.md
+++ b/docs/config/lua/keyassignment/MoveTab.md
@@ -11,9 +11,9 @@ local mykeys = {}
 for i = 1, 8 do
   -- CTRL+ALT + number to move to that position
   table.insert(mykeys, {
-    key=tostring(i),
-    mods="CTRL|ALT",
-    action=wezterm.action.MoveTab(i - 1),
+    key = tostring(i),
+    mods = 'CTRL|ALT',
+    action = wezterm.action.MoveTab(i - 1),
   })
 end
 

--- a/docs/config/lua/keyassignment/MoveTabRelative.md
+++ b/docs/config/lua/keyassignment/MoveTabRelative.md
@@ -10,9 +10,9 @@ local act = wezterm.action
 
 return {
   keys = {
-    {key="{", mods="SHIFT|ALT", action=act.MoveTabRelative(-1)},
-    {key="}", mods="SHIFT|ALT", action=act.MoveTabRelative(1)},
-  }
+    { key = '{', mods = 'SHIFT|ALT', action = act.MoveTabRelative(-1) },
+    { key = '}', mods = 'SHIFT|ALT', action = act.MoveTabRelative(1) },
+  },
 }
 ```
 

--- a/docs/config/lua/keyassignment/Multiple.md
+++ b/docs/config/lua/keyassignment/Multiple.md
@@ -13,12 +13,15 @@ local act = wezterm.action
 
 return {
   keys = {
-    {key="LeftArrow", action=act.Multiple{
-      act.SendKey{key="l"},
-      act.SendKey{key="e"},
-      act.SendKey{key="f"},
-      act.SendKey{key="t"}
-    }}
-  }
+    {
+      key = 'LeftArrow',
+      action = act.Multiple {
+        act.SendKey { key = 'l' },
+        act.SendKey { key = 'e' },
+        act.SendKey { key = 'f' },
+        act.SendKey { key = 't' },
+      },
+    },
+  },
 }
 ```

--- a/docs/config/lua/keyassignment/Nop.md
+++ b/docs/config/lua/keyassignment/Nop.md
@@ -12,8 +12,8 @@ local wezterm = require 'wezterm'
 return {
   keys = {
     -- Turn off any side effects from pressing CMD-m
-    {key="m", mods="CMD", action=wezterm.action.Nop},
-  }
+    { key = 'm', mods = 'CMD', action = wezterm.action.Nop },
+  },
 }
 ```
 

--- a/docs/config/lua/keyassignment/OpenLinkAtMouseCursor.md
+++ b/docs/config/lua/keyassignment/OpenLinkAtMouseCursor.md
@@ -10,9 +10,9 @@ return {
   mouse_bindings = {
     -- Ctrl-click will open the link under the mouse cursor
     {
-      event={Up={streak=1, button="Left"}},
-      mods="CTRL",
-      action=wezterm.action.OpenLinkAtMouseCursor,
+      event = { Up = { streak = 1, button = 'Left' } },
+      mods = 'CTRL',
+      action = wezterm.action.OpenLinkAtMouseCursor,
     },
   },
 }

--- a/docs/config/lua/keyassignment/PaneSelect.md
+++ b/docs/config/lua/keyassignment/PaneSelect.md
@@ -29,12 +29,20 @@ return {
 
   keys = {
     -- activate pane selection mode with the default alphabet (labels are "a", "s", "d", "f" and so on)
-    {key="8", mods="CTRL", action=act.PaneSelect},
+    { key = '8', mods = 'CTRL', action = act.PaneSelect },
     -- activate pane selection mode with numeric labels
-    {key="9", mods="CTRL", action=act.PaneSelect{alphabet="1234567890"}},
+    {
+      key = '9',
+      mods = 'CTRL',
+      action = act.PaneSelect { alphabet = '1234567890' },
+    },
     -- show the pane selection mode, but have it swap the active and selected panes
-    {key="0", mods="CTRL", action=act.PaneSelect{mode="SwapWithActive"}},
-  }
+    {
+      key = '0',
+      mods = 'CTRL',
+      action = act.PaneSelect { mode = 'SwapWithActive' },
+    },
+  },
 }
 ```
 

--- a/docs/config/lua/keyassignment/Paste.md
+++ b/docs/config/lua/keyassignment/Paste.md
@@ -14,18 +14,18 @@ local wezterm = require 'wezterm'
 
 return {
   keys = {
-    {key="v", mods="SHIFT|CTRL", action=wezterm.action.Paste},
+    { key = 'v', mods = 'SHIFT|CTRL', action = wezterm.action.Paste },
   },
 
   -- Middle mouse button pastes the clipboard.
   -- Note that this is the default so you needn't copy this.
   mouse_bindings = {
     {
-      event={Up={streak=1, button="Middle"}},
-      mods="NONE",
-      action=wezterm.action.Paste,
+      event = { Up = { streak = 1, button = 'Middle' } },
+      mods = 'NONE',
+      action = wezterm.action.Paste,
     },
-  }
+  },
 }
 ```
 

--- a/docs/config/lua/keyassignment/PasteFrom.md
+++ b/docs/config/lua/keyassignment/PasteFrom.md
@@ -18,10 +18,10 @@ local act = wezterm.action
 return {
   keys = {
     -- paste from the clipboard
-    {key="V", mods="CTRL", action=act.PasteFrom("Clipboard")},
+    { key = 'V', mods = 'CTRL', action = act.PasteFrom 'Clipboard' },
 
     -- paste from the primary selection
-    {key="V", mods="CTRL", action=act.PasteFrom("PrimarySelection")},
+    { key = 'V', mods = 'CTRL', action = act.PasteFrom 'PrimarySelection' },
   },
 }
 ```

--- a/docs/config/lua/keyassignment/PastePrimarySelection.md
+++ b/docs/config/lua/keyassignment/PastePrimarySelection.md
@@ -16,17 +16,17 @@ local act = wezterm.action
 
 return {
   keys = {
-    {key="v", mods="SHIFT|CTRL", action=act.PastePrimarySelection},
+    { key = 'v', mods = 'SHIFT|CTRL', action = act.PastePrimarySelection },
   },
 
   -- Middle mouse button pastes the primary selection.
   mouse_bindings = {
     {
-      event={Up={streak=1, button="Middle"}},
-      mods="NONE",
-      action=act.PastePrimarySelection,
+      event = { Up = { streak = 1, button = 'Middle' } },
+      mods = 'NONE',
+      action = act.PastePrimarySelection,
     },
-  }
+  },
 }
 ```
 

--- a/docs/config/lua/keyassignment/QuickSelect.md
+++ b/docs/config/lua/keyassignment/QuickSelect.md
@@ -9,8 +9,8 @@ local wezterm = require 'wezterm'
 
 return {
   keys = {
-    {key=" ", mods="SHIFT|CTRL", action=wezterm.action.QuickSelect},
-  }
+    { key = ' ', mods = 'SHIFT|CTRL', action = wezterm.action.QuickSelect },
+  },
 }
 ```
 

--- a/docs/config/lua/keyassignment/QuickSelectArgs.md
+++ b/docs/config/lua/keyassignment/QuickSelectArgs.md
@@ -15,13 +15,15 @@ local wezterm = require 'wezterm'
 
 return {
   keys = {
-    {key="P", mods="CTRL",
-     action=wezterm.action.QuickSelectArgs{
-       patterns={
-          "https?://\\S+"
-       },
-     }
-   },
+    {
+      key = 'P',
+      mods = 'CTRL',
+      action = wezterm.action.QuickSelectArgs {
+        patterns = {
+          'https?://\\S+',
+        },
+      },
+    },
   },
 }
 ```
@@ -42,19 +44,21 @@ local wezterm = require 'wezterm'
 
 return {
   keys = {
-    {key="P", mods="CTRL",
-     action=wezterm.action.QuickSelectArgs{
-       label = "open url",
-       patterns={
-          "https?://\\S+"
-       },
-       action = wezterm.action_callback(function(window, pane)
+    {
+      key = 'P',
+      mods = 'CTRL',
+      action = wezterm.action.QuickSelectArgs {
+        label = 'open url',
+        patterns = {
+          'https?://\\S+',
+        },
+        action = wezterm.action_callback(function(window, pane)
           local url = window:get_selection_text_for_pane(pane)
-          wezterm.log_info("opening: " .. url)
+          wezterm.log_info('opening: ' .. url)
           wezterm.open_with(url)
-       end)
-     }
-   },
+        end),
+      },
+    },
   },
 }
 ```

--- a/docs/config/lua/keyassignment/QuitApplication.md
+++ b/docs/config/lua/keyassignment/QuitApplication.md
@@ -7,8 +7,8 @@ local wezterm = require 'wezterm'
 
 return {
   keys = {
-    {key="q", mods="CMD", action=wezterm.action.QuitApplication},
-  }
+    { key = 'q', mods = 'CMD', action = wezterm.action.QuitApplication },
+  },
 }
 ```
 

--- a/docs/config/lua/keyassignment/ReloadConfiguration.md
+++ b/docs/config/lua/keyassignment/ReloadConfiguration.md
@@ -7,8 +7,12 @@ local wezterm = require 'wezterm'
 
 return {
   keys = {
-    {key="r", mods="CMD|SHIFT", action=wezterm.action.ReloadConfiguration},
-  }
+    {
+      key = 'r',
+      mods = 'CMD|SHIFT',
+      action = wezterm.action.ReloadConfiguration,
+    },
+  },
 }
 ```
 

--- a/docs/config/lua/keyassignment/ResetFontAndWindowSize.md
+++ b/docs/config/lua/keyassignment/ResetFontAndWindowSize.md
@@ -10,8 +10,12 @@ local wezterm = require 'wezterm'
 
 return {
   keys = {
-    {key="0", mods="CTRL", action=wezterm.action.ResetFontAndWindowSize},
-  }
+    {
+      key = '0',
+      mods = 'CTRL',
+      action = wezterm.action.ResetFontAndWindowSize,
+    },
+  },
 }
 ```
 

--- a/docs/config/lua/keyassignment/ResetFontSize.md
+++ b/docs/config/lua/keyassignment/ResetFontSize.md
@@ -7,8 +7,8 @@ local wezterm = require 'wezterm'
 
 return {
   keys = {
-    {key="0", mods="CTRL", action=wezterm.action.ResetFontSize},
-  }
+    { key = '0', mods = 'CTRL', action = wezterm.action.ResetFontSize },
+  },
 }
 ```
 

--- a/docs/config/lua/keyassignment/RotatePanes.md
+++ b/docs/config/lua/keyassignment/RotatePanes.md
@@ -43,8 +43,12 @@ local act = wezterm.action
 
 return {
   keys = {
-    {key="b", mods="CTRL", action=act.RotatePanes("CounterClockwise")},
-    {key="n", mods="CTRL", action=act.RotatePanes("Clockwise")},
+    {
+      key = 'b',
+      mods = 'CTRL',
+      action = act.RotatePanes 'CounterClockwise',
+    },
+    { key = 'n', mods = 'CTRL', action = act.RotatePanes 'Clockwise' },
   },
 }
 ```

--- a/docs/config/lua/keyassignment/ScrollByLine.md
+++ b/docs/config/lua/keyassignment/ScrollByLine.md
@@ -6,14 +6,14 @@ Adjusts the scroll position by the number of lines specified by the argument.
 Negative values scroll upwards, while positive values scroll downwards.
 
 ```lua
-local wezterm = require 'wezterm';
+local wezterm = require 'wezterm'
 local act = wezterm.action
 
 return {
   keys = {
-    {key="UpArrow", mods="SHIFT", action=act.ScrollByLine(-1)},
-    {key="DownArrow", mods="SHIFT", action=act.ScrollByLine(1)},
-  }
+    { key = 'UpArrow', mods = 'SHIFT', action = act.ScrollByLine(-1) },
+    { key = 'DownArrow', mods = 'SHIFT', action = act.ScrollByLine(1) },
+  },
 }
 ```
 

--- a/docs/config/lua/keyassignment/ScrollByPage.md
+++ b/docs/config/lua/keyassignment/ScrollByPage.md
@@ -9,9 +9,9 @@ local act = wezterm.action
 
 return {
   keys = {
-    {key="PageUp", mods="SHIFT", action=act.ScrollByPage(-1)},
-    {key="PageDown", mods="SHIFT", action=act.ScrollByPage(1)},
-  }
+    { key = 'PageUp', mods = 'SHIFT', action = act.ScrollByPage(-1) },
+    { key = 'PageDown', mods = 'SHIFT', action = act.ScrollByPage(1) },
+  },
 }
 ```
 
@@ -21,12 +21,12 @@ You may now use floating point values to scroll by partial pages.  This example 
 how to make the `PageUp`/`PageDown` scroll by half a page at a time:
 
 ```lua
-local wezterm = require 'wezterm';
+local wezterm = require 'wezterm'
 
 return {
   keys = {
-    {key="PageUp", mods="SHIFT", action=act.ScrollByPage(-0.5)},
-    {key="PageDown", mods="SHIFT", action=act.ScrollByPage(0.5)},
-  }
+    { key = 'PageUp', mods = 'SHIFT', action = act.ScrollByPage(-0.5) },
+    { key = 'PageDown', mods = 'SHIFT', action = act.ScrollByPage(0.5) },
+  },
 }
 ```

--- a/docs/config/lua/keyassignment/ScrollToPrompt.md
+++ b/docs/config/lua/keyassignment/ScrollToPrompt.md
@@ -26,9 +26,9 @@ local act = wezterm.action
 
 return {
   keys = {
-    {key="UpArrow", mods="SHIFT", action=act.ScrollToPrompt(-1)},
-    {key="DownArrow", mods="SHIFT", action=act.ScrollToPrompt(1)},
-  }
+    { key = 'UpArrow', mods = 'SHIFT', action = act.ScrollToPrompt(-1) },
+    { key = 'DownArrow', mods = 'SHIFT', action = act.ScrollToPrompt(1) },
+  },
 }
 ```
 

--- a/docs/config/lua/keyassignment/Search.md
+++ b/docs/config/lua/keyassignment/Search.md
@@ -18,11 +18,23 @@ local act = wezterm.action
 return {
   keys = {
     -- search for things that look like git hashes
-    {key="H", mods="SHIFT|CTRL", action=act.Search{Regex="[a-f0-9]{6,}"}},
+    {
+      key = 'H',
+      mods = 'SHIFT|CTRL',
+      action = act.Search { Regex = '[a-f0-9]{6,}' },
+    },
     -- search for the lowercase string "hash" matching the case exactly
-    {key="H", mods="SHIFT|CTRL", action=act.Search{CaseSensitiveString="hash"}},
+    {
+      key = 'H',
+      mods = 'SHIFT|CTRL',
+      action = act.Search { CaseSensitiveString = 'hash' },
+    },
     -- search for the string "hash" matching regardless of case
-    {key="H", mods="SHIFT|CTRL", action=act.Search{CaseInSensitiveString="hash"}},
+    {
+      key = 'H',
+      mods = 'SHIFT|CTRL',
+      action = act.Search { CaseInSensitiveString = 'hash' },
+    },
   },
 }
 ```

--- a/docs/config/lua/keyassignment/SelectTextAtMouseCursor.md
+++ b/docs/config/lua/keyassignment/SelectTextAtMouseCursor.md
@@ -18,9 +18,10 @@ local wezterm = require 'wezterm'
 
 return {
   mouse_bindings = {
-    { event={Down={streak=3, button="Left"}},
-      action=wezterm.action.SelectTextAtMouseCursor("SemanticZone"),
-      mods="NONE"
+    {
+      event = { Down = { streak = 3, button = 'Left' } },
+      action = wezterm.action.SelectTextAtMouseCursor 'SemanticZone',
+      mods = 'NONE',
     },
   },
 }

--- a/docs/config/lua/keyassignment/SendKey.md
+++ b/docs/config/lua/keyassignment/SendKey.md
@@ -23,10 +23,18 @@ local act = wezterm.action
 
 return {
   keys = {
-     -- Rebind OPT-Left, OPT-Right as ALT-b, ALT-f respectively to match Terminal.app behavior
-     {key="LeftArrow", mods="OPT", action=act.SendKey{key="b", mods="ALT"}},
-     {key="RightArrow", mods="OPT", action=act.SendKey{key="f", mods="ALT"}},
-  }
+    -- Rebind OPT-Left, OPT-Right as ALT-b, ALT-f respectively to match Terminal.app behavior
+    {
+      key = 'LeftArrow',
+      mods = 'OPT',
+      action = act.SendKey { key = 'b', mods = 'ALT' },
+    },
+    {
+      key = 'RightArrow',
+      mods = 'OPT',
+      action = act.SendKey { key = 'f', mods = 'ALT' },
+    },
+  },
 }
 ```
 

--- a/docs/config/lua/keyassignment/SendString.md
+++ b/docs/config/lua/keyassignment/SendString.md
@@ -8,8 +8,8 @@ local wezterm = require 'wezterm'
 
 return {
   keys = {
-    {key="m", mods="CMD", action=wezterm.action.SendString("Hello")},
-  }
+    { key = 'm', mods = 'CMD', action = wezterm.action.SendString 'Hello' },
+  },
 }
 ```
 
@@ -26,10 +26,10 @@ local act = wezterm.action
 return {
   keys = {
     -- Make Option-Left equivalent to Alt-b which many line editors interpret as backward-word
-    {key="LeftArrow", mods="OPT", action=act.SendString("\x1bb")},
+    { key = 'LeftArrow', mods = 'OPT', action = act.SendString '\x1bb' },
     -- Make Option-Right equivalent to Alt-f; forward-word
-    {key="RightArrow", mods="OPT", action=act.SendString("\x1bf")},
-  }
+    { key = 'RightArrow', mods = 'OPT', action = act.SendString '\x1bf' },
+  },
 }
 ```
 

--- a/docs/config/lua/keyassignment/ShowDebugOverlay.md
+++ b/docs/config/lua/keyassignment/ShowDebugOverlay.md
@@ -20,7 +20,7 @@ local wezterm = require 'wezterm'
 return {
   keys = {
     -- CTRL-SHIFT-l activates the debug overlay
-    {key="L", mods="CTRL", action=wezterm.action.ShowDebugOverlay},
-  }
+    { key = 'L', mods = 'CTRL', action = wezterm.action.ShowDebugOverlay },
+  },
 }
 ```

--- a/docs/config/lua/keyassignment/ShowLauncher.md
+++ b/docs/config/lua/keyassignment/ShowLauncher.md
@@ -8,8 +8,8 @@ local wezterm = require 'wezterm'
 
 return {
   keys = {
-    {key="l", mods="ALT", action=wezterm.action.ShowLauncher},
-  }
+    { key = 'l', mods = 'ALT', action = wezterm.action.ShowLauncher },
+  },
 }
 ```
 

--- a/docs/config/lua/keyassignment/ShowLauncherArgs.md
+++ b/docs/config/lua/keyassignment/ShowLauncherArgs.md
@@ -36,7 +36,11 @@ local wezterm = require 'wezterm'
 
 return {
   keys = {
-    {key="9", mods="ALT", action=wezterm.action.ShowLauncherArgs{flags="FUZZY|TABS"}},
+    {
+      key = '9',
+      mods = 'ALT',
+      action = wezterm.action.ShowLauncherArgs { flags = 'FUZZY|TABS' },
+    },
   },
 }
 ```

--- a/docs/config/lua/keyassignment/ShowTabNavigator.md
+++ b/docs/config/lua/keyassignment/ShowTabNavigator.md
@@ -9,8 +9,8 @@ local wezterm = require 'wezterm'
 
 return {
   keys = {
-    {key="F9", mods="ALT", action=wezterm.action.ShowTabNavigator},
-  }
+    { key = 'F9', mods = 'ALT', action = wezterm.action.ShowTabNavigator },
+  },
 }
 ```
 

--- a/docs/config/lua/keyassignment/SpawnCommandInNewTab.md
+++ b/docs/config/lua/keyassignment/SpawnCommandInNewTab.md
@@ -10,10 +10,14 @@ local wezterm = require 'wezterm'
 return {
   keys = {
     -- CMD-y starts `top` in a new window
-    {key="y", mods="CMD", action=wezterm.action.SpawnCommandInNewTab{
-      args={"top"}
-    }},
-  }
+    {
+      key = 'y',
+      mods = 'CMD',
+      action = wezterm.action.SpawnCommandInNewTab {
+        args = { 'top' },
+      },
+    },
+  },
 }
 ```
 

--- a/docs/config/lua/keyassignment/SpawnCommandInNewWindow.md
+++ b/docs/config/lua/keyassignment/SpawnCommandInNewWindow.md
@@ -10,10 +10,14 @@ local wezterm = require 'wezterm'
 return {
   keys = {
     -- CMD-y starts `top` in a new window
-    {key="y", mods="CMD", action=wezterm.action.SpawnCommandInNewWindow{
-      args={"top"}
-    }},
-  }
+    {
+      key = 'y',
+      mods = 'CMD',
+      action = wezterm.action.SpawnCommandInNewWindow {
+        args = { 'top' },
+      },
+    },
+  },
 }
 ```
 

--- a/docs/config/lua/keyassignment/SpawnTab.md
+++ b/docs/config/lua/keyassignment/SpawnTab.md
@@ -10,12 +10,20 @@ return {
   keys = {
     -- Create a new tab in the same domain as the current pane.
     -- This is usually what you want.
-    {key="t", mods="SHIFT|ALT", action=act.SpawnTab("CurrentPaneDomain")},
+    {
+      key = 't',
+      mods = 'SHIFT|ALT',
+      action = act.SpawnTab 'CurrentPaneDomain',
+    },
     -- Create a new tab in the default domain
-    {key="t", mods="SHIFT|ALT", action=act.SpawnTab("DefaultDomain")},
+    { key = 't', mods = 'SHIFT|ALT', action = act.SpawnTab 'DefaultDomain' },
     -- Create a tab in a named domain
-    {key="t", mods="SHIFT|ALT", action=act.SpawnTab{DomainName="unix"}},
-  }
+    {
+      key = 't',
+      mods = 'SHIFT|ALT',
+      action = act.SpawnTab { DomainName = 'unix' },
+    },
+  },
 }
 ```
 

--- a/docs/config/lua/keyassignment/SpawnWindow.md
+++ b/docs/config/lua/keyassignment/SpawnWindow.md
@@ -7,8 +7,8 @@ local wezterm = require 'wezterm'
 
 return {
   keys = {
-    {key="n", mods="SHIFT|CTRL", action=wezterm.action.SpawnWindow},
-  }
+    { key = 'n', mods = 'SHIFT|CTRL', action = wezterm.action.SpawnWindow },
+  },
 }
 ```
 

--- a/docs/config/lua/keyassignment/SplitHorizontal.md
+++ b/docs/config/lua/keyassignment/SplitHorizontal.md
@@ -11,9 +11,12 @@ local wezterm = require 'wezterm'
 return {
   keys = {
     -- This will create a new split and run your default program inside it
-    {key="%", mods="CTRL|SHIFT|ALT",
-      action=wezterm.action.SplitHorizontal{domain="CurrentPaneDomain"}},
-  }
+    {
+      key = '%',
+      mods = 'CTRL|SHIFT|ALT',
+      action = wezterm.action.SplitHorizontal { domain = 'CurrentPaneDomain' },
+    },
+  },
 }
 ```
 
@@ -26,10 +29,14 @@ local wezterm = require 'wezterm'
 return {
   keys = {
     -- This will create a new split and run the `top` program inside it
-    {key="%", mods="CTRL|SHIFT|ALT", action=wezterm.action.SplitHorizontal{
-      args={"top"}
-    }},
-  }
+    {
+      key = '%',
+      mods = 'CTRL|SHIFT|ALT',
+      action = wezterm.action.SplitHorizontal {
+        args = { 'top' },
+      },
+    },
+  },
 }
 ```
 

--- a/docs/config/lua/keyassignment/SplitPane.md
+++ b/docs/config/lua/keyassignment/SplitPane.md
@@ -17,12 +17,16 @@ local wezterm = require 'wezterm'
 return {
   keys = {
     -- This will create a new split and run the `top` program inside it
-    {key="%", mods="CTRL|SHIFT|ALT", action=wezterm.action.SplitPane{
-      direction="Left",
-      command={args={"top"}},
-      size={Percent=50},
-    }},
-  }
+    {
+      key = '%',
+      mods = 'CTRL|SHIFT|ALT',
+      action = wezterm.action.SplitPane {
+        direction = 'Left',
+        command = { args = { 'top' } },
+        size = { Percent = 50 },
+      },
+    },
+  },
 }
 ```
 

--- a/docs/config/lua/keyassignment/SplitVertical.md
+++ b/docs/config/lua/keyassignment/SplitVertical.md
@@ -11,9 +11,12 @@ local wezterm = require 'wezterm'
 return {
   keys = {
     -- This will create a new split and run your default program inside it
-    {key="\"", mods="CTRL|SHIFT|ALT",
-      action=wezterm.action.SplitVertical{domain="CurrentPaneDomain"}},
-  }
+    {
+      key = '"',
+      mods = 'CTRL|SHIFT|ALT',
+      action = wezterm.action.SplitVertical { domain = 'CurrentPaneDomain' },
+    },
+  },
 }
 ```
 
@@ -21,15 +24,19 @@ return {
 specify what should be spawned into the new split.
 
 ```lua
-local wezterm = require 'wezterm';
+local wezterm = require 'wezterm'
 
 return {
   keys = {
     -- This will create a new split and run the `top` program inside it
-    {key="\"", mods="CTRL|SHIFT|ALT", action=wezterm.action.SplitVertical{
-      args={"top"}
-    }},
-  }
+    {
+      key = '"',
+      mods = 'CTRL|SHIFT|ALT',
+      action = wezterm.action.SplitVertical {
+        args = { 'top' },
+      },
+    },
+  },
 }
 ```
 

--- a/docs/config/lua/keyassignment/StartWindowDrag.md
+++ b/docs/config/lua/keyassignment/StartWindowDrag.md
@@ -13,15 +13,15 @@ local wezterm = require 'wezterm'
 return {
   mouse_bindings = {
     {
-      event={Drag={streak=1, button="Left"}},
-      mods="SUPER",
-      action=wezterm.action.StartWindowDrag
+      event = { Drag = { streak = 1, button = 'Left' } },
+      mods = 'SUPER',
+      action = wezterm.action.StartWindowDrag,
     },
     {
-      event={Drag={streak=1, button="Left"}},
-      mods="CTRL|SHIFT",
-      action=wezterm.action.StartWindowDrag
+      event = { Drag = { streak = 1, button = 'Left' } },
+      mods = 'CTRL|SHIFT',
+      action = wezterm.action.StartWindowDrag,
     },
-  }
+  },
 }
 ```

--- a/docs/config/lua/keyassignment/SwitchToWorkspace.md
+++ b/docs/config/lua/keyassignment/SwitchToWorkspace.md
@@ -13,30 +13,42 @@ Switch to a different workspace, creating it if it doesn't already exist.
 local wezterm = require 'wezterm'
 local act = wezterm.action
 
-wezterm.on("update-right-status", function(window, pane)
+wezterm.on('update-right-status', function(window, pane)
   window:set_right_status(window:active_workspace())
 end)
 
 return {
   keys = {
     -- Switch to the default workspace
-    {key="y", mods="CTRL|SHIFT", action=act.SwitchToWorkspace{
-      name = "default"
-    }},
+    {
+      key = 'y',
+      mods = 'CTRL|SHIFT',
+      action = act.SwitchToWorkspace {
+        name = 'default',
+      },
+    },
     -- Switch to a monitoring workspace, which will have `top` launched into it
-    {key="u", mods="CTRL|SHIFT", action=act.SwitchToWorkspace{
-      name = "monitoring",
-      spawn = {
-        args = {"top"},
-      }
-    }},
+    {
+      key = 'u',
+      mods = 'CTRL|SHIFT',
+      action = act.SwitchToWorkspace {
+        name = 'monitoring',
+        spawn = {
+          args = { 'top' },
+        },
+      },
+    },
     -- Create a new workspace with a random name and switch to it
-    {key="i", mods="CTRL|SHIFT", action=act.SwitchToWorkspace},
+    { key = 'i', mods = 'CTRL|SHIFT', action = act.SwitchToWorkspace },
     -- Show the launcher in fuzzy selection mode and have it list all workspaces
     -- and allow activating one.
-    {key="9", mods="ALT", action=act.ShowLauncherArgs{
-      flags="FUZZY|WORKSPACES"
-    }},
+    {
+      key = '9',
+      mods = 'ALT',
+      action = act.ShowLauncherArgs {
+        flags = 'FUZZY|WORKSPACES',
+      },
+    },
   },
 }
 ```

--- a/docs/config/lua/keyassignment/SwitchWorkspaceRelative.md
+++ b/docs/config/lua/keyassignment/SwitchWorkspaceRelative.md
@@ -17,15 +17,19 @@ to create workspaces.
 local wezterm = require 'wezterm'
 local act = wezterm.action
 
-wezterm.on("update-right-status", function(window, pane)
+wezterm.on('update-right-status', function(window, pane)
   window:set_right_status(window:active_workspace())
 end)
 
 return {
   keys = {
-    {key="9", mods="ALT", action=act.ShowLauncherArgs{flags="FUZZY|WORKSPACES"}},
-    {key="n", mods="CTRL", action=act.SwitchWorkspaceRelative(1)},
-    {key="p", mods="CTRL", action=act.SwitchWorkspaceRelative(-1)},
+    {
+      key = '9',
+      mods = 'ALT',
+      action = act.ShowLauncherArgs { flags = 'FUZZY|WORKSPACES' },
+    },
+    { key = 'n', mods = 'CTRL', action = act.SwitchWorkspaceRelative(1) },
+    { key = 'p', mods = 'CTRL', action = act.SwitchWorkspaceRelative(-1) },
   },
 }
 ```

--- a/docs/config/lua/keyassignment/ToggleFullScreen.md
+++ b/docs/config/lua/keyassignment/ToggleFullScreen.md
@@ -7,8 +7,12 @@ local wezterm = require 'wezterm'
 
 return {
   keys = {
-    {key="n", mods="SHIFT|CTRL", action=wezterm.action.ToggleFullScreen},
-  }
+    {
+      key = 'n',
+      mods = 'SHIFT|CTRL',
+      action = wezterm.action.ToggleFullScreen,
+    },
+  },
 }
 ```
 

--- a/docs/config/lua/keyassignment/TogglePaneZoomState.md
+++ b/docs/config/lua/keyassignment/TogglePaneZoomState.md
@@ -11,8 +11,12 @@ local wezterm = require 'wezterm'
 
 return {
   keys = {
-    { key = "Z", mods="CTRL", action=wezterm.action.TogglePaneZoomState },
-  }
+    {
+      key = 'Z',
+      mods = 'CTRL',
+      action = wezterm.action.TogglePaneZoomState,
+    },
+  },
 }
 ```
 

--- a/docs/config/lua/mux-events/mux-is-process-stateful.md
+++ b/docs/config/lua/mux-events/mux-is-process-stateful.md
@@ -29,16 +29,26 @@ Since it returns `nil`, it uses the default behavior.
 local wezterm = require 'wezterm'
 
 function log_proc(proc, indent)
-  indent = indent or ""
-  wezterm.log_info(indent .. "pid=" .. proc.pid .. ", name=" .. proc.name .. ", status=" .. proc.status)
-  wezterm.log_info(indent .. "argv=" .. table.concat(proc.argv, " "))
-  wezterm.log_info(indent .. "executable=" .. proc.executable .. ", cwd=" .. proc.cwd)
+  indent = indent or ''
+  wezterm.log_info(
+    indent
+      .. 'pid='
+      .. proc.pid
+      .. ', name='
+      .. proc.name
+      .. ', status='
+      .. proc.status
+  )
+  wezterm.log_info(indent .. 'argv=' .. table.concat(proc.argv, ' '))
+  wezterm.log_info(
+    indent .. 'executable=' .. proc.executable .. ', cwd=' .. proc.cwd
+  )
   for pid, child in pairs(proc.children) do
-    log_proc(child, indent .. "  ")
+    log_proc(child, indent .. '  ')
   end
 end
 
-wezterm.on("mux-is-process-stateful", function(proc)
+wezterm.on('mux-is-process-stateful', function(proc)
   log_proc(proc)
 
   -- Just use the default behavior

--- a/docs/config/lua/mux-events/mux-startup.md
+++ b/docs/config/lua/mux-events/mux-startup.md
@@ -18,14 +18,14 @@ local mux = wezterm.mux
 
 -- this is called by the mux server when it starts up.
 -- It makes a window split top/bottom
-wezterm.on("mux-startup", function()
-  local tab, pane, window = mux.spawn_window{}
-  pane:split{direction="Top"}
+wezterm.on('mux-startup', function()
+  local tab, pane, window = mux.spawn_window {}
+  pane:split { direction = 'Top' }
 end)
 
 return {
   unix_domains = {
-    {name="unix"}
+    { name = 'unix' },
   },
 }
 ```

--- a/docs/config/lua/mux-window/set_title.md
+++ b/docs/config/lua/mux-window/set_title.md
@@ -6,7 +6,7 @@ Sets the window title to the provided string. Note that applications may
 subsequently change the title via escape sequences.
 
 ```lua
-window:set_title("my title")
+window:set_title 'my title'
 ```
 
 

--- a/docs/config/lua/mux-window/spawn_tab.md
+++ b/docs/config/lua/mux-window/spawn_tab.md
@@ -7,7 +7,7 @@ Spawns a program into a new tab within this window, returning the
 [MuxWindow](index.md) objects associated with it:
 
 ```lua
-local tab, pane, window = window:spawn_tab{}
+local tab, pane, window = window:spawn_tab {}
 ```
 
 When no arguments are passed, the default program is spawned.
@@ -20,7 +20,7 @@ Specifies the argument array for the command that should be spawned.
 If omitted the default program for the domain will be spawned.
 
 ```lua
-window:spawn_tab{args={"top"}}
+window:spawn_tab { args = { 'top' } }
 ```
 
 ### cwd
@@ -31,7 +31,7 @@ the program.
 If unspecified, follows the rules from [default_cwd](../config/default_cwd.md)
 
 ```lua
-window:spawn_tab{cwd="/tmp"}
+window:spawn_tab { cwd = '/tmp' }
 ```
 
 ### set_environment_variables
@@ -53,7 +53,7 @@ You may specify the name of one of the multiplexer domains
 defined in your configuration using the following:
 
 ```lua
-window:spawn_tab{domain={DomainName="my.name"}}
+window:spawn_tab { domain = { DomainName = 'my.name' } }
 ```
 
 

--- a/docs/config/lua/pane/get_foreground_process_info.md
+++ b/docs/config/lua/pane/get_foreground_process_info.md
@@ -23,19 +23,20 @@ local wezterm = require 'wezterm'
 -- Given "/foo/bar" returns "bar"
 -- Given "c:\\foo\\bar" returns "bar"
 function basename(s)
-  return string.gsub(s, "(.*[/\\])(.*)", "%2")
+  return string.gsub(s, '(.*[/\\])(.*)', '%2')
 end
 
-wezterm.on("update-right-status", function(window, pane)
+wezterm.on('update-right-status', function(window, pane)
   local info = pane:get_foreground_process_info()
   if info then
-    window:set_right_status(tostring(info.pid) .. " " .. basename(info.executable))
+    window:set_right_status(
+      tostring(info.pid) .. ' ' .. basename(info.executable)
+    )
   else
-    window:set_right_status("")
+    window:set_right_status ''
   end
 end)
 
-return {
-}
+return {}
 ```
 

--- a/docs/config/lua/pane/get_foreground_process_name.md
+++ b/docs/config/lua/pane/get_foreground_process_name.md
@@ -23,15 +23,14 @@ local wezterm = require 'wezterm'
 -- Given "/foo/bar" returns "bar"
 -- Given "c:\\foo\\bar" returns "bar"
 function basename(s)
-  return string.gsub(s, "(.*[/\\])(.*)", "%2")
+  return string.gsub(s, '(.*[/\\])(.*)', '%2')
 end
 
-wezterm.on("update-right-status", function(window, pane)
+wezterm.on('update-right-status', function(window, pane)
   window:set_right_status(basename(pane:get_foreground_process_name()))
 end)
 
-return {
-}
+return {}
 ```
 
 See also: [get_foreground_process_info](get_foreground_process_info.md)

--- a/docs/config/lua/pane/get_user_vars.md
+++ b/docs/config/lua/pane/get_user_vars.md
@@ -16,6 +16,6 @@ printf "\033]1337;SetUserVar=%s=%s\007" foo `echo -n bar | base64`
 you're then able to access this in your wezterm config:
 
 ```lua
-wezterm.log_info("foo var is " .. pane:get_user_vars().foo)
+wezterm.log_info('foo var is ' .. pane:get_user_vars().foo)
 ```
 

--- a/docs/config/lua/wezterm.color/extract_colors_from_image.md
+++ b/docs/config/lua/wezterm.color/extract_colors_from_image.md
@@ -107,7 +107,7 @@ This example computes a color palette for the terminal based on some other image
 ```lua
 local wezterm = require 'wezterm'
 
-local colors = wezterm.color.extract_colors_from_image("/path/to/image/jpeg")
+local colors = wezterm.color.extract_colors_from_image '/path/to/image/jpeg'
 local ansi = {}
 local brights = {}
 
@@ -115,7 +115,7 @@ for idx, color in ipairs(colors) do
   if idx <= 8 then
     ansi[idx] = color
   else
-    brights[idx-8] = color
+    brights[idx - 8] = color
   end
 end
 
@@ -123,6 +123,6 @@ return {
   colors = {
     ansi = ansi,
     brights = brights,
-  }
+  },
 }
 ```

--- a/docs/config/lua/wezterm.color/get_builtin_schemes.md
+++ b/docs/config/lua/wezterm.color/get_builtin_schemes.md
@@ -23,20 +23,19 @@ for name, scheme in pairs(wezterm.color.get_builtin_schemes()) do
   table.insert(schemes, name)
 end
 
-wezterm.on("window-config-reloaded", function(window, pane)
+wezterm.on('window-config-reloaded', function(window, pane)
   -- If there are no overrides, this is our first time seeing
   -- this window, so we can pick a random scheme.
   if not window:get_config_overrides() then
     -- Pick a random scheme name
     local scheme = schemes[math.random(#schemes)]
-    window:set_config_overrides({
-      color_scheme = scheme
-    })
+    window:set_config_overrides {
+      color_scheme = scheme,
+    }
   end
 end)
 
-return {
-}
+return {}
 ```
 
 This example shows how to take an existing scheme, modify a color, and
@@ -45,19 +44,19 @@ then use that new scheme to override the default:
 ```lua
 local wezterm = require 'wezterm'
 
-local scheme = wezterm.color.get_builtin_schemes()["Gruvbox Light"]
-scheme.background = "red"
+local scheme = wezterm.color.get_builtin_schemes()['Gruvbox Light']
+scheme.background = 'red'
 
 return {
   color_schemes = {
     -- Override the builtin Gruvbox Light scheme with our modification.
-    ["Gruvbox Light"] = scheme,
+    ['Gruvbox Light'] = scheme,
 
     -- We can also give it a different name if we don't want to override
     -- the default
-    ["Gruvbox Red"] = scheme,
+    ['Gruvbox Red'] = scheme,
   },
-  color_scheme = "Gruvbox Light",
+  color_scheme = 'Gruvbox Light',
 }
 ```
 
@@ -90,19 +89,18 @@ end
 
 local dark = dark_schemes()
 
-wezterm.on("window-config-reloaded", function(window, pane)
+wezterm.on('window-config-reloaded', function(window, pane)
   -- If there are no overrides, this is our first time seeing
   -- this window, so we can pick a random scheme.
   if not window:get_config_overrides() then
     -- Pick a random scheme name
 
     local scheme = dark[math.random(#dark)]
-    window:set_config_overrides({
-      color_scheme = scheme
-    })
+    window:set_config_overrides {
+      color_scheme = scheme,
+    }
   end
 end)
 
-return {
-}
+return {}
 ```

--- a/docs/config/lua/wezterm.color/get_default_colors.md
+++ b/docs/config/lua/wezterm.color/get_default_colors.md
@@ -14,17 +14,17 @@ other is one of the many built-in schemes:
 ```lua
 local wezterm = require 'wezterm'
 
-local gruvbox = wezterm.color.get_builtin_schemes()["Gruvbox Light"]
-gruvbox.background = "red"
+local gruvbox = wezterm.color.get_builtin_schemes()['Gruvbox Light']
+gruvbox.background = 'red'
 
 local my_default = wezterm.color.get_default_colors()
-my_default.background = "red"
+my_default.background = 'red'
 
 return {
   color_schemes = {
-    ["My Gruvbox"] = my_gruvbox,
-    ["My Default"] = my_default,
+    ['My Gruvbox'] = my_gruvbox,
+    ['My Default'] = my_default,
   },
-  color_scheme = "My Gruvbox",
+  color_scheme = 'My Gruvbox',
 }
 ```

--- a/docs/config/lua/wezterm.color/parse.md
+++ b/docs/config/lua/wezterm.color/parse.md
@@ -19,14 +19,14 @@ darkens it to use it as a background color:
 ```lua
 local wezterm = require 'wezterm'
 
-local fg = wezterm.color.parse("yellow")
+local fg = wezterm.color.parse 'yellow'
 local bg = fg:complement_ryb():darken(0.2)
 
 return {
   colors = {
     foreground = fg,
     background = bg,
-  }
+  },
 }
 ```
 

--- a/docs/config/lua/wezterm.gui/get_appearance.md
+++ b/docs/config/lua/wezterm.gui/get_appearance.md
@@ -20,10 +20,10 @@ automatically adjust to the current appearance:
 local wezterm = require 'wezterm'
 
 function scheme_for_appearance(appearance)
-  if appearance:find("Dark") then
-    return "Builtin Solarized Dark"
+  if appearance:find 'Dark' then
+    return 'Builtin Solarized Dark'
   else
-    return "Builtin Solarized Light"
+    return 'Builtin Solarized Light'
   end
 end
 

--- a/docs/config/lua/wezterm.mux/spawn_window.md
+++ b/docs/config/lua/wezterm.mux/spawn_window.md
@@ -7,7 +7,7 @@ Spawns a program into a new window, returning the [MuxTab](../MuxTab.md),
 associated with it:
 
 ```lua
-local tab, pane, window = wezterm.mux.spawn_window{}
+local tab, pane, window = wezterm.mux.spawn_window {}
 ```
 
 When no arguments are passed, the default program is spawned.
@@ -20,7 +20,7 @@ Specifies the argument array for the command that should be spawned.
 If omitted the default program for the domain will be spawned.
 
 ```lua
-wezterm.mux.spawn_window{args={"top"}}
+wezterm.mux.spawn_window { args = { 'top' } }
 ```
 
 ### cwd
@@ -31,7 +31,7 @@ the program.
 If unspecified, follows the rules from [default_cwd](../config/default_cwd.md)
 
 ```lua
-wezterm.mux.spawn_window{cwd="/tmp"}
+wezterm.mux.spawn_window { cwd = '/tmp' }
 ```
 
 ### set_environment_variables
@@ -53,7 +53,7 @@ You may specify the name of one of the multiplexer domains
 defined in your configuration using the following:
 
 ```lua
-wezterm.mux.spawn_window{domain={DomainName="my.name"}}
+wezterm.mux.spawn_window { domain = { DomainName = 'my.name' } }
 ```
 
 ### width and height
@@ -62,7 +62,7 @@ Only valid when width and height are used together, allows specifying
 the number of column and row cells that the window should have.
 
 ```lua
-wezterm.mux.spawn_window{width=60, height=30}
+wezterm.mux.spawn_window { width = 60, height = 30 }
 ```
 
 ### workspace
@@ -72,7 +72,7 @@ will be associated with.  If omitted, the currently active workspace
 name will be used.
 
 ```lua
-wezterm.mux.spawn_window{workspace={"coding"}}
+wezterm.mux.spawn_window { workspace = { 'coding' } }
 ```
 
 

--- a/docs/config/lua/wezterm/GLOBAL.md
+++ b/docs/config/lua/wezterm/GLOBAL.md
@@ -28,8 +28,8 @@ local wezterm = require 'wezterm'
 -- Count how many times the lua config has been loaded
 wezterm.GLOBAL.parse_count = (wezterm.GLOBAL.parse_count or 0) + 1
 
-wezterm.on("update-right-status", function(window, pane)
-  window:set_right_status("Reloads=" .. tostring(wezterm.GLOBAL.parse_count))
+wezterm.on('update-right-status', function(window, pane)
+  window:set_right_status('Reloads=' .. tostring(wezterm.GLOBAL.parse_count))
 end)
 
 return {}

--- a/docs/config/lua/wezterm/action.md
+++ b/docs/config/lua/wezterm/action.md
@@ -33,9 +33,13 @@ having to add any extra punctuation:
 ```lua
 local wezterm = require 'wezterm'
 return {
-   keys = {
-     {key=" ", mods="CTRL|SHIFT", action=wezterm.action.QuickSelectArgs},
-   }
+  keys = {
+    {
+      key = ' ',
+      mods = 'CTRL|SHIFT',
+      action = wezterm.action.QuickSelectArgs,
+    },
+  },
 }
 ```
 
@@ -45,11 +49,15 @@ them, like this:
 ```lua
 local wezterm = require 'wezterm'
 return {
-   keys = {
-     {key=" ", mods="CTRL|SHIFT", action=wezterm.action.QuickSelectArgs{
-      alphabet="abc"
-     }},
-   }
+  keys = {
+    {
+      key = ' ',
+      mods = 'CTRL|SHIFT',
+      action = wezterm.action.QuickSelectArgs {
+        alphabet = 'abc',
+      },
+    },
+  },
 }
 ```
 
@@ -63,22 +71,22 @@ local wezterm = require 'wezterm'
 local act = wezterm.action
 
 return {
-   keys = {
-     {key="F1", mods="ALT", action=act.ActivatePaneByIndex(0)},
-     {key="F2", mods="ALT", action=act.ActivatePaneByIndex(1)},
-     {key="F3", mods="ALT", action=act.ActivatePaneByIndex(2)},
-     {key="F4", mods="ALT", action=act.ActivatePaneByIndex(3)},
-     {key="F5", mods="ALT", action=act.ActivatePaneByIndex(4)},
-     {key="F6", mods="ALT", action=act.ActivatePaneByIndex(5)},
-     {key="F7", mods="ALT", action=act.ActivatePaneByIndex(6)},
-     {key="F8", mods="ALT", action=act.ActivatePaneByIndex(7)},
-     {key="F9", mods="ALT", action=act.ActivatePaneByIndex(8)},
-     {key="F10", mods="ALT", action=act.ActivatePaneByIndex(9)},
+  keys = {
+    { key = 'F1', mods = 'ALT', action = act.ActivatePaneByIndex(0) },
+    { key = 'F2', mods = 'ALT', action = act.ActivatePaneByIndex(1) },
+    { key = 'F3', mods = 'ALT', action = act.ActivatePaneByIndex(2) },
+    { key = 'F4', mods = 'ALT', action = act.ActivatePaneByIndex(3) },
+    { key = 'F5', mods = 'ALT', action = act.ActivatePaneByIndex(4) },
+    { key = 'F6', mods = 'ALT', action = act.ActivatePaneByIndex(5) },
+    { key = 'F7', mods = 'ALT', action = act.ActivatePaneByIndex(6) },
+    { key = 'F8', mods = 'ALT', action = act.ActivatePaneByIndex(7) },
+    { key = 'F9', mods = 'ALT', action = act.ActivatePaneByIndex(8) },
+    { key = 'F10', mods = 'ALT', action = act.ActivatePaneByIndex(9) },
 
-     -- Compare this with the older syntax shown in the section below
-     {key="{", mods="CTRL", action=act.ActivateTabRelative(-1)},
-     {key="}", mods="CTRL", action=act.ActivateTabRelative(1)},
-   }
+    -- Compare this with the older syntax shown in the section below
+    { key = '{', mods = 'CTRL', action = act.ActivateTabRelative(-1) },
+    { key = '}', mods = 'CTRL', action = act.ActivateTabRelative(1) },
+  },
 }
 ```
 
@@ -87,12 +95,20 @@ return {
 For versions before *20220624-141144-bd1b7c5d*, usage looks like this:
 
 ```lua
-local wezterm = require 'wezterm';
+local wezterm = require 'wezterm'
 return {
-   keys = {
-     {key="{", mods="CTRL", action=wezterm.action{ActivateTabRelative=-1}},
-     {key="}", mods="CTRL", action=wezterm.action{ActivateTabRelative=1}},
-   }
+  keys = {
+    {
+      key = '{',
+      mods = 'CTRL',
+      action = wezterm.action { ActivateTabRelative = -1 },
+    },
+    {
+      key = '}',
+      mods = 'CTRL',
+      action = wezterm.action { ActivateTabRelative = 1 },
+    },
+  },
 }
 ```
 

--- a/docs/config/lua/wezterm/action_callback.md
+++ b/docs/config/lua/wezterm/action_callback.md
@@ -10,7 +10,7 @@ the event and use it in a different place.
 The implementation is essentially the same as:
 ```lua
 function wezterm.action_callback(callback)
-  local event_id = "..." -- the function generates a unique event id
+  local event_id = '...' -- the function generates a unique event id
   wezterm.on(event_id, callback)
   return wezterm.action.EmitEvent(event_id)
 end
@@ -22,18 +22,23 @@ See [wezterm.on](./on.md) and [wezterm.action](./action.md) for more info on wha
 ## Usage
 
 ```lua
-local wezterm = require 'wezterm';
+local wezterm = require 'wezterm'
 
 return {
   keys = {
     {
-      mods = "CTRL|SHIFT",
-      key = "i",
+      mods = 'CTRL|SHIFT',
+      key = 'i',
       action = wezterm.action_callback(function(win, pane)
-        wezterm.log_info("Hello from callback!")
-        wezterm.log_info("WindowID:", win:window_id(), "PaneID:", pane:pane_id())
-      end)
+        wezterm.log_info 'Hello from callback!'
+        wezterm.log_info(
+          'WindowID:',
+          win:window_id(),
+          'PaneID:',
+          pane:pane_id()
+        )
+      end),
     },
-  }
+  },
 }
 ```

--- a/docs/config/lua/wezterm/background_child_process.md
+++ b/docs/config/lua/wezterm/background_child_process.md
@@ -18,15 +18,19 @@ the terminal background image in a separate image viewer process:
 local wezterm = require 'wezterm'
 
 return {
-  window_background_image = "/home/wez/Downloads/sunset-american-fork-canyon.jpg",
+  window_background_image = '/home/wez/Downloads/sunset-american-fork-canyon.jpg',
   keys = {
-    {mods="CTRL|SHIFT", key="m",
-      action=wezterm.action_callback(function(win, pane)
-        wezterm.background_child_process(
-            {"xdg-open", win:effective_config().window_background_image})
-      end)
-    }
-  }
+    {
+      mods = 'CTRL|SHIFT',
+      key = 'm',
+      action = wezterm.action_callback(function(win, pane)
+        wezterm.background_child_process {
+          'xdg-open',
+          win:effective_config().window_background_image,
+        }
+      end),
+    },
+  },
 }
 ```
 

--- a/docs/config/lua/wezterm/battery_info.md
+++ b/docs/config/lua/wezterm/battery_info.md
@@ -19,19 +19,19 @@ The return value is an array of objects with the following fields:
 This example shows the battery status for each battery, along with the date and time in the status bar:
 
 ```lua
-local wezterm = require 'wezterm';
+local wezterm = require 'wezterm'
 
-wezterm.on("update-right-status", function(window, pane)
+wezterm.on('update-right-status', function(window, pane)
   -- "Wed Mar 3 08:14"
-  local date = wezterm.strftime("%a %b %-d %H:%M ");
+  local date = wezterm.strftime '%a %b %-d %H:%M '
 
-  local bat = ""
+  local bat = ''
   for _, b in ipairs(wezterm.battery_info()) do
-    bat = "🔋 " .. string.format("%.0f%%", b.state_of_charge * 100)
+    bat = '🔋 ' .. string.format('%.0f%%', b.state_of_charge * 100)
   end
 
-  window:set_right_status(wezterm.format({
-    {Text=bat .. "   "..date},
-  }));
+  window:set_right_status(wezterm.format {
+    { Text = bat .. '   ' .. date },
+  })
 end)
 ```

--- a/docs/config/lua/wezterm/config_dir.md
+++ b/docs/config/lua/wezterm/config_dir.md
@@ -4,8 +4,8 @@ This constant is set to the path to the directory in which your `wezterm.lua`
 configuration file was found.
 
 ```lua
-local wezterm = require 'wezterm';
-wezterm.log_error("Config Dir " .. wezterm.config_dir)
+local wezterm = require 'wezterm'
+wezterm.log_error('Config Dir ' .. wezterm.config_dir)
 ```
 
 

--- a/docs/config/lua/wezterm/config_file.md
+++ b/docs/config/lua/wezterm/config_file.md
@@ -5,8 +5,8 @@
 This constant is set to the path to the `wezterm.lua` that is in use.
 
 ```lua
-local wezterm = require 'wezterm';
-wezterm.log_info("Config file " .. wezterm.config_file)
+local wezterm = require 'wezterm'
+wezterm.log_info('Config file ' .. wezterm.config_file)
 ```
 
 

--- a/docs/config/lua/wezterm/default_wsl_domains.md
+++ b/docs/config/lua/wezterm/default_wsl_domains.md
@@ -39,8 +39,8 @@ local wezterm = require 'wezterm'
 local wsl_domains = wezterm.default_wsl_domains()
 
 for idx, dom in ipairs(wsl_domains) do
-  if dom.name == "WSL:Ubuntu-18.04" then
-    dom.default_prog = {"fish"}
+  if dom.name == 'WSL:Ubuntu-18.04' then
+    dom.default_prog = { 'fish' }
   end
 end
 

--- a/docs/config/lua/wezterm/enumerate_ssh_hosts.md
+++ b/docs/config/lua/wezterm/enumerate_ssh_hosts.md
@@ -44,18 +44,16 @@ for host, config in pairs(wezterm.enumerate_ssh_hosts()) do
 
     -- multiplexing = "None",
 
-
     -- if you know that the remote host has a posix/unix environment,
     -- setting assume_shell = "Posix" will result in new panes respecting
     -- the remote current directory when multiplexing = "None".
-    assume_shell = "Posix",
+    assume_shell = 'Posix',
   })
 end
 
 return {
   ssh_domains = ssh_domains,
 }
-
 ```
 
 This shows the structure of the returned data, by evaluating the function in the [debug overlay](../keyassignment/ShowDebugOverlay.md) (`CTRL-SHIFT-L`):

--- a/docs/config/lua/wezterm/executable_dir.md
+++ b/docs/config/lua/wezterm/executable_dir.md
@@ -4,8 +4,8 @@ This constant is set to the directory containing the `wezterm`
 executable file.
 
 ```lua
-local wezterm = require 'wezterm';
-wezterm.log_error("Exe dir " .. wezterm.executable_dir)
+local wezterm = require 'wezterm'
+wezterm.log_error('Exe dir ' .. wezterm.executable_dir)
 ```
 
 

--- a/docs/config/lua/wezterm/font.md
+++ b/docs/config/lua/wezterm/font.md
@@ -4,10 +4,10 @@ This function constructs a lua table that corresponds to the internal `FontAttri
 struct that is used to select a single named font:
 
 ```lua
-local wezterm = require 'wezterm';
+local wezterm = require 'wezterm'
 
 return {
-  font = wezterm.font("JetBrains Mono"),
+  font = wezterm.font 'JetBrains Mono',
 }
 ```
 
@@ -27,10 +27,10 @@ following keys are allowed:
 When attributes are specified, the font must match both the family name and attributes in order to be selected.
 
 ```lua
-local wezterm = require 'wezterm';
+local wezterm = require 'wezterm'
 
 return {
-  font = wezterm.font("JetBrains Mono", {bold=true}),
+  font = wezterm.font('JetBrains Mono', { bold = true }),
 }
 ```
 
@@ -51,10 +51,13 @@ attributes, but allows for locating a close match within the specified font
 family.
 
 ```lua
-local wezterm = require 'wezterm';
+local wezterm = require 'wezterm'
 
 return {
-  font = wezterm.font('Iosevka Term', {stretch="Expanded", weight="Regular"}),
+  font = wezterm.font(
+    'Iosevka Term',
+    { stretch = 'Expanded', weight = 'Regular' }
+  ),
 }
 ```
 
@@ -64,10 +67,14 @@ are combined in the same lua table.  This form is most useful when used together
 weights for the different fallback fonts:
 
 ```lua
-local wezterm = require 'wezterm';
+local wezterm = require 'wezterm'
 
 return {
-  font = wezterm.font({family='Iosevka Term', stretch="Expanded", weight="Regular"}),
+  font = wezterm.font {
+    family = 'Iosevka Term',
+    stretch = 'Expanded',
+    weight = 'Regular',
+  },
 }
 ```
 
@@ -80,10 +87,10 @@ default ligature feature just for this particular font:
 ```lua
 local wezterm = require 'wezterm'
 return {
-  font = wezterm.font({
-    family="JetBrains Mono",
-    harfbuzz_features={"calt=0", "clig=0", "liga=0"},
-  })
+  font = wezterm.font {
+    family = 'JetBrains Mono',
+    harfbuzz_features = { 'calt=0', 'clig=0', 'liga=0' },
+  },
 }
 ```
 

--- a/docs/config/lua/wezterm/font_with_fallback.md
+++ b/docs/config/lua/wezterm/font_with_fallback.md
@@ -7,10 +7,10 @@ checked and so on.
 The first parameter is a table listing the fonts in their preferred order:
 
 ```lua
-local wezterm = require 'wezterm';
+local wezterm = require 'wezterm'
 
 return {
-  font = wezterm.font_with_fallback({"JetBrains Mono", "Noto Color Emoji"}),
+  font = wezterm.font_with_fallback { 'JetBrains Mono', 'Noto Color Emoji' },
 }
 ```
 
@@ -26,14 +26,14 @@ The attributes can now be specified per fallback font using this alternative
 form where the family and attributes are specified as part of the same lua table:
 
 ```lua
-local wezterm = require 'wezterm';
+local wezterm = require 'wezterm'
 
 return {
-  font = wezterm.font_with_fallback({
-    {family="JetBrains Mono", weight="Medium"},
-    {family="Terminus", weight="Bold"},
-    "Noto Color Emoji",
-  }),
+  font = wezterm.font_with_fallback {
+    { family = 'JetBrains Mono', weight = 'Medium' },
+    { family = 'Terminus', weight = 'Bold' },
+    'Noto Color Emoji',
+  },
 }
 ```
 
@@ -45,17 +45,17 @@ default ligature feature just for JetBrains Mono, but leave it on for the
 other fonts in the fallback:
 
 ```lua
-local wezterm = require 'wezterm';
+local wezterm = require 'wezterm'
 
 return {
-  font = wezterm.font_with_fallback({
+  font = wezterm.font_with_fallback {
     {
-      family="JetBrains Mono",
-      harfbuzz_features={"calt=0", "clig=0", "liga=0"},
+      family = 'JetBrains Mono',
+      harfbuzz_features = { 'calt=0', 'clig=0', 'liga=0' },
     },
-    {family="Terminus", weight="Bold"},
-    "Noto Color Emoji",
-  }),
+    { family = 'Terminus', weight = 'Bold' },
+    'Noto Color Emoji',
+  },
 }
 ```
 
@@ -101,9 +101,9 @@ local wezterm = require 'wezterm'
 
 return {
   line_height = 1.2,
-  font = wezterm.font_with_fallback({
-    "JetBrains Mono",
-    {family="Microsoft YaHei", scale=1.5},
-  }),
+  font = wezterm.font_with_fallback {
+    'JetBrains Mono',
+    { family = 'Microsoft YaHei', scale = 1.5 },
+  },
 }
 ```

--- a/docs/config/lua/wezterm/format.md
+++ b/docs/config/lua/wezterm/format.md
@@ -14,18 +14,18 @@ This example logs the text `Hello`, then the date/time, underlined, in purple
 text on a blue background to the stderr of the wezterm process:
 
 ```lua
-local wezterm = require 'wezterm';
+local wezterm = require 'wezterm'
 
-local success, date, stderr = wezterm.run_child_process({"date"});
+local success, date, stderr = wezterm.run_child_process { 'date' }
 
-wezterm.log_info(wezterm.format({
-  {Attribute={Underline="Single"}},
-  {Foreground={AnsiColor="Fuchsia"}},
-  {Background={Color="blue"}},
-  {Text="Hello " .. date .. " "},
-  "ResetAttributes",
-  {Text="this text has default attributes"}
-}))
+wezterm.log_info(wezterm.format {
+  { Attribute = { Underline = 'Single' } },
+  { Foreground = { AnsiColor = 'Fuchsia' } },
+  { Background = { Color = 'blue' } },
+  { Text = 'Hello ' .. date .. ' ' },
+  'ResetAttributes',
+  { Text = 'this text has default attributes' },
+})
 ```
 
 Possible values for the `FormatItem` elements are:

--- a/docs/config/lua/wezterm/get_builtin_color_schemes.md
+++ b/docs/config/lua/wezterm/get_builtin_color_schemes.md
@@ -21,20 +21,19 @@ for name, scheme in pairs(wezterm.get_builtin_color_schemes()) do
   table.insert(schemes, name)
 end
 
-wezterm.on("window-config-reloaded", function(window, pane)
+wezterm.on('window-config-reloaded', function(window, pane)
   -- If there are no overrides, this is our first time seeing
   -- this window, so we can pick a random scheme.
   if not window:get_config_overrides() then
     -- Pick a random scheme name
     local scheme = schemes[math.random(#schemes)]
-    window:set_config_overrides({
-      color_scheme = scheme
-    })
+    window:set_config_overrides {
+      color_scheme = scheme,
+    }
   end
 end)
 
-return {
-}
+return {}
 ```
 
 This example shows how to take an existing scheme, modify a color, and
@@ -43,19 +42,19 @@ then use that new scheme to override the default:
 ```lua
 local wezterm = require 'wezterm'
 
-local scheme = wezterm.get_builtin_color_schemes()["Gruvbox Light"]
-scheme.background = "red"
+local scheme = wezterm.get_builtin_color_schemes()['Gruvbox Light']
+scheme.background = 'red'
 
 return {
   color_schemes = {
     -- Override the builtin Gruvbox Light scheme with our modification.
-    ["Gruvbox Light"] = scheme,
+    ['Gruvbox Light'] = scheme,
 
     -- We can also give it a different name if we don't want to override
     -- the default
-    ["Gruvbox Red"] = scheme,
+    ['Gruvbox Red'] = scheme,
   },
-  color_scheme = "Gruvbox Light",
+  color_scheme = 'Gruvbox Light',
 }
 ```
 
@@ -88,21 +87,20 @@ end
 
 local dark = dark_schemes()
 
-wezterm.on("window-config-reloaded", function(window, pane)
+wezterm.on('window-config-reloaded', function(window, pane)
   -- If there are no overrides, this is our first time seeing
   -- this window, so we can pick a random scheme.
   if not window:get_config_overrides() then
     -- Pick a random scheme name
 
     local scheme = dark[math.random(#dark)]
-    window:set_config_overrides({
-      color_scheme = scheme
-    })
+    window:set_config_overrides {
+      color_scheme = scheme,
+    }
   end
 end)
 
-return {
-}
+return {}
 ```
 
 *Since: nightly builds only*

--- a/docs/config/lua/wezterm/glob.md
+++ b/docs/config/lua/wezterm/glob.md
@@ -12,11 +12,11 @@ to a path.  If the results have the same prefix as `relative_to` then it will
 be removed from the returned path.
 
 ```lua
-local wezterm = require 'wezterm';
+local wezterm = require 'wezterm'
 
 -- logs the names of all of the conf files under `/etc`
-for _, v in ipairs(wezterm.glob("/etc/*.conf")) do
-  wezterm.log_error("entry: " .. v)
+for _, v in ipairs(wezterm.glob '/etc/*.conf') do
+  wezterm.log_error('entry: ' .. v)
 end
 ```
 

--- a/docs/config/lua/wezterm/home_dir.md
+++ b/docs/config/lua/wezterm/home_dir.md
@@ -3,8 +3,8 @@
 This constant is set to the home directory of the user running `wezterm`.
 
 ```lua
-local wezterm = require 'wezterm';
-wezterm.log_error("Home " .. wezterm.home_dir)
+local wezterm = require 'wezterm'
+wezterm.log_error('Home ' .. wezterm.home_dir)
 ```
 
 

--- a/docs/config/lua/wezterm/hostname.md
+++ b/docs/config/lua/wezterm/hostname.md
@@ -7,19 +7,19 @@ Note that environments that use DHCP and have many clients and short leases may
 make it harder to rely on the hostname for this purpose.
 
 ```lua
-local wezterm = require 'wezterm';
-local hostname = wezterm.hostname();
+local wezterm = require 'wezterm'
+local hostname = wezterm.hostname()
 
-local font_size;
-if hostname == "pixelbookgo-localdomain" then
+local font_size
+if hostname == 'pixelbookgo-localdomain' then
   -- Use a bigger font on the smaller screen of my PixelBook Go
-  font_size = 12.0;
+  font_size = 12.0
 else
-  font_size = 10.0;
+  font_size = 10.0
 end
 
 return {
-  font_size = font_size
+  font_size = font_size,
 }
 ```
 

--- a/docs/config/lua/wezterm/log_error.md
+++ b/docs/config/lua/wezterm/log_error.md
@@ -6,8 +6,8 @@ to the stdout of that terminal.  If running as a daemon for the multiplexer
 server then it will be logged to the daemon output path.
 
 ```lua
-local wezterm = require 'wezterm';
-wezterm.log_error("Hello!");
+local wezterm = require 'wezterm'
+wezterm.log_error 'Hello!'
 ```
 
 *Since: 20210814-124438-54e29167*

--- a/docs/config/lua/wezterm/log_info.md
+++ b/docs/config/lua/wezterm/log_info.md
@@ -8,8 +8,8 @@ to the stdout of that terminal.  If running as a daemon for the multiplexer
 server then it will be logged to the daemon output path.
 
 ```lua
-local wezterm = require 'wezterm';
-wezterm.log_info("Hello!");
+local wezterm = require 'wezterm'
+wezterm.log_info 'Hello!'
 ```
 
 *Since: 20210814-124438-54e29167*

--- a/docs/config/lua/wezterm/log_warn.md
+++ b/docs/config/lua/wezterm/log_warn.md
@@ -8,8 +8,8 @@ to the stdout of that terminal.  If running as a daemon for the multiplexer
 server then it will be logged to the daemon output path.
 
 ```lua
-local wezterm = require 'wezterm';
-wezterm.log_warn("Hello!");
+local wezterm = require 'wezterm'
+wezterm.log_warn 'Hello!'
 ```
 
 *Since: 20210814-124438-54e29167*

--- a/docs/config/lua/wezterm/nerdfonts.md
+++ b/docs/config/lua/wezterm/nerdfonts.md
@@ -16,15 +16,15 @@ the Material Design Icons glyph representing a clock, and use
 that together with the current date/time in the status area:
 
 ```lua
-local wezterm = require 'wezterm';
+local wezterm = require 'wezterm'
 
-wezterm.on("update-right-status", function(window, pane)
+wezterm.on('update-right-status', function(window, pane)
   -- "Wed Mar 3 08:14"
-  local date = wezterm.strftime("%a %b %-d %H:%M ");
+  local date = wezterm.strftime '%a %b %-d %H:%M '
 
-  window:set_right_status(wezterm.format({
-    {Text=wezterm.nerdfonts.mdi_clock .. " "..date},
-  }));
+  window:set_right_status(wezterm.format {
+    { Text = wezterm.nerdfonts.mdi_clock .. ' ' .. date },
+  })
 end)
 ```
 

--- a/docs/config/lua/wezterm/on.md
+++ b/docs/config/lua/wezterm/on.md
@@ -49,12 +49,12 @@ In the following example, a key is assigned to capture the visible content of th
 pane, write it to a file and then open that file in the `vim` editor:
 
 ```lua
-local wezterm = require "wezterm"
-local io = require "io"
-local os = require "os"
+local wezterm = require 'wezterm'
+local io = require 'io'
+local os = require 'os'
 local act = wezterm.action
 
-wezterm.on("trigger-vim-with-visible-text", function(window, pane)
+wezterm.on('trigger-vim-with-visible-text', function(window, pane)
   -- Retrieve the current viewport's text.
   --
   -- Note: You could also pass an optional number of lines (eg: 2000) to
@@ -63,15 +63,18 @@ wezterm.on("trigger-vim-with-visible-text", function(window, pane)
 
   -- Create a temporary file to pass to vim
   local name = os.tmpname()
-  local f = io.open(name, "w+")
+  local f = io.open(name, 'w+')
   f:write(viewport_text)
   f:flush()
   f:close()
 
   -- Open a new window running vim and tell it to open the file
-  window:perform_action(act.SpawnCommandInNewWindow{
-    args={"vim", name}
-  }, pane)
+  window:perform_action(
+    act.SpawnCommandInNewWindow {
+      args = { 'vim', name },
+    },
+    pane
+  )
 
   -- Wait "enough" time for vim to read the file before we remove it.
   -- The window creation and process spawn are asynchronous wrt. running
@@ -85,8 +88,11 @@ end)
 
 return {
   keys = {
-    {key="E", mods="CTRL",
-      action=act.EmitEvent("trigger-vim-with-visible-text")},
-  }
+    {
+      key = 'E',
+      mods = 'CTRL',
+      action = act.EmitEvent 'trigger-vim-with-visible-text',
+    },
+  },
 }
 ```

--- a/docs/config/lua/wezterm/open_with.md
+++ b/docs/config/lua/wezterm/open_with.md
@@ -8,9 +8,9 @@ in.
 
 ```lua
 -- Opens a URL in your default browser
-wezterm.open_with("http://example.com")
+wezterm.open_with 'http://example.com'
 
 -- Opens a URL specifically in firefox
-wezterm.open_with("http://example.com", "firefox")
+wezterm.open_with('http://example.com', 'firefox')
 ```
 

--- a/docs/config/lua/wezterm/permute_any_mods.md
+++ b/docs/config/lua/wezterm/permute_any_mods.md
@@ -18,15 +18,15 @@ An array holding all of those combinations is returned.
 If this is your only binding, or it is the _last_ binding, the resulting array can be unpacked into a lua table initializer and used like this:
 
 ```lua
-local wezterm = require 'wezterm';
+local wezterm = require 'wezterm'
 
 return {
   mouse_bindings = {
-    table.unpack(wezterm.permute_any_mods({
-      event={Down={streak=1, button="Middle"}},
-      action="PastePrimarySelection"
-    }))
-  }
+    table.unpack(wezterm.permute_any_mods {
+      event = { Down = { streak = 1, button = 'Middle' } },
+      action = 'PastePrimarySelection',
+    }),
+  },
 }
 ```
 (and if you have other bindings before and/or after, use a for loop to iterate and add each binding to your bindings table)
@@ -36,157 +36,157 @@ This is equivalent to writing this out, but is much less verbose:
 ```lua
 return {
   mouse_bindings = {
-        {
-            action = "PastePrimarySelection",
-            event = {
-                Down = {
-                    button = "Middle",
-                    streak = 1,
-                },
-            },
-            mods = "SUPER",
+    {
+      action = 'PastePrimarySelection',
+      event = {
+        Down = {
+          button = 'Middle',
+          streak = 1,
         },
-        {
-            action = "PastePrimarySelection",
-            event = {
-                Down = {
-                    button = "Middle",
-                    streak = 1,
-                },
-            },
-            mods = "ALT",
+      },
+      mods = 'SUPER',
+    },
+    {
+      action = 'PastePrimarySelection',
+      event = {
+        Down = {
+          button = 'Middle',
+          streak = 1,
         },
-        {
-            action = "PastePrimarySelection",
-            event = {
-                Down = {
-                    button = "Middle",
-                    streak = 1,
-                },
-            },
-            mods = "ALT | SUPER",
+      },
+      mods = 'ALT',
+    },
+    {
+      action = 'PastePrimarySelection',
+      event = {
+        Down = {
+          button = 'Middle',
+          streak = 1,
         },
-        {
-            action = "PastePrimarySelection",
-            event = {
-                Down = {
-                    button = "Middle",
-                    streak = 1,
-                },
-            },
-            mods = "SHIFT",
+      },
+      mods = 'ALT | SUPER',
+    },
+    {
+      action = 'PastePrimarySelection',
+      event = {
+        Down = {
+          button = 'Middle',
+          streak = 1,
         },
-        {
-            action = "PastePrimarySelection",
-            event = {
-                Down = {
-                    button = "Middle",
-                    streak = 1,
-                },
-            },
-            mods = "SHIFT | SUPER",
+      },
+      mods = 'SHIFT',
+    },
+    {
+      action = 'PastePrimarySelection',
+      event = {
+        Down = {
+          button = 'Middle',
+          streak = 1,
         },
-        {
-            action = "PastePrimarySelection",
-            event = {
-                Down = {
-                    button = "Middle",
-                    streak = 1,
-                },
-            },
-            mods = "SHIFT | ALT",
+      },
+      mods = 'SHIFT | SUPER',
+    },
+    {
+      action = 'PastePrimarySelection',
+      event = {
+        Down = {
+          button = 'Middle',
+          streak = 1,
         },
-        {
-            action = "PastePrimarySelection",
-            event = {
-                Down = {
-                    button = "Middle",
-                    streak = 1,
-                },
-            },
-            mods = "SHIFT | ALT | SUPER",
+      },
+      mods = 'SHIFT | ALT',
+    },
+    {
+      action = 'PastePrimarySelection',
+      event = {
+        Down = {
+          button = 'Middle',
+          streak = 1,
         },
-        {
-            action = "PastePrimarySelection",
-            event = {
-                Down = {
-                    button = "Middle",
-                    streak = 1,
-                },
-            },
-            mods = "CTRL",
+      },
+      mods = 'SHIFT | ALT | SUPER',
+    },
+    {
+      action = 'PastePrimarySelection',
+      event = {
+        Down = {
+          button = 'Middle',
+          streak = 1,
         },
-        {
-            action = "PastePrimarySelection",
-            event = {
-                Down = {
-                    button = "Middle",
-                    streak = 1,
-                },
-            },
-            mods = "CTRL | SUPER",
+      },
+      mods = 'CTRL',
+    },
+    {
+      action = 'PastePrimarySelection',
+      event = {
+        Down = {
+          button = 'Middle',
+          streak = 1,
         },
-        {
-            action = "PastePrimarySelection",
-            event = {
-                Down = {
-                    button = "Middle",
-                    streak = 1,
-                },
-            },
-            mods = "ALT | CTRL",
+      },
+      mods = 'CTRL | SUPER',
+    },
+    {
+      action = 'PastePrimarySelection',
+      event = {
+        Down = {
+          button = 'Middle',
+          streak = 1,
         },
-        {
-            action = "PastePrimarySelection",
-            event = {
-                Down = {
-                    button = "Middle",
-                    streak = 1,
-                },
-            },
-            mods = "ALT | CTRL | SUPER",
+      },
+      mods = 'ALT | CTRL',
+    },
+    {
+      action = 'PastePrimarySelection',
+      event = {
+        Down = {
+          button = 'Middle',
+          streak = 1,
         },
-        {
-            action = "PastePrimarySelection",
-            event = {
-                Down = {
-                    button = "Middle",
-                    streak = 1,
-                },
-            },
-            mods = "SHIFT | CTRL",
+      },
+      mods = 'ALT | CTRL | SUPER',
+    },
+    {
+      action = 'PastePrimarySelection',
+      event = {
+        Down = {
+          button = 'Middle',
+          streak = 1,
         },
-        {
-            action = "PastePrimarySelection",
-            event = {
-                Down = {
-                    button = "Middle",
-                    streak = 1,
-                },
-            },
-            mods = "SHIFT | CTRL | SUPER",
+      },
+      mods = 'SHIFT | CTRL',
+    },
+    {
+      action = 'PastePrimarySelection',
+      event = {
+        Down = {
+          button = 'Middle',
+          streak = 1,
         },
-        {
-            action = "PastePrimarySelection",
-            event = {
-                Down = {
-                    button = "Middle",
-                    streak = 1,
-                },
-            },
-            mods = "SHIFT | ALT | CTRL",
+      },
+      mods = 'SHIFT | CTRL | SUPER',
+    },
+    {
+      action = 'PastePrimarySelection',
+      event = {
+        Down = {
+          button = 'Middle',
+          streak = 1,
         },
-        {
-            action = "PastePrimarySelection",
-            event = {
-                Down = {
-                    button = "Middle",
-                    streak = 1,
-                },
-            },
-            mods = "SHIFT | ALT | CTRL | SUPER",
+      },
+      mods = 'SHIFT | ALT | CTRL',
+    },
+    {
+      action = 'PastePrimarySelection',
+      event = {
+        Down = {
+          button = 'Middle',
+          streak = 1,
         },
-  }
+      },
+      mods = 'SHIFT | ALT | CTRL | SUPER',
+    },
+  },
 }
 ```
 

--- a/docs/config/lua/wezterm/permute_any_or_no_mods.md
+++ b/docs/config/lua/wezterm/permute_any_or_no_mods.md
@@ -18,15 +18,15 @@ An array holding all of those combinations is returned.
 If this is your only binding, or it is the _last_ binding, the resulting array can be unpacked into a lua table initializer and used like this:
 
 ```lua
-local wezterm = require 'wezterm';
+local wezterm = require 'wezterm'
 
 return {
   mouse_bindings = {
-    table.unpack(wezterm.permute_any_or_no_mods({
-      event={Down={streak=1, button="Middle"}},
-      action="PastePrimarySelection"
-    }))
-  }
+    table.unpack(wezterm.permute_any_or_no_mods {
+      event = { Down = { streak = 1, button = 'Middle' } },
+      action = 'PastePrimarySelection',
+    }),
+  },
 }
 ```
 (and if you have other bindings before and/or after, use a for loop to iterate and add each binding to your bindings table)
@@ -36,166 +36,166 @@ This is equivalent to writing this out, but is much less verbose:
 ```lua
 return {
   mouse_bindings = {
-        {
-            action= "PastePrimarySelection",
-            event = {
-                Down = {
-                    button = "Middle",
-                    streak = 1,
-                },
-            },
-            mods = "NONE",
+    {
+      action = 'PastePrimarySelection',
+      event = {
+        Down = {
+          button = 'Middle',
+          streak = 1,
         },
-        {
-            action = "PastePrimarySelection",
-            event = {
-                Down = {
-                    button = "Middle",
-                    streak = 1,
-                },
-            },
-            mods = "SUPER",
+      },
+      mods = 'NONE',
+    },
+    {
+      action = 'PastePrimarySelection',
+      event = {
+        Down = {
+          button = 'Middle',
+          streak = 1,
         },
-        {
-            action = "PastePrimarySelection",
-            event = {
-                Down = {
-                    button = "Middle",
-                    streak = 1,
-                },
-            },
-            mods = "ALT",
+      },
+      mods = 'SUPER',
+    },
+    {
+      action = 'PastePrimarySelection',
+      event = {
+        Down = {
+          button = 'Middle',
+          streak = 1,
         },
-        {
-            action = "PastePrimarySelection",
-            event = {
-                Down = {
-                    button = "Middle",
-                    streak = 1,
-                },
-            },
-            mods = "ALT | SUPER",
+      },
+      mods = 'ALT',
+    },
+    {
+      action = 'PastePrimarySelection',
+      event = {
+        Down = {
+          button = 'Middle',
+          streak = 1,
         },
-        {
-            action = "PastePrimarySelection",
-            event = {
-                Down = {
-                    button = "Middle",
-                    streak = 1,
-                },
-            },
-            mods = "SHIFT",
+      },
+      mods = 'ALT | SUPER',
+    },
+    {
+      action = 'PastePrimarySelection',
+      event = {
+        Down = {
+          button = 'Middle',
+          streak = 1,
         },
-        {
-            action = "PastePrimarySelection",
-            event = {
-                Down = {
-                    button = "Middle",
-                    streak = 1,
-                },
-            },
-            mods = "SHIFT | SUPER",
+      },
+      mods = 'SHIFT',
+    },
+    {
+      action = 'PastePrimarySelection',
+      event = {
+        Down = {
+          button = 'Middle',
+          streak = 1,
         },
-        {
-            action = "PastePrimarySelection",
-            event = {
-                Down = {
-                    button = "Middle",
-                    streak = 1,
-                },
-            },
-            mods = "SHIFT | ALT",
+      },
+      mods = 'SHIFT | SUPER',
+    },
+    {
+      action = 'PastePrimarySelection',
+      event = {
+        Down = {
+          button = 'Middle',
+          streak = 1,
         },
-        {
-            action = "PastePrimarySelection",
-            event = {
-                Down = {
-                    button = "Middle",
-                    streak = 1,
-                },
-            },
-            mods = "SHIFT | ALT | SUPER",
+      },
+      mods = 'SHIFT | ALT',
+    },
+    {
+      action = 'PastePrimarySelection',
+      event = {
+        Down = {
+          button = 'Middle',
+          streak = 1,
         },
-        {
-            action = "PastePrimarySelection",
-            event = {
-                Down = {
-                    button = "Middle",
-                    streak = 1,
-                },
-            },
-            mods = "CTRL",
+      },
+      mods = 'SHIFT | ALT | SUPER',
+    },
+    {
+      action = 'PastePrimarySelection',
+      event = {
+        Down = {
+          button = 'Middle',
+          streak = 1,
         },
-        {
-            action = "PastePrimarySelection",
-            event = {
-                Down = {
-                    button = "Middle",
-                    streak = 1,
-                },
-            },
-            mods = "CTRL | SUPER",
+      },
+      mods = 'CTRL',
+    },
+    {
+      action = 'PastePrimarySelection',
+      event = {
+        Down = {
+          button = 'Middle',
+          streak = 1,
         },
-        {
-            action = "PastePrimarySelection",
-            event = {
-                Down = {
-                    button = "Middle",
-                    streak = 1,
-                },
-            },
-            mods = "ALT | CTRL",
+      },
+      mods = 'CTRL | SUPER',
+    },
+    {
+      action = 'PastePrimarySelection',
+      event = {
+        Down = {
+          button = 'Middle',
+          streak = 1,
         },
-        {
-            action = "PastePrimarySelection",
-            event = {
-                Down = {
-                    button = "Middle",
-                    streak = 1,
-                },
-            },
-            mods = "ALT | CTRL | SUPER",
+      },
+      mods = 'ALT | CTRL',
+    },
+    {
+      action = 'PastePrimarySelection',
+      event = {
+        Down = {
+          button = 'Middle',
+          streak = 1,
         },
-        {
-            action = "PastePrimarySelection",
-            event = {
-                Down = {
-                    button = "Middle",
-                    streak = 1,
-                },
-            },
-            mods = "SHIFT | CTRL",
+      },
+      mods = 'ALT | CTRL | SUPER',
+    },
+    {
+      action = 'PastePrimarySelection',
+      event = {
+        Down = {
+          button = 'Middle',
+          streak = 1,
         },
-        {
-            action = "PastePrimarySelection",
-            event = {
-                Down = {
-                    button = "Middle",
-                    streak = 1,
-                },
-            },
-            mods = "SHIFT | CTRL | SUPER",
+      },
+      mods = 'SHIFT | CTRL',
+    },
+    {
+      action = 'PastePrimarySelection',
+      event = {
+        Down = {
+          button = 'Middle',
+          streak = 1,
         },
-        {
-            action = "PastePrimarySelection",
-            event = {
-                Down = {
-                    button = "Middle",
-                    streak = 1,
-                },
-            },
-            mods = "SHIFT | ALT | CTRL",
+      },
+      mods = 'SHIFT | CTRL | SUPER',
+    },
+    {
+      action = 'PastePrimarySelection',
+      event = {
+        Down = {
+          button = 'Middle',
+          streak = 1,
         },
-        {
-            action = "PastePrimarySelection",
-            event = {
-                Down = {
-                    button = "Middle",
-                    streak = 1,
-                },
-            },
-            mods = "SHIFT | ALT | CTRL | SUPER",
+      },
+      mods = 'SHIFT | ALT | CTRL',
+    },
+    {
+      action = 'PastePrimarySelection',
+      event = {
+        Down = {
+          button = 'Middle',
+          streak = 1,
         },
-  }
+      },
+      mods = 'SHIFT | ALT | CTRL | SUPER',
+    },
+  },
 }
 ```

--- a/docs/config/lua/wezterm/read_dir.md
+++ b/docs/config/lua/wezterm/read_dir.md
@@ -8,11 +8,11 @@ must be able to be represented as UTF-8 or this function will generate an
 error.
 
 ```lua
-local wezterm = require 'wezterm';
+local wezterm = require 'wezterm'
 
 -- logs the names of all of the entries under `/etc`
-for _, v in ipairs(wezterm.read_dir("/etc")) do
-  wezterm.log_error("entry: " .. v)
+for _, v in ipairs(wezterm.read_dir '/etc') do
+  wezterm.log_error('entry: ' .. v)
 end
 ```
 

--- a/docs/config/lua/wezterm/run_child_process.md
+++ b/docs/config/lua/wezterm/run_child_process.md
@@ -7,9 +7,9 @@ and will return a tuple consisting of the boolean success of the invocation,
 the stdout data and the stderr data.
 
 ```lua
-local wezterm = require 'wezterm';
+local wezterm = require 'wezterm'
 
-local success, stdout, stderr = wezterm.run_child_process({"ls", "-l"})
+local success, stdout, stderr = wezterm.run_child_process { 'ls', '-l' }
 ```
 
 See also [background_child_process](background_child_process.md)

--- a/docs/config/lua/wezterm/running_under_wsl.md
+++ b/docs/config/lua/wezterm/running_under_wsl.md
@@ -7,9 +7,13 @@ Linux but there will be some slight differences in system behavior (such as
 filesystem capabilities) that you may wish to probe for in the configuration.
 
 ```lua
-local wezterm = require 'wezterm';
-wezterm.log_error("System " .. wezterm.target_triple .. " " ..
-  tostring(wezterm.running_under_wsl()))
+local wezterm = require 'wezterm'
+wezterm.log_error(
+  'System '
+    .. wezterm.target_triple
+    .. ' '
+    .. tostring(wezterm.running_under_wsl())
+)
 ```
 
 

--- a/docs/config/lua/wezterm/split_by_newlines.md
+++ b/docs/config/lua/wezterm/split_by_newlines.md
@@ -7,9 +7,9 @@ are recognized as newlines) and returns the result as an array of strings that
 have the newlines removed.
 
 ```lua
-local wezterm = require 'wezterm';
+local wezterm = require 'wezterm'
 
-local example = "hello\nthere\n";
+local example = 'hello\nthere\n'
 
 for _, line in ipairs(wezterm.split_by_newlines(example)) do
   wezterm.log_error(line)

--- a/docs/config/lua/wezterm/strftime.md
+++ b/docs/config/lua/wezterm/strftime.md
@@ -6,10 +6,10 @@ Formats the current local date/time into a string using [the Rust chrono
 strftime syntax](https://docs.rs/chrono/0.4.19/chrono/format/strftime/index.html).
 
 ```lua
-local wezterm = require 'wezterm';
+local wezterm = require 'wezterm'
 
-local date_and_time = wezterm.strftime("%Y-%m-%d %H:%M:%S");
-wezterm.log_info(date_and_time);
+local date_and_time = wezterm.strftime '%Y-%m-%d %H:%M:%S'
+wezterm.log_info(date_and_time)
 ```
 
 See also [strftime_utc](strftime_utc.md).

--- a/docs/config/lua/wezterm/strftime_utc.md
+++ b/docs/config/lua/wezterm/strftime_utc.md
@@ -6,10 +6,10 @@ Formats the current UTC date/time into a string using [the Rust chrono
 strftime syntax](https://docs.rs/chrono/0.4.19/chrono/format/strftime/index.html).
 
 ```lua
-local wezterm = require 'wezterm';
+local wezterm = require 'wezterm'
 
-local date_and_time = wezterm.strftime_utc("%Y-%m-%d %H:%M:%S");
-wezterm.log_info(date_and_time);
+local date_and_time = wezterm.strftime_utc '%Y-%m-%d %H:%M:%S'
+wezterm.log_info(date_and_time)
 ```
 
 See also [strftime](strftime.md).

--- a/docs/config/lua/wezterm/target_triple.md
+++ b/docs/config/lua/wezterm/target_triple.md
@@ -6,9 +6,9 @@ platform on which `wezterm` was built.  This can be useful when you wish to
 conditionally adjust your configuration based on the platform.
 
 ```lua
-local wezterm = require 'wezterm';
+local wezterm = require 'wezterm'
 
-if wezterm.target_triple == "x86_64-pc-windows-msvc" then
+if wezterm.target_triple == 'x86_64-pc-windows-msvc' then
   -- We are running on Windows; maybe we emit different
   -- key assignments here?
 end

--- a/docs/config/lua/wezterm/utf16_to_utf8.md
+++ b/docs/config/lua/wezterm/utf16_to_utf8.md
@@ -8,9 +8,10 @@ This function is overly specific and exists primarily to workaround
 It takes as input a string and attempts to convert it from utf16 to utf8.
 
 ```lua
-local wezterm = require 'wezterm';
+local wezterm = require 'wezterm'
 
-local success, wsl_list, wsl_err = wezterm.run_child_process({"wsl.exe", "-l"})
+local success, wsl_list, wsl_err =
+  wezterm.run_child_process { 'wsl.exe', '-l' }
 wsl_list = wezterm.utf16_to_utf8(wsl_list)
 ```
 

--- a/docs/config/lua/wezterm/version.md
+++ b/docs/config/lua/wezterm/version.md
@@ -10,8 +10,8 @@ than another; the first component is the date on which the release was made,
 the second component is the time and the final component is a git hash.
 
 ```lua
-local wezterm = require 'wezterm';
-wezterm.log_error("Version " .. wezterm.version)
+local wezterm = require 'wezterm'
+wezterm.log_error('Version ' .. wezterm.version)
 ```
 
 

--- a/docs/config/lua/window-events/bell.md
+++ b/docs/config/lua/window-events/bell.md
@@ -17,10 +17,10 @@ represents the pane in which the bell was rung, which may not be active
 pane--it could be in an unfocused pane or tab..
 
 ```lua
-local wezterm = require 'wezterm';
+local wezterm = require 'wezterm'
 
-wezterm.on("bell", function(window, pane)
-  wezterm.log_info("the bell was rung in pane " .. pane:pane_id() .. "!");
+wezterm.on('bell', function(window, pane)
+  wezterm.log_info('the bell was rung in pane ' .. pane:pane_id() .. '!')
 end)
 
 return {}

--- a/docs/config/lua/window-events/format-tab-title.md
+++ b/docs/config/lua/window-events/format-tab-title.md
@@ -21,15 +21,18 @@ but it demonstrates that it is possible to format more than just the text
 shown in the tab.
 
 ```lua
-wezterm.on("format-tab-title", function(tab, tabs, panes, config, hover, max_width)
-  if tab.is_active then
-    return {
-      {Background={Color="blue"}},
-      {Text=" " .. tab.active_pane.title .. " "},
-    }
+wezterm.on(
+  'format-tab-title',
+  function(tab, tabs, panes, config, hover, max_width)
+    if tab.is_active then
+      return {
+        { Background = { Color = 'blue' } },
+        { Text = ' ' .. tab.active_pane.title .. ' ' },
+      }
+    end
+    return tab.active_pane.title
   end
-  return tab.active_pane.title
-end)
+)
 ```
 
 The parameters to the event are:
@@ -64,7 +67,7 @@ sense to define multiple instances of the event with multiple
 A more elaborate example:
 
 ```lua
-local wezterm = require 'wezterm';
+local wezterm = require 'wezterm'
 
 -- The filled in variant of the < symbol
 local SOLID_LEFT_ARROW = utf8.char(0xe0b2)
@@ -72,37 +75,40 @@ local SOLID_LEFT_ARROW = utf8.char(0xe0b2)
 -- The filled in variant of the > symbol
 local SOLID_RIGHT_ARROW = utf8.char(0xe0b0)
 
-wezterm.on("format-tab-title", function(tab, tabs, panes, config, hover, max_width)
-  local edge_background = "#0b0022"
-  local background = "#1b1032"
-  local foreground = "#808080"
+wezterm.on(
+  'format-tab-title',
+  function(tab, tabs, panes, config, hover, max_width)
+    local edge_background = '#0b0022'
+    local background = '#1b1032'
+    local foreground = '#808080'
 
-  if tab.is_active then
-    background = "#2b2042"
-    foreground = "#c0c0c0"
-  elseif hover then
-    background = "#3b3052"
-    foreground = "#909090"
+    if tab.is_active then
+      background = '#2b2042'
+      foreground = '#c0c0c0'
+    elseif hover then
+      background = '#3b3052'
+      foreground = '#909090'
+    end
+
+    local edge_foreground = background
+
+    -- ensure that the titles fit in the available space,
+    -- and that we have room for the edges.
+    local title = wezterm.truncate_right(tab.active_pane.title, max_width - 2)
+
+    return {
+      { Background = { Color = edge_background } },
+      { Foreground = { Color = edge_foreground } },
+      { Text = SOLID_LEFT_ARROW },
+      { Background = { Color = background } },
+      { Foreground = { Color = foreground } },
+      { Text = title },
+      { Background = { Color = edge_background } },
+      { Foreground = { Color = edge_foreground } },
+      { Text = SOLID_RIGHT_ARROW },
+    }
   end
-
-  local edge_foreground = background
-
-  -- ensure that the titles fit in the available space,
-  -- and that we have room for the edges.
-  local title = wezterm.truncate_right(tab.active_pane.title, max_width-2)
-
-  return {
-    {Background={Color=edge_background}},
-    {Foreground={Color=edge_foreground}},
-    {Text=SOLID_LEFT_ARROW},
-    {Background={Color=background}},
-    {Foreground={Color=foreground}},
-    {Text=title},
-    {Background={Color=edge_background}},
-    {Foreground={Color=edge_foreground}},
-    {Text=SOLID_RIGHT_ARROW},
-  }
-end)
+)
 
 return {}
 ```

--- a/docs/config/lua/window-events/format-window-title.md
+++ b/docs/config/lua/window-events/format-window-title.md
@@ -19,15 +19,15 @@ to the default processing--not very useful except as a starting point for
 making your own title text:
 
 ```lua
-wezterm.on("format-window-title", function(tab, pane, tabs, panes, config)
-  local zoomed = ""
+wezterm.on('format-window-title', function(tab, pane, tabs, panes, config)
+  local zoomed = ''
   if tab.active_pane.is_zoomed then
-    zoomed = "[Z] "
+    zoomed = '[Z] '
   end
 
-  local index = ""
+  local index = ''
   if #tabs > 1 then
-    index = string.format("[%d/%d] ", tab.tab_index + 1, #tabs)
+    index = string.format('[%d/%d] ', tab.tab_index + 1, #tabs)
   end
 
   return zoomed .. index .. tab.active_pane.title

--- a/docs/config/lua/window-events/open-uri.md
+++ b/docs/config/lua/window-events/open-uri.md
@@ -10,15 +10,18 @@ For example, if you prefer to launch your preferred MUA in a new window
 in response to clicking on `mailto:` URLs, you could do something like:
 
 ```lua
-local wezterm = require "wezterm"
+local wezterm = require 'wezterm'
 
-wezterm.on("open-uri", function(window, pane, uri)
-  local start, match_end = uri:find("mailto:")
+wezterm.on('open-uri', function(window, pane, uri)
+  local start, match_end = uri:find 'mailto:'
   if start == 1 then
-    local recipient = uri:sub(match_end+1)
-    window:perform_action(wezterm.action.SpawnCommandInNewWindow{
-      args={"mutt", recipient}
-    }, pane)
+    local recipient = uri:sub(match_end + 1)
+    window:perform_action(
+      wezterm.action.SpawnCommandInNewWindow {
+        args = { 'mutt', recipient },
+      },
+      pane
+    )
     -- prevent the default action from opening in a browser
     return false
   end

--- a/docs/config/lua/window-events/window-config-reloaded.md
+++ b/docs/config/lua/window-events/window-config-reloaded.md
@@ -26,10 +26,10 @@ The second event parameter is a [`pane` object](../pane/index.md) that
 represents the active pane in that window.
 
 ```lua
-local wezterm = require 'wezterm';
+local wezterm = require 'wezterm'
 
-wezterm.on("window-config-reloaded", function(window, pane)
-  wezterm.log_info("the config was reloaded for this window!");
+wezterm.on('window-config-reloaded', function(window, pane)
+  wezterm.log_info 'the config was reloaded for this window!'
 end)
 ```
 

--- a/docs/config/lua/window-events/window-resized.md
+++ b/docs/config/lua/window-events/window-resized.md
@@ -27,18 +27,18 @@ effect both when toggling fullscreen and when editing the config file to adjust
 the event handling code:
 
 ```lua
-local wezterm = require 'wezterm';
+local wezterm = require 'wezterm'
 
 function recompute_padding(window)
-  local window_dims = window:get_dimensions();
+  local window_dims = window:get_dimensions()
   local overrides = window:get_config_overrides() or {}
 
   if not window_dims.is_full_screen then
     if not overrides.window_padding then
       -- not changing anything
-      return;
+      return
     end
-    overrides.window_padding = nil;
+    overrides.window_padding = nil
   else
     -- Use only the middle 33%
     local third = math.floor(window_dims.pixel_width / 3)
@@ -46,23 +46,25 @@ function recompute_padding(window)
       left = third,
       right = third,
       top = 0,
-      bottom = 0
-    };
-    if overrides.window_padding and new_padding.left == overrides.window_padding.left then
+      bottom = 0,
+    }
+    if
+      overrides.window_padding
+      and new_padding.left == overrides.window_padding.left
+    then
       -- padding is same, avoid triggering further changes
       return
     end
     overrides.window_padding = new_padding
-
   end
   window:set_config_overrides(overrides)
 end
 
-wezterm.on("window-resized", function(window, pane)
+wezterm.on('window-resized', function(window, pane)
   recompute_padding(window)
-end);
+end)
 
-wezterm.on("window-config-reloaded", function(window)
+wezterm.on('window-config-reloaded', function(window)
   recompute_padding(window)
-end);
+end)
 ```

--- a/docs/config/lua/window/active_workspace.md
+++ b/docs/config/lua/window/active_workspace.md
@@ -10,13 +10,17 @@ and how the workspace can be shown in the right status area.
 ```lua
 local wezterm = require 'wezterm'
 
-wezterm.on("update-right-status", function(window, pane)
+wezterm.on('update-right-status', function(window, pane)
   window:set_right_status(window:active_workspace())
 end)
 
 return {
   keys = {
-    {key="9", mods="ALT", action=wezterm.action.ShowLauncherArgs{flags="FUZZY|WORKSPACES"}},
+    {
+      key = '9',
+      mods = 'ALT',
+      action = wezterm.action.ShowLauncherArgs { flags = 'FUZZY|WORKSPACES' },
+    },
   },
 }
 ```

--- a/docs/config/lua/window/composition_status.md
+++ b/docs/config/lua/window/composition_status.md
@@ -11,19 +11,19 @@ This example shows how to show the composition status in the status area.
 The cursor color is also changed to `orange` when in this state.
 
 ```lua
-local wezterm = require 'wezterm';
+local wezterm = require 'wezterm'
 
-wezterm.on("update-right-status", function(window, pane)
+wezterm.on('update-right-status', function(window, pane)
   local compose = window:composition_status()
   if compose then
-    compose = "COMPOSING: " .. compose
+    compose = 'COMPOSING: ' .. compose
   end
-  window:set_right_status(compose or "")
-end);
+  window:set_right_status(compose or '')
+end)
 
 return {
   colors = {
-    compose_cursor = "orange",
+    compose_cursor = 'orange',
   },
 }
 ```

--- a/docs/config/lua/window/copy_to_clipboard.md
+++ b/docs/config/lua/window/copy_to_clipboard.md
@@ -17,14 +17,17 @@ applications before you trigger some other action in your lua code then you may
 need to add a short sleep to allow for that to complete.
 
 ```lua
-window:copy_to_clipboard("put this text in the clipboard and primary selection!")
+window:copy_to_clipboard 'put this text in the clipboard and primary selection!'
 ```
 
 ```lua
-window:copy_to_clipboard("put me in the clipboard only", "Clipboard")
+window:copy_to_clipboard('put me in the clipboard only', 'Clipboard')
 ```
 
 ```lua
-window:copy_to_clipboard("put me in the primary selection", "PrimarySelection")
+window:copy_to_clipboard(
+  'put me in the primary selection',
+  'PrimarySelection'
+)
 ```
 

--- a/docs/config/lua/window/effective_config.md
+++ b/docs/config/lua/window/effective_config.md
@@ -15,15 +15,19 @@ If you want to change the configuration in a window, look at [set_config_overrid
 This example will log the configured font size when `CTRL-SHIFT-E` is pressed:
 
 ```lua
-local wezterm = require'wezterm'
+local wezterm = require 'wezterm'
 
-wezterm.on("show-font-size", function(window, pane)
-  wezterm.log_error(window:effective_config().font_size);
+wezterm.on('show-font-size', function(window, pane)
+  wezterm.log_error(window:effective_config().font_size)
 end)
 
 return {
   keys = {
-    {key="E", mods="CTRL", action=wezterm.action.EmitEvent("show-font-size")},
+    {
+      key = 'E',
+      mods = 'CTRL',
+      action = wezterm.action.EmitEvent 'show-font-size',
+    },
   },
 }
 ```

--- a/docs/config/lua/window/get_appearance.md
+++ b/docs/config/lua/window/get_appearance.md
@@ -23,14 +23,14 @@ automatically adjust to the current appearance:
 local wezterm = require 'wezterm'
 
 function scheme_for_appearance(appearance)
-  if appearance:find("Dark") then
-    return "Builtin Solarized Dark"
+  if appearance:find 'Dark' then
+    return 'Builtin Solarized Dark'
   else
-    return "Builtin Solarized Light"
+    return 'Builtin Solarized Light'
   end
 end
 
-wezterm.on("window-config-reloaded", function(window, pane)
+wezterm.on('window-config-reloaded', function(window, pane)
   local overrides = window:get_config_overrides() or {}
   local appearance = window:get_appearance()
   local scheme = scheme_for_appearance(appearance)
@@ -40,8 +40,7 @@ wezterm.on("window-config-reloaded", function(window, pane)
   end
 end)
 
-return {
-}
+return {}
 ```
 
 ### Wayland GNOME Appearance
@@ -63,25 +62,28 @@ following function, which takes advantage of this:
 
 ```lua
 function query_appearance_gnome()
-  local success, stdout = wezterm.run_child_process(
-    {"gsettings", "get", "org.gnome.desktop.interface", "gtk-theme"}
-  )
+  local success, stdout = wezterm.run_child_process {
+    'gsettings',
+    'get',
+    'org.gnome.desktop.interface',
+    'gtk-theme',
+  }
   -- lowercase and remove whitespace
-  stdout = stdout:lower():gsub("%s+", "")
+  stdout = stdout:lower():gsub('%s+', '')
   local mapping = {
-     highcontrast = "LightHighContrast",
-     highcontrastinverse = "DarkHighContrast",
-     adwaita = "Light",
-     ["adwaita-dark"] = "Dark"
+    highcontrast = 'LightHighContrast',
+    highcontrastinverse = 'DarkHighContrast',
+    adwaita = 'Light',
+    ['adwaita-dark'] = 'Dark',
   }
   local appearance = mapping[stdout]
   if appearance then
-     return appearance
+    return appearance
   end
-  if stdout:find("dark") then
-     return "Dark"
+  if stdout:find 'dark' then
+    return 'Dark'
   end
-  return "Light"
+  return 'Light'
 end
 ```
 
@@ -94,14 +96,14 @@ will essentially poll for the appearance periodically:
 local wezterm = require 'wezterm'
 
 function scheme_for_appearance(appearance)
-  if appearance:find("Dark") then
-    return "Builtin Solarized Dark"
+  if appearance:find 'Dark' then
+    return 'Builtin Solarized Dark'
   else
-    return "Builtin Solarized Light"
+    return 'Builtin Solarized Light'
   end
 end
 
-wezterm.on("update-right-status", function(window, pane)
+wezterm.on('update-right-status', function(window, pane)
   local overrides = window:get_config_overrides() or {}
   local appearance = query_appearance_gnome()
   local scheme = scheme_for_appearance(appearance)
@@ -111,6 +113,5 @@ wezterm.on("update-right-status", function(window, pane)
   end
 end)
 
-return {
-}
+return {}
 ```

--- a/docs/config/lua/window/get_selection_escapes_for_pane.md
+++ b/docs/config/lua/window/get_selection_escapes_for_pane.md
@@ -18,11 +18,15 @@ local wezterm = require 'wezterm'
 
 return {
   keys = {
-    {key="E", mods="CTRL", action=wezterm.action_callback(function(window, pane)
-      local ansi = window:get_selection_escapes_for_pane(pane);
-      window:copy_to_clipboard(ansi)
-    end)}
-  }
+    {
+      key = 'E',
+      mods = 'CTRL',
+      action = wezterm.action_callback(function(window, pane)
+        local ansi = window:get_selection_escapes_for_pane(pane)
+        window:copy_to_clipboard(ansi)
+      end),
+    },
+  },
 }
 ```
 

--- a/docs/config/lua/window/get_selection_text_for_pane.md
+++ b/docs/config/lua/window/get_selection_text_for_pane.md
@@ -14,16 +14,20 @@ potentially be mapped into multiple windows.
 This example logs the current selection when a CTRL+SHIFT+E is pressed:
 
 ```lua
-local wezterm = require 'wezterm';
+local wezterm = require 'wezterm'
 
-wezterm.on("log-selection", function(window, pane)
-  local sel = window:get_selection_text_for_pane(pane);
-  wezterm.log_info("selection is: " .. sel)
+wezterm.on('log-selection', function(window, pane)
+  local sel = window:get_selection_text_for_pane(pane)
+  wezterm.log_info('selection is: ' .. sel)
 end)
 
 return {
   keys = {
-    {key="E", mods="CTRL", action=wezterm.action.EmitEvent("log-selection")},
-  }
+    {
+      key = 'E',
+      mods = 'CTRL',
+      action = wezterm.action.EmitEvent 'log-selection',
+    },
+  },
 }
 ```

--- a/docs/config/lua/window/leader_is_active.md
+++ b/docs/config/lua/window/leader_is_active.md
@@ -8,20 +8,20 @@ This example shows `LEADER` in the right status area, and turns the cursor orang
 when the leader is active:
 
 ```lua
-local wezterm = require 'wezterm';
+local wezterm = require 'wezterm'
 
-wezterm.on("update-right-status", function(window, pane)
-  local leader = ""
+wezterm.on('update-right-status', function(window, pane)
+  local leader = ''
   if window:leader_is_active() then
-    leader = "LEADER"
+    leader = 'LEADER'
   end
   window:set_right_status(leader)
-end);
+end)
 
 return {
-  leader = { key="a", mods="CTRL" },
+  leader = { key = 'a', mods = 'CTRL' },
   colors = {
-    compose_cursor = "orange",
+    compose_cursor = 'orange',
   },
 }
 ```

--- a/docs/config/lua/window/set_config_overrides.md
+++ b/docs/config/lua/window/set_config_overrides.md
@@ -23,11 +23,11 @@ ligatures in the current window:
 ```lua
 local wezterm = require 'wezterm'
 
-wezterm.on("toggle-ligature", function(window, pane)
+wezterm.on('toggle-ligature', function(window, pane)
   local overrides = window:get_config_overrides() or {}
   if not overrides.harfbuzz_features then
     -- If we haven't overridden it yet, then override with ligatures disabled
-    overrides.harfbuzz_features =  {"calt=0", "clig=0", "liga=0"}
+    overrides.harfbuzz_features = { 'calt=0', 'clig=0', 'liga=0' }
   else
     -- else we did already, and we should disable out override now
     overrides.harfbuzz_features = nil
@@ -37,7 +37,11 @@ end)
 
 return {
   keys = {
-    {key="E", mods="CTRL", action=wezterm.action.EmitEvent("toggle-ligature")},
+    {
+      key = 'E',
+      mods = 'CTRL',
+      action = wezterm.action.EmitEvent 'toggle-ligature',
+    },
   },
 }
 ```
@@ -48,10 +52,10 @@ for the window:
 ```lua
 local wezterm = require 'wezterm'
 
-wezterm.on("toggle-opacity", function(window, pane)
+wezterm.on('toggle-opacity', function(window, pane)
   local overrides = window:get_config_overrides() or {}
   if not overrides.window_background_opacity then
-    overrides.window_background_opacity = 0.5;
+    overrides.window_background_opacity = 0.5
   else
     overrides.window_background_opacity = nil
   end
@@ -60,7 +64,11 @@ end)
 
 return {
   keys = {
-    {key="B", mods="CTRL", action=wezterm.action.EmitEvent("toggle-opacity")},
+    {
+      key = 'B',
+      mods = 'CTRL',
+      action = wezterm.action.EmitEvent 'toggle-opacity',
+    },
   },
 }
 ```

--- a/docs/config/lua/window/set_right_status.md
+++ b/docs/config/lua/window/set_right_status.md
@@ -18,18 +18,18 @@ Here's a basic example that displays the time in the status area:
   alt="Demonstrating setting the right status area to the current date and time">
 
 ```lua
-local wezterm = require 'wezterm';
+local wezterm = require 'wezterm'
 
-wezterm.on("update-right-status", function(window, pane)
-  local date = wezterm.strftime("%Y-%m-%d %H:%M:%S");
+wezterm.on('update-right-status', function(window, pane)
+  local date = wezterm.strftime '%Y-%m-%d %H:%M:%S'
 
   -- Make it italic and underlined
-  window:set_right_status(wezterm.format({
-    {Attribute={Underline="Single"}},
-    {Attribute={Italic=true}},
-    {Text="Hello "..date},
-  }));
-end);
+  window:set_right_status(wezterm.format {
+    { Attribute = { Underline = 'Single' } },
+    { Attribute = { Italic = true } },
+    { Text = 'Hello ' .. date },
+  })
+end)
 
 return {}
 ```
@@ -44,74 +44,74 @@ it can potentially pick up the remote hostname if your remote shell session is u
   alt="Demonstrating setting the right status area with powerline styling">
 
 ```lua
-wezterm.on("update-right-status", function(window, pane)
+wezterm.on('update-right-status', function(window, pane)
   -- Each element holds the text for a cell in a "powerline" style << fade
-  local cells = {};
+  local cells = {}
 
   -- Figure out the cwd and host of the current pane.
   -- This will pick up the hostname for the remote host if your
   -- shell is using OSC 7 on the remote host.
   local cwd_uri = pane:get_current_working_dir()
   if cwd_uri then
-    cwd_uri = cwd_uri:sub(8);
-    local slash = cwd_uri:find("/")
-    local cwd = ""
-    local hostname = ""
+    cwd_uri = cwd_uri:sub(8)
+    local slash = cwd_uri:find '/'
+    local cwd = ''
+    local hostname = ''
     if slash then
-      hostname = cwd_uri:sub(1, slash-1)
+      hostname = cwd_uri:sub(1, slash - 1)
       -- Remove the domain name portion of the hostname
-      local dot = hostname:find("[.]")
+      local dot = hostname:find '[.]'
       if dot then
-        hostname = hostname:sub(1, dot-1)
+        hostname = hostname:sub(1, dot - 1)
       end
       -- and extract the cwd from the uri
       cwd = cwd_uri:sub(slash)
 
-      table.insert(cells, cwd);
-      table.insert(cells, hostname);
+      table.insert(cells, cwd)
+      table.insert(cells, hostname)
     end
   end
 
   -- I like my date/time in this style: "Wed Mar 3 08:14"
-  local date = wezterm.strftime("%a %b %-d %H:%M");
-  table.insert(cells, date);
+  local date = wezterm.strftime '%a %b %-d %H:%M'
+  table.insert(cells, date)
 
   -- An entry for each battery (typically 0 or 1 battery)
   for _, b in ipairs(wezterm.battery_info()) do
-    table.insert(cells, string.format("%.0f%%", b.state_of_charge * 100))
+    table.insert(cells, string.format('%.0f%%', b.state_of_charge * 100))
   end
 
   -- The powerline < symbol
-  local LEFT_ARROW = utf8.char(0xe0b3);
+  local LEFT_ARROW = utf8.char(0xe0b3)
   -- The filled in variant of the < symbol
   local SOLID_LEFT_ARROW = utf8.char(0xe0b2)
 
   -- Color palette for the backgrounds of each cell
   local colors = {
-    "#3c1361",
-    "#52307c",
-    "#663a82",
-    "#7c5295",
-    "#b491c8",
-  };
+    '#3c1361',
+    '#52307c',
+    '#663a82',
+    '#7c5295',
+    '#b491c8',
+  }
 
   -- Foreground color for the text across the fade
-  local text_fg = "#c0c0c0";
+  local text_fg = '#c0c0c0'
 
   -- The elements to be formatted
-  local elements = {};
+  local elements = {}
   -- How many cells have been formatted
-  local num_cells = 0;
+  local num_cells = 0
 
   -- Translate a cell into elements
   function push(text, is_last)
     local cell_no = num_cells + 1
-    table.insert(elements, {Foreground={Color=text_fg}})
-    table.insert(elements, {Background={Color=colors[cell_no]}})
-    table.insert(elements, {Text=" "..text.." "})
+    table.insert(elements, { Foreground = { Color = text_fg } })
+    table.insert(elements, { Background = { Color = colors[cell_no] } })
+    table.insert(elements, { Text = ' ' .. text .. ' ' })
     if not is_last then
-      table.insert(elements, {Foreground={Color=colors[cell_no+1]}})
-      table.insert(elements, {Text=SOLID_LEFT_ARROW})
+      table.insert(elements, { Foreground = { Color = colors[cell_no + 1] } })
+      table.insert(elements, { Text = SOLID_LEFT_ARROW })
     end
     num_cells = num_cells + 1
   end
@@ -121,6 +121,6 @@ wezterm.on("update-right-status", function(window, pane)
     push(cell, #cells == 0)
   end
 
-  window:set_right_status(wezterm.format(elements));
-end);
+  window:set_right_status(wezterm.format(elements))
+end)
 ```

--- a/docs/config/lua/window/toast_notification.md
+++ b/docs/config/lua/window/toast_notification.md
@@ -26,8 +26,8 @@ multiple notifications:
 ```lua
 local wezterm = require 'wezterm'
 
-wezterm.on("window-config-reloaded", function(window, pane)
-  window:toast_notification("wezterm", "configuration reloaded!", nil, 4000)
+wezterm.on('window-config-reloaded', function(window, pane)
+  window:toast_notification('wezterm', 'configuration reloaded!', nil, 4000)
 end)
 
 return {}

--- a/docs/config/mouse.md
+++ b/docs/config/mouse.md
@@ -67,31 +67,31 @@ return {
 You can define mouse actions using the `mouse_bindings` configuration section:
 
 ```lua
-local wezterm = require 'wezterm';
+local wezterm = require 'wezterm'
 local act = wezterm.action
 
 return {
   mouse_bindings = {
     -- Right click sends "woot" to the terminal
     {
-      event={Down={streak=1, button="Right"}},
-      mods="NONE",
-      action=act.SendString("woot"),
+      event = { Down = { streak = 1, button = 'Right' } },
+      mods = 'NONE',
+      action = act.SendString 'woot',
     },
 
     -- Change the default click behavior so that it only selects
     -- text and doesn't open hyperlinks
     {
-      event={Up={streak=1, button="Left"}},
-      mods="NONE",
-      action=act.CompleteSelection("PrimarySelection"),
+      event = { Up = { streak = 1, button = 'Left' } },
+      mods = 'NONE',
+      action = act.CompleteSelection 'PrimarySelection',
     },
 
     -- and make CTRL-Click open hyperlinks
     {
-      event={Up={streak=1, button="Left"}},
-      mods="CTRL",
-      action=act.OpenLinkAtMouseCursor,
+      event = { Up = { streak = 1, button = 'Left' } },
+      mods = 'CTRL',
+      action = act.OpenLinkAtMouseCursor,
     },
     -- NOTE that binding only the 'Up' event can give unexpected behaviors.
     -- Read more below on the gotcha of binding an 'Up' event only.
@@ -136,22 +136,22 @@ event, but not the 'Up' event (which is bound to something in your config).
 To avoid this, it is recommended to disable the 'Down' event (to ensure it won't
 be sent to the running program), for example:
 ```lua
-local wezterm = require "wezterm"
+local wezterm = require 'wezterm'
 local act = wezterm.action
 
 return {
   mouse_bindings = {
     -- Bind 'Up' event of CTRL-Click to open hyperlinks
     {
-      event={Up={streak=1, button="Left"}},
-      mods="CTRL",
-      action=act.OpenLinkAtMouseCursor,
+      event = { Up = { streak = 1, button = 'Left' } },
+      mods = 'CTRL',
+      action = act.OpenLinkAtMouseCursor,
     },
     -- Disable the 'Down' event of CTRL-Click to avoid weird program behaviors
     {
-      event={Down={streak=1, button="Left"}},
-      mods="CTRL",
-      action=act.Nop,
+      event = { Down = { streak = 1, button = 'Left' } },
+      mods = 'CTRL',
+      action = act.Nop,
     },
   },
 }

--- a/docs/copymode.md
+++ b/docs/copymode.md
@@ -86,66 +86,182 @@ local act = wezterm.action
 return {
   key_tables = {
     copy_mode = {
-      {key="c", mods="CTRL", action=act.CopyMode("Close")},
-      {key="g", mods="CTRL", action=act.CopyMode("Close")},
-      {key="q", mods="NONE", action=act.CopyMode("Close")},
-      {key="Escape", mods="NONE", action=act.CopyMode("Close")},
+      { key = 'c', mods = 'CTRL', action = act.CopyMode 'Close' },
+      { key = 'g', mods = 'CTRL', action = act.CopyMode 'Close' },
+      { key = 'q', mods = 'NONE', action = act.CopyMode 'Close' },
+      { key = 'Escape', mods = 'NONE', action = act.CopyMode 'Close' },
 
-      {key="h", mods="NONE", action=act.CopyMode("MoveLeft")},
-      {key="j", mods="NONE", action=act.CopyMode("MoveDown")},
-      {key="k", mods="NONE", action=act.CopyMode("MoveUp")},
-      {key="l", mods="NONE", action=act.CopyMode("MoveRight")},
+      { key = 'h', mods = 'NONE', action = act.CopyMode 'MoveLeft' },
+      { key = 'j', mods = 'NONE', action = act.CopyMode 'MoveDown' },
+      { key = 'k', mods = 'NONE', action = act.CopyMode 'MoveUp' },
+      { key = 'l', mods = 'NONE', action = act.CopyMode 'MoveRight' },
 
-      {key="LeftArrow",  mods="NONE", action=act.CopyMode("MoveLeft")},
-      {key="DownArrow",  mods="NONE", action=act.CopyMode("MoveDown")},
-      {key="UpArrow",    mods="NONE", action=act.CopyMode("MoveUp")},
-      {key="RightArrow", mods="NONE", action=act.CopyMode("MoveRight")},
+      { key = 'LeftArrow', mods = 'NONE', action = act.CopyMode 'MoveLeft' },
+      { key = 'DownArrow', mods = 'NONE', action = act.CopyMode 'MoveDown' },
+      { key = 'UpArrow', mods = 'NONE', action = act.CopyMode 'MoveUp' },
+      {
+        key = 'RightArrow',
+        mods = 'NONE',
+        action = act.CopyMode 'MoveRight',
+      },
 
-      {key="RightArrow", mods="ALT",  action=act.CopyMode("MoveForwardWord")},
-      {key="f",          mods="ALT",  action=act.CopyMode("MoveForwardWord")},
-      {key="Tab",        mods="NONE", action=act.CopyMode("MoveForwardWord")},
-      {key="w",          mods="NONE", action=act.CopyMode("MoveForwardWord")},
+      {
+        key = 'RightArrow',
+        mods = 'ALT',
+        action = act.CopyMode 'MoveForwardWord',
+      },
+      { key = 'f', mods = 'ALT', action = act.CopyMode 'MoveForwardWord' },
+      {
+        key = 'Tab',
+        mods = 'NONE',
+        action = act.CopyMode 'MoveForwardWord',
+      },
+      { key = 'w', mods = 'NONE', action = act.CopyMode 'MoveForwardWord' },
 
-      {key="LeftArrow", mods="ALT",   action=act.CopyMode("MoveBackwardWord")},
-      {key="b",         mods="ALT",   action=act.CopyMode("MoveBackwardWord")},
-      {key="Tab",       mods="SHIFT", action=act.CopyMode("MoveBackwardWord")},
-      {key="b",         mods="NONE",  action=act.CopyMode("MoveBackwardWord")},
+      {
+        key = 'LeftArrow',
+        mods = 'ALT',
+        action = act.CopyMode 'MoveBackwardWord',
+      },
+      { key = 'b', mods = 'ALT', action = act.CopyMode 'MoveBackwardWord' },
+      {
+        key = 'Tab',
+        mods = 'SHIFT',
+        action = act.CopyMode 'MoveBackwardWord',
+      },
+      { key = 'b', mods = 'NONE', action = act.CopyMode 'MoveBackwardWord' },
 
-      {key="0",     mods="NONE",  action=act.CopyMode("MoveToStartOfLine")},
-      {key="Enter", mods="NONE",  action=act.CopyMode("MoveToStartOfNextLine")},
+      {
+        key = '0',
+        mods = 'NONE',
+        action = act.CopyMode 'MoveToStartOfLine',
+      },
+      {
+        key = 'Enter',
+        mods = 'NONE',
+        action = act.CopyMode 'MoveToStartOfNextLine',
+      },
 
-      {key="$",     mods="NONE",  action=act.CopyMode("MoveToEndOfLineContent")},
-      {key="$",     mods="SHIFT", action=act.CopyMode("MoveToEndOfLineContent")},
-      {key="^",     mods="NONE",  action=act.CopyMode("MoveToStartOfLineContent")},
-      {key="^",     mods="SHIFT", action=act.CopyMode("MoveToStartOfLineContent")},
-      {key="m",     mods="ALT",   action=act.CopyMode("MoveToStartOfLineContent")},
+      {
+        key = '$',
+        mods = 'NONE',
+        action = act.CopyMode 'MoveToEndOfLineContent',
+      },
+      {
+        key = '$',
+        mods = 'SHIFT',
+        action = act.CopyMode 'MoveToEndOfLineContent',
+      },
+      {
+        key = '^',
+        mods = 'NONE',
+        action = act.CopyMode 'MoveToStartOfLineContent',
+      },
+      {
+        key = '^',
+        mods = 'SHIFT',
+        action = act.CopyMode 'MoveToStartOfLineContent',
+      },
+      {
+        key = 'm',
+        mods = 'ALT',
+        action = act.CopyMode 'MoveToStartOfLineContent',
+      },
 
-      {key=" ", mods="NONE",  action=act.CopyMode{SetSelectionMode="Cell"}},
-      {key="v", mods="NONE",  action=act.CopyMode{SetSelectionMode="Cell"}},
-      {key="V", mods="NONE",  action=act.CopyMode{SetSelectionMode="Line"}},
-      {key="V", mods="SHIFT", action=act.CopyMode{SetSelectionMode="Line"}},
-      {key="v", mods="CTRL",  action=act.CopyMode{SetSelectionMode="Block"}},
+      {
+        key = ' ',
+        mods = 'NONE',
+        action = act.CopyMode { SetSelectionMode = 'Cell' },
+      },
+      {
+        key = 'v',
+        mods = 'NONE',
+        action = act.CopyMode { SetSelectionMode = 'Cell' },
+      },
+      {
+        key = 'V',
+        mods = 'NONE',
+        action = act.CopyMode { SetSelectionMode = 'Line' },
+      },
+      {
+        key = 'V',
+        mods = 'SHIFT',
+        action = act.CopyMode { SetSelectionMode = 'Line' },
+      },
+      {
+        key = 'v',
+        mods = 'CTRL',
+        action = act.CopyMode { SetSelectionMode = 'Block' },
+      },
 
-      {key="G", mods="NONE",  action=act.CopyMode("MoveToScrollbackBottom")},
-      {key="G", mods="SHIFT", action=act.CopyMode("MoveToScrollbackBottom")},
-      {key="g", mods="NONE",  action=act.CopyMode("MoveToScrollbackTop")},
+      {
+        key = 'G',
+        mods = 'NONE',
+        action = act.CopyMode 'MoveToScrollbackBottom',
+      },
+      {
+        key = 'G',
+        mods = 'SHIFT',
+        action = act.CopyMode 'MoveToScrollbackBottom',
+      },
+      {
+        key = 'g',
+        mods = 'NONE',
+        action = act.CopyMode 'MoveToScrollbackTop',
+      },
 
-      {key="H", mods="NONE",  action=act.CopyMode("MoveToViewportTop")},
-      {key="H", mods="SHIFT", action=act.CopyMode("MoveToViewportTop")},
-      {key="M", mods="NONE",  action=act.CopyMode("MoveToViewportMiddle")},
-      {key="M", mods="SHIFT", action=act.CopyMode("MoveToViewportMiddle")},
-      {key="L", mods="NONE",  action=act.CopyMode("MoveToViewportBottom")},
-      {key="L", mods="SHIFT", action=act.CopyMode("MoveToViewportBottom")},
+      {
+        key = 'H',
+        mods = 'NONE',
+        action = act.CopyMode 'MoveToViewportTop',
+      },
+      {
+        key = 'H',
+        mods = 'SHIFT',
+        action = act.CopyMode 'MoveToViewportTop',
+      },
+      {
+        key = 'M',
+        mods = 'NONE',
+        action = act.CopyMode 'MoveToViewportMiddle',
+      },
+      {
+        key = 'M',
+        mods = 'SHIFT',
+        action = act.CopyMode 'MoveToViewportMiddle',
+      },
+      {
+        key = 'L',
+        mods = 'NONE',
+        action = act.CopyMode 'MoveToViewportBottom',
+      },
+      {
+        key = 'L',
+        mods = 'SHIFT',
+        action = act.CopyMode 'MoveToViewportBottom',
+      },
 
-      {key="o", mods="NONE",  action=act.CopyMode("MoveToSelectionOtherEnd")},
-      {key="O", mods="NONE",  action=act.CopyMode("MoveToSelectionOtherEndHoriz")},
-      {key="O", mods="SHIFT", action=act.CopyMode("MoveToSelectionOtherEndHoriz")},
+      {
+        key = 'o',
+        mods = 'NONE',
+        action = act.CopyMode 'MoveToSelectionOtherEnd',
+      },
+      {
+        key = 'O',
+        mods = 'NONE',
+        action = act.CopyMode 'MoveToSelectionOtherEndHoriz',
+      },
+      {
+        key = 'O',
+        mods = 'SHIFT',
+        action = act.CopyMode 'MoveToSelectionOtherEndHoriz',
+      },
 
-      {key="PageUp",   mods="NONE", action=act.CopyMode("PageUp")},
-      {key="PageDown", mods="NONE", action=act.CopyMode("PageDown")},
+      { key = 'PageUp', mods = 'NONE', action = act.CopyMode 'PageUp' },
+      { key = 'PageDown', mods = 'NONE', action = act.CopyMode 'PageDown' },
 
-      {key="b", mods="CTRL", action=act.CopyMode("PageUp")},
-      {key="f", mods="CTRL", action=act.CopyMode("PageDown")},
+      { key = 'b', mods = 'CTRL', action = act.CopyMode 'PageUp' },
+      { key = 'f', mods = 'CTRL', action = act.CopyMode 'PageDown' },
     },
   },
 }

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -93,14 +93,14 @@ You can resolve this by explicitly adding fallback font(s) the have the glyphs
 that you need in your `.wezterm.lua`:
 
 ```lua
-local wezterm = require 'wezterm';
+local wezterm = require 'wezterm'
 
 return {
-  font = wezterm.font_with_fallback({
-    "My Preferred Font",
+  font = wezterm.font_with_fallback {
+    'My Preferred Font',
     -- This font has a broader selection of Chinese glyphs than my preferred font
-    "DengXian"
-  })
+    'DengXian',
+  },
 }
 ```
 

--- a/docs/hyperlinks.md
+++ b/docs/hyperlinks.md
@@ -18,22 +18,22 @@ return {
     -- Linkify things that look like URLs and the host has a TLD name.
     -- Compiled-in default. Used if you don't specify any hyperlink_rules.
     {
-      regex = "\\b\\w+://[\\w.-]+\\.[a-z]{2,15}\\S*\\b",
-      format = "$0",
+      regex = '\\b\\w+://[\\w.-]+\\.[a-z]{2,15}\\S*\\b',
+      format = '$0',
     },
 
     -- linkify email addresses
     -- Compiled-in default. Used if you don't specify any hyperlink_rules.
     {
       regex = [[\b\w+@[\w-]+(\.[\w-]+)+\b]],
-      format = "mailto:$0",
+      format = 'mailto:$0',
     },
 
     -- file:// URI
     -- Compiled-in default. Used if you don't specify any hyperlink_rules.
     {
       regex = [[\bfile://\S*\b]],
-      format = "$0",
+      format = '$0',
     },
 
     -- Linkify things that look like URLs with numeric addresses as hosts.
@@ -41,25 +41,25 @@ return {
     -- or http://192.168.1.1 for the web interface of many routers.
     {
       regex = [[\b\w+://(?:[\d]{1,3}\.){3}[\d]{1,3}\S*\b]],
-      format = "$0",
+      format = '$0',
     },
 
     -- Make task numbers clickable
     -- The first matched regex group is captured in $1.
     {
       regex = [[\b[tT](\d+)\b]],
-      format = "https://example.com/tasks/?t=$1",
+      format = 'https://example.com/tasks/?t=$1',
     },
-    
+
     -- Make username/project paths clickable. This implies paths like the following are for GitHub.
     -- ( "nvim-treesitter/nvim-treesitter" | wbthomason/packer.nvim | wez/wezterm | "wez/wezterm.git" )
-    -- As long as a full URL hyperlink regex exists above this it should not match a full URL to 
+    -- As long as a full URL hyperlink regex exists above this it should not match a full URL to
     -- GitHub or GitLab / BitBucket (i.e. https://gitlab.com/user/project.git is still a whole clickable URL)
     {
       regex = [[["]?([\w\d]{1}[-\w\d]+)(/){1}([-\w\d\.]+)["]?]],
-      format = "https://www.github.com/$1/$3",
-    }
-  }
+      format = 'https://www.github.com/$1/$3',
+    },
+  },
 }
 ```
 

--- a/docs/multiplexing.md
+++ b/docs/multiplexing.md
@@ -39,14 +39,14 @@ return {
   ssh_domains = {
     {
       -- This name identifies the domain
-      name = "my.server",
+      name = 'my.server',
       -- The hostname or address to connect to. Will be used to match settings
       -- from your ssh config file
-      remote_address = "192.168.1.1",
+      remote_address = '192.168.1.1',
       -- The username to use on the remote host
-      username = "wez",
-    }
-  }
+      username = 'wez',
+    },
+  },
 }
 ```
 
@@ -81,15 +81,15 @@ when wezterm is launched:
 return {
   unix_domains = {
     {
-      name = "unix",
-    }
+      name = 'unix',
+    },
   },
 
   -- This causes `wezterm` to act as though it was started as
   -- `wezterm connect unix` by default, connecting to the unix
   -- domain on startup.
   -- If you prefer to connect manually, leave out this line.
-  default_gui_startup_args = {"connect", "unix"},
+  default_gui_startup_args = { 'connect', 'unix' },
 }
 ```
 
@@ -111,7 +111,7 @@ return {
   unix_domains = {
     {
       -- The name; must be unique amongst all domains
-      name = "unix",
+      name = 'unix',
 
       -- The path to the socket.  If unspecified, a resonable default
       -- value will be computed.
@@ -130,9 +130,8 @@ return {
       -- on the host NTFS volume.
 
       -- skip_permissions_check = false,
-
-    }
-  }
+    },
+  },
 }
 ```
 
@@ -151,10 +150,10 @@ to an appropriate invocation of netcat/socat on Windows:
 return {
   unix_domains = {
     {
-      name = "unix",
-      proxy_command = {"nc", "-U", "/Users/wez/.local/share/wezterm/sock"},
-    }
-  }
+      name = 'unix',
+      proxy_command = { 'nc', '-U', '/Users/wez/.local/share/wezterm/sock' },
+    },
+  },
 }
 ```
 
@@ -171,9 +170,9 @@ user. This option only applies when `multiplexing = "WezTerm"`.
 return {
   unix_domains = {
     {
-      name = "unix",
+      name = 'unix',
       local_echo_threshold_ms = 10,
-    }
+    },
   },
 }
 ```
@@ -206,11 +205,11 @@ In the host win32 configuration, use this snippet:
 return {
   unix_domains = {
     {
-      name = "wsl",
-      serve_command = {"wsl", "wezterm-mux-server", "--daemonize"},
-    }
+      name = 'wsl',
+      serve_command = { 'wsl', 'wezterm-mux-server', '--daemonize' },
+    },
   },
-  default_gui_startup_args = {"connect", "wsl"},
+  default_gui_startup_args = { 'connect', 'wsl' },
 }
 ```
 
@@ -245,14 +244,14 @@ return {
     {
       -- A handy alias for this session; you will use `wezterm connect server.name`
       -- to connect to it.
-      name = "server.name",
+      name = 'server.name',
       -- The host:port for the remote host
-      remote_address = "server.hostname:8080",
+      remote_address = 'server.hostname:8080',
       -- The value can be "user@host:port"; it accepts the same syntax as the
       -- `wezterm ssh` subcommand.
-      bootstrap_via_ssh = "server.hostname",
-    }
-  }
+      bootstrap_via_ssh = 'server.hostname',
+    },
+  },
 }
 ```
 
@@ -267,9 +266,9 @@ return {
     {
       -- The host:port combination on which the server will listen
       -- for connections
-      bind_address = "server.hostname:8080"
-    }
-  }
+      bind_address = 'server.hostname:8080',
+    },
+  },
 }
 ```
 

--- a/docs/scrollback.md
+++ b/docs/scrollback.md
@@ -103,18 +103,30 @@ local act = wezterm.action
 return {
   key_tables = {
     search_mode = {
-      {key="Escape", mods="NONE", action=act.CopyMode("Close")},
-      {key="UpArrow", mods="NONE", action=act.CopyMode("PriorMatch")},
-      {key="Enter", mods="NONE", action=act.CopyMode("PriorMatch")},
-      {key="p", mods="CTRL", action=act.CopyMode("PriorMatch")},
-      {key="PageUp", mods="NONE", action=act.CopyMode("PriorMatchPage")},
-      {key="PageDown", mods="NONE", action=act.CopyMode("NextMatchPage")},
-      {key="n", mods="CTRL", action=act.CopyMode("NextMatchPage")},
-      {key="DownArrow", mods="NONE", action=act.CopyMode("NextMatch")},
-      {key="r", mods="CTRL", action=act.CopyMode("CycleMatchType")},
-      {key="u", mods="CTRL", action=act.CopyMode("ClearPattern")},
-    }
-  }
+      { key = 'Escape', mods = 'NONE', action = act.CopyMode 'Close' },
+      { key = 'UpArrow', mods = 'NONE', action = act.CopyMode 'PriorMatch' },
+      { key = 'Enter', mods = 'NONE', action = act.CopyMode 'PriorMatch' },
+      { key = 'p', mods = 'CTRL', action = act.CopyMode 'PriorMatch' },
+      {
+        key = 'PageUp',
+        mods = 'NONE',
+        action = act.CopyMode 'PriorMatchPage',
+      },
+      {
+        key = 'PageDown',
+        mods = 'NONE',
+        action = act.CopyMode 'NextMatchPage',
+      },
+      { key = 'n', mods = 'CTRL', action = act.CopyMode 'NextMatchPage' },
+      {
+        key = 'DownArrow',
+        mods = 'NONE',
+        action = act.CopyMode 'NextMatch',
+      },
+      { key = 'r', mods = 'CTRL', action = act.CopyMode 'CycleMatchType' },
+      { key = 'u', mods = 'CTRL', action = act.CopyMode 'ClearPattern' },
+    },
+  },
 }
 ```
 
@@ -132,11 +144,15 @@ for your mouse to copy and paste a relevant git commit hash then you might like
 this:
 
 ```lua
-local wezterm = require 'wezterm';
+local wezterm = require 'wezterm'
 return {
   keys = {
     -- search for things that look like git hashes
-    {key="H", mods="SHIFT|CTRL", action=wezterm.action.Search{Regex="[a-f0-9]{6,}"}},
+    {
+      key = 'H',
+      mods = 'SHIFT|CTRL',
+      action = wezterm.action.Search { Regex = '[a-f0-9]{6,}' },
+    },
   },
 }
 ```

--- a/docs/shell-integration.md
+++ b/docs/shell-integration.md
@@ -63,8 +63,8 @@ span multiple lines:
 ```lua
 return {
   set_environment_variables = {
-    prompt = "$E]7;file://localhost/$P$E\\$E[32m$T$E[0m $E[35m$P$E[36m$_$G$E[0m ",
-  }
+    prompt = '$E]7;file://localhost/$P$E\\$E[32m$T$E[0m $E[35m$P$E[36m$_$G$E[0m ',
+  },
 }
 ```
 
@@ -97,18 +97,20 @@ in your `.wezterm.lua`; for example, if you have extracted clink to `c:\clink`
 you might configure this:
 
 ```lua
-local wezterm = require 'wezterm';
+local wezterm = require 'wezterm'
 
-local default_prog;
+local default_prog
 local set_environment_variables = {}
 
-if wezterm.target_triple == "x86_64-pc-windows-msvc" then
+if wezterm.target_triple == 'x86_64-pc-windows-msvc' then
   -- Use OSC 7 as per the above example
-  set_environment_variables["prompt"] = "$E]7;file://localhost/$P$E\\$E[32m$T$E[0m $E[35m$P$E[36m$_$G$E[0m "
+  set_environment_variables['prompt'] =
+    '$E]7;file://localhost/$P$E\\$E[32m$T$E[0m $E[35m$P$E[36m$_$G$E[0m '
   -- use a more ls-like output format for dir
-  set_environment_variables["DIRCMD"] = "/d"
+  set_environment_variables['DIRCMD'] = '/d'
   -- And inject clink into the command prompt
-  default_prog = {"cmd.exe", "/s", "/k", "c:/clink/clink_x64.exe", "inject", "-q"}
+  default_prog =
+    { 'cmd.exe', '/s', '/k', 'c:/clink/clink_x64.exe', 'inject', '-q' }
 end
 
 return {


### PR DESCRIPTION
I build an app called [Gelatyx](https://github.com/azzamsa/gelatyx) for this purpose.  It worked well.  However, StyLua find some invalid code such;

```bash
[31merror parsing: error occurred while creating ast: unexpected token `(`. (starting from line 1, character 9 and ending on line 1, character 10)
additional information: expected function name[0m
[31merror parsing: error occurred while creating ast: unexpected token `(`. (starting from line 3, character 9 and ending on line 3, character 10)
additional information: expected function name[0m
[32mdocs/config/lua/ExecDomain.md[0m is formatted
```

It says the code is missing function name: https://github.com/wez/wezterm/blob/2b17a64d740023efed4d596640346a931b2a29a3/docs/config/lua/ExecDomain.md?plain=1#L37

Here is the full list of files that has invalid code:
[result.txt](https://github.com/wez/wezterm/files/9127839/result.txt)

Usage;

```bash
$ gelatyx lua --file docs/**/*.md --check
```

fixes:  #2253