### PR TITLE
fonts: Allow to build GUI without vendored (built-in) fonts

### DIFF
--- a/wezterm-font/Cargo.toml
+++ b/wezterm-font/Cargo.toml
@@ -6,6 +6,9 @@ edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+vendored-fonts = []
+
 [dependencies]
 anyhow = "1.0"
 config = { path = "../config" }

--- a/wezterm-font/src/parser.rs
+++ b/wezterm-font/src/parser.rs
@@ -700,7 +700,9 @@ pub(crate) fn load_built_in_fonts(font_info: &mut Vec<ParsedFont>) -> anyhow::Re
         };
     }
     let lib = crate::ftwrap::Library::new()?;
-    for (data, name) in &[
+
+    #[cfg(any(test, feature = "vendored-fonts"))]
+    let fonts = &[
         font!("../../assets/fonts/JetBrainsMono-BoldItalic.ttf"),
         font!("../../assets/fonts/JetBrainsMono-Bold.ttf"),
         font!("../../assets/fonts/JetBrainsMono-ExtraBoldItalic.ttf"),
@@ -730,7 +732,13 @@ pub(crate) fn load_built_in_fonts(font_info: &mut Vec<ParsedFont>) -> anyhow::Re
         font!("../../assets/fonts/NotoColorEmoji.ttf"),
         font!("../../assets/fonts/Symbols-Nerd-Font-Mono.ttf"),
         font!("../../assets/fonts/LastResortHE-Regular.ttf"),
-    ] {
+    ];
+    #[cfg(not(any(test, feature = "vendored-fonts")))]
+    let fonts = &[
+        font!("../../assets/fonts/LastResortHE-Regular.ttf"),
+    ];
+
+    for (data, name) in fonts {
         let locator = FontDataHandle {
             source: FontDataSource::BuiltIn { data, name },
             index: 0,

--- a/wezterm-gui/Cargo.toml
+++ b/wezterm-gui/Cargo.toml
@@ -9,9 +9,10 @@ resolver = "2"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = ["wayland"]
+default = ["vendored-fonts", "wayland"]
 wayland = ["window/wayland"]
 distro-defaults = ["config/distro-defaults"]
+vendored-fonts = ["wezterm-font/vendored-fonts"]
 
 [build-dependencies]
 anyhow = "1.0"


### PR DESCRIPTION
Bundling fonts into the binary is ~~completely~~ unnecessary ~~and inadequate~~ when WezTerm is installed using a package manager, e.g. from a Linux distribution repository. The package maintainer can declare the needed fonts as dependencies of the package, so they can be installed with the WezTerm package into a standard location, available for all applications.

This commit adds a new feature gate "vendored-fonts" into wezterm-font and wezterm-gui. If this feature is disabled, ~~load_built_in_fonts() in parser.rs is replaced with a no-op function and no fonts are included in the binary.~~ only LastResortHE-Regular.ttf is included in the binary (according to https://github.com/wez/wezterm/pull/2305#issuecomment-1194779072, WezTerm would panic if this font is not found). WezTerm will simply use the system's font API (fontconfig on Linux) to locate the default fonts.

This feature is enabled by default in wezterm-gui, so nothing will change, unless explicitly disabled.