### PR TITLE
zsh  p10k and fast syntax highlight base16 preview for docs

### DIFF
--- a/ci/generate-docs.py
+++ b/ci/generate-docs.py
@@ -174,6 +174,17 @@ def screen_shot_table(scheme):
 
     return base64.b64encode(f"{header}\n{data}\n".encode("UTF-8")).decode("UTF-8")
 
+def prompt_preview(scheme, screen) -> str:
+    header = {
+        "version": 2,
+        "width": 80,
+        "height": 24,
+        "title": scheme["name"],
+    }
+    header = json.dumps(header, sort_keys=True)
+    data = json.dumps([0.0, "o", screen])
+
+    return base64.b64encode(f"{header}\n{data}\n".encode("UTF-8")).decode("UTF-8")
 
 class GenColorScheme(object):
     def __init__(self, title, dirname, index=None):
@@ -197,6 +208,9 @@ class GenColorScheme(object):
             scheme_filename = f"{self.dirname}/{scheme_prefix}/index.md"
             os.makedirs(os.path.dirname(scheme_filename), exist_ok=True)
             children.append(Page(scheme_prefix, scheme_filename))
+            ansifile = open(f"{self.dirname}/zsh-fsyh-base16.ansi", "r")
+            ansistr = ansifile.read()
+            ansistr = ansistr.replace("\n","\r\n")
 
             with open(scheme_filename, "w") as idx:
 
@@ -205,11 +219,13 @@ class GenColorScheme(object):
                     idx.write(f"# {title}\n")
 
                     data = screen_shot_table(scheme)
+                    prompt_data = prompt_preview(scheme, ansistr)
                     ident = scheme["ident"]
 
                     idx.write(
                         f"""
-<div id="{ident}-player"></div>
+<div id="{ident}-palette-player"></div>
+<div id="{ident}-prompt-player"></div>
 
 <style>
 {scheme["css"]}
@@ -219,7 +235,13 @@ class GenColorScheme(object):
 window.addEventListener('load', function () {{
     AsciinemaPlayer.create(
         'data:text/plain;base64,{data}',
-        document.getElementById('{ident}-player'), {{
+        document.getElementById('{ident}-palette-player'), {{
+        theme: "{ident}",
+        autoPlay: true,
+    }});
+    AsciinemaPlayer.create(
+        'data:text/plain;base64,{prompt_data}',
+        document.getElementById('{ident}-prompt-player'), {{
         theme: "{ident}",
         autoPlay: true,
     }});

--- a/docs/colorschemes/zsh-fsyh-base16.ansi
+++ b/docs/colorschemes/zsh-fsyh-base16.ansi
@@ -1,0 +1,23 @@
+[37m░▒▓[38;5;232m[47m  [37m[44m[38;5;254m  [1m[38;5;255m~[0m[38;5;254m[44m/[38;5;250mDoc[38;5;254m/[1m[38;5;255mcoolors[0m[38;5;254m[44m [34m[43m[30m   master !5 ?13 [33m[49m[39m [34mfast-theme[39m [33m-t[39m [91mbase16
+[90m# simple fn with loop
+[39m_fmt_tmux_string[35m()[1m[33m{
+[0m[39m[49m [34mlocal[39m -A windata=[35m([31m$[1m[36m{[0m[31m[49mreply[1m[32m[[0m[31m[49m@[1m[32m][36m}[0m[35m[49m)
+[39m reply=[35m()
+[39m [35mfor[39m k v in [31m$[1m[36m{[32m([0m[31m[49mQkv[1m[32m)[0m[31m[49mwindata[1m[32m[[0m[31m[49m@[1m[32m][36m}[0m[39m[49m; [35mdo
+[39m   fmt_string=[31m$[1m[36m{[0m[39m[49mfmt_string/[31m$k[39m/[31m$v[1m[36m}
+[0m[39m[49m [35mdone
+[39m reply+=[31m$fmt_string
+[1m[33m}
+[0m[90m[49m# loop
+[35mrepeat[39m 0 [1m[33m{
+[0m[39m[49m [34mzsh[39m [33m-i[39m -c "[34mcat[39m [36m/etc/shells*[39m | [34mgrep[39m [33m-x[39m [33m--line-buffered[39m [33m-i[39m [32m'/bin/zsh[39m'"
+ [36mbuiltin[39m [34mexit[39m [31m$return_value
+[39m [34mfast-theme[39m [33m-tq[39m [91mdefault
+[39m [34mfsh-alias[39m [33m-tq[39m [31mdefault-X
+[39m [36mcommand[39m [33m-v[39m [34mgit[39m | [34mgrep[39m [32m".+git"[39m && [34mecho[39m [32m$'Git is installed'
+[39m [34mgit[39m [36mcheckout[39m [33m-m[39m [33m--ours[39m [94m/etc/shells[39m && [34mgit[39m status-X
+ [34mgem[39m [36minstall[39m asciidoctor
+ [34mcat[39m [96m<<<[31m[103m$PATH[39m[49m | [34mtr[39m : \\n > [91m/dev/null[39m 2>[4m[91m/usr/local
+[0m[39m[49m [34mman[39m [33m-a[39m fopen fopen-X
+ CFLAGS=[32m"-g -Wall -O0"[39m [1m[31m./configure
+[33m}


### PR DESCRIPTION
the palette is great and all but not the greatest for showing the color usage in an actual use case. figured it would be nice to show the scheme in a real usage scenario

![Screenshot_2022-07-20-02-33-01_1920x1080](https://user-images.githubusercontent.com/1828125/179913041-6f6d056e-ef2e-4413-b946-99983bd9933c.png)

adds an extra asciipreview with a dump from a tmux pane with p10k prompt and output of `fast-theme -t base16` which is the `zsh-users/F-sy-h` syntax highlighted