### PR TITLE
lua: WheelUp and WheelDown support for mouse_bindings

### DIFF
--- a/config/src/keyassignment.rs
+++ b/config/src/keyassignment.rs
@@ -132,6 +132,7 @@ impl Default for Pattern {
 
 /// A mouse event that can trigger an action
 #[derive(Debug, Clone, PartialEq, Eq, Ord, PartialOrd, Hash, FromDynamic, ToDynamic)]
+#[dynamic(try_from = "String")]
 pub enum MouseEventTrigger {
     /// Mouse button is pressed. streak is how many times in a row
     /// it was pressed.
@@ -142,6 +143,34 @@ pub enum MouseEventTrigger {
     /// Mouse button is being released. streak is how many times
     /// in a row it was pressed and released.
     Up { streak: usize, button: MouseButton },
+}
+
+impl MouseEventTrigger {
+    pub const fn default_wheel_up() -> MouseEventTrigger {
+        MouseEventTrigger::Down {
+            streak: 1,
+            button: MouseButton::WheelUp(1),
+        }
+    }
+
+    pub const fn default_wheel_down() -> MouseEventTrigger {
+        MouseEventTrigger::Down {
+            streak: 1,
+            button: MouseButton::WheelDown(1),
+        }
+    }
+}
+
+impl TryFrom<String> for MouseEventTrigger {
+    type Error = String;
+
+    fn try_from(s: String) -> Result<MouseEventTrigger, String> {
+        match &*s {
+            "WheelUp" => Ok(Self::default_wheel_up()),
+            "WheelDown" => Ok(Self::default_wheel_down()),
+            _ => Err(format!("Could not parse '{}'", s)),
+        }
+    }
 }
 
 /// When spawning a tab, specify which domain should be used to

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -18,6 +18,7 @@ As features stabilize some brief notes about them will accumulate here.
 * [window:set_position](config/lua/window/set_position.md) method for controlling window position.
 * [window:maximize](config/lua/window/maximize.md) and [window:restore](config/lua/window/restore.md) methods for controlling window maximization state.
 * [window:get_selection_escapes_for_pane](config/lua/window/get_selection_escapes_for_pane.md) method for getting the current selection including escape sequences. [#2223](https://github.com/wez/wezterm/issues/2223)
+* [window:current_event](config/lua/window/current_event.md) method for getting the current event. [#2296](https://github.com/wez/wezterm/pull/2296)
 * [wezterm.color](config/lua/wezterm.color/index.md) module for working with colors and importing color schemes.
 * [wezterm.gui](config/lua/wezterm.gui/index.md) module and [mux_window:gui_window](config/lua/mux-window/gui_window.md) method.
 * [wezterm.gui.screens()](config/lua/wezterm.gui/screens.md) function for getting information about the available screens/monitors/displays
@@ -32,6 +33,7 @@ As features stabilize some brief notes about them will accumulate here.
 * [pane:is_alt_screen_active()](config/lua/pane/is_alt_screen_active.md) for testing whether the alt screen is active. Thanks to [@Funami580](https://github.com/Funami580)! [#2234](https://github.com/wez/wezterm/issues/2234)
 * X11/Wayland: [XDG desktop portal](https://flatpak.github.io/xdg-desktop-portal/) is now used to determine whether dark mode is in use [#2258](https://github.com/wez/wezterm/issues/2258)
 * [SetPaneZoomState](config/lua/keyassignment/SetPaneZoomState.md) key assignment and [MuxTab:set_zoomed()](config/lua/MuxTab/set_zoomed.md) for explicitly setting the zoom state of a pane. [#2284](https://github.com/wez/wezterm/discussions/2284)
+* [mouse_bindings](config/mouse.md) can now handle scroll events. Thanks to [@Funami580](https://github.com/Funami580)! [#2173](https://github.com/wez/wezterm/issues/2173) [#2296](https://github.com/wez/wezterm/pull/2296)
 
 #### Changed
 * If `timeout_milliseconds` is specified in

--- a/docs/config/lua/window/current_event.md
+++ b/docs/config/lua/window/current_event.md
@@ -1,0 +1,26 @@
+# `window:current_event()`
+
+*Since: nightly builds only*
+
+Returns the current event.
+For now only implemented for mouse events.
+
+This example prints the delta scroll value
+when you scroll up with your mouse wheel while holding `CTRL`:
+
+```lua
+local wezterm = require 'wezterm'
+
+return {
+  mouse_bindings = {
+    {
+      event = 'WheelUp',
+      mods = 'CTRL',
+      action = wezterm.action_callback(function(window, pane)
+        local delta = window:current_event()['Down']['button']['WheelUp']
+        wezterm.log_info('delta is: ' .. delta)
+      end),
+    },
+  },
+}
+```

--- a/docs/config/mouse.md
+++ b/docs/config/mouse.md
@@ -124,6 +124,36 @@ you wanted quadruple-click bindings you can specify `streak=4`.
 | Double Left Up  | `event={Up={streak=2, button="Left"}}` |
 | Single Left Drag  | `event={Drag={streak=1, button="Left"}}` |
 
+*since: nightly builds only*
+
+You can handle scroll events by using `'WheelUp'` or `'WheelDown'` as event.
+Currently, this only works with at least one modifier being present.
+
+```lua
+local wezterm = require 'wezterm'
+local act = wezterm.action
+
+return {
+  mouse_bindings = {
+    -- Scrolling up while holding CTRL increases the font size
+    {
+      event = 'WheelUp',
+      mods = 'CTRL',
+      action = act.IncreaseFontSize,
+    },
+
+    -- Scrolling down while holding CTRL decreases the font size
+    {
+      event = 'WheelDown',
+      mods = 'CTRL',
+      action = act.DecreaseFontSize,
+    },
+  },
+}
+```
+
+Take a look at [`window:current_event`](lua/window/current_event.md),
+if you want to access the delta scroll value while handling the event.
 
 # Gotcha on binding an 'Up' event only
 

--- a/wezterm-gui/src/termwindow/mod.rs
+++ b/wezterm-gui/src/termwindow/mod.rs
@@ -53,6 +53,7 @@ use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 use termwiz::hyperlink::Hyperlink;
 use termwiz::surface::SequenceNo;
+use wezterm_dynamic::Value;
 use wezterm_font::FontConfiguration;
 use wezterm_gui_subcommands::GuiPosition;
 use wezterm_term::color::ColorPalette;
@@ -408,6 +409,7 @@ pub struct TermWindow {
     modal: RefCell<Option<Rc<dyn Modal>>>,
 
     event_states: HashMap<String, EventState>,
+    pub current_event: Option<Value>,
     has_animation: RefCell<Option<Instant>>,
     /// We use this to attempt to do something reasonable
     /// if we run out of texture space
@@ -695,6 +697,7 @@ impl TermWindow {
                 None,
             )),
             event_states: HashMap::new(),
+            current_event: None,
             has_animation: RefCell::new(None),
             scheduled_animation: RefCell::new(None),
             allow_images: true,


### PR DESCRIPTION
refs: #2173

Allows you to do things like
```lua
local wezterm = require 'wezterm'

return {
  mouse_bindings = {
    {
      event="WheelUp",
      mods="CTRL",
      action=wezterm.scroll_callback(function(window, pane, delta)
        window:perform_action("IncreaseFontSize", pane)
      end),
    },
    {
      event="WheelDown",
      mods="CTRL",
      action=wezterm.scroll_callback(function(window, pane, delta)
        window:perform_action("DecreaseFontSize", pane)
      end),
    },
  },
}
```