### PR TITLE
Allow to build with system-provided xcb-imdkit and libzstd

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6005,6 +6005,7 @@ checksum = "ebd5b733d7cf2d9447e2c3e76a5589b4f5e5ae065c22a2bc0b023cbc331b6c8e"
 dependencies = [
  "cc",
  "libc",
+ "pkg-config",
 ]
 
 [[package]]

--- a/codec/Cargo.toml
+++ b/codec/Cargo.toml
@@ -6,6 +6,9 @@ edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+system-libs = ["zstd/pkg-config"]
+
 [dependencies]
 anyhow = "1.0"
 config = { path = "../config" }

--- a/wezterm-gui/Cargo.toml
+++ b/wezterm-gui/Cargo.toml
@@ -12,7 +12,7 @@ resolver = "2"
 default = ["wayland"]
 wayland = ["window/wayland"]
 distro-defaults = ["config/distro-defaults"]
-system-libs = ["window/system-libs"]
+system-libs = ["codec/system-libs", "window/system-libs"]
 
 [build-dependencies]
 anyhow = "1.0"

--- a/wezterm-gui/Cargo.toml
+++ b/wezterm-gui/Cargo.toml
@@ -12,6 +12,7 @@ resolver = "2"
 default = ["wayland"]
 wayland = ["window/wayland"]
 distro-defaults = ["config/distro-defaults"]
+system-libs = ["window/system-libs"]
 
 [build-dependencies]
 anyhow = "1.0"

--- a/wezterm-mux-server-impl/Cargo.toml
+++ b/wezterm-mux-server-impl/Cargo.toml
@@ -6,6 +6,9 @@ edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+system-libs = ["codec/system-libs"]
+
 [dependencies]
 anyhow = "1.0"
 async_ossl = { path = "../async_ossl" }

--- a/wezterm-mux-server/Cargo.toml
+++ b/wezterm-mux-server/Cargo.toml
@@ -7,6 +7,9 @@ resolver = "2"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+system-libs = ["wezterm-mux-server-impl/system-libs"]
+
 [dependencies]
 anyhow = "1.0"
 async_ossl = { path = "../async_ossl" }

--- a/wezterm/Cargo.toml
+++ b/wezterm/Cargo.toml
@@ -6,6 +6,9 @@ edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+system-libs = ["codec/system-libs"]
+
 [build-dependencies]
 anyhow = "1.0"
 

--- a/window/Cargo.toml
+++ b/window/Cargo.toml
@@ -16,6 +16,7 @@ gl_generator = "0.14"
 
 [features]
 wayland = ["wayland-client", "smithay-client-toolkit", "wayland-egl", "wayland-protocols"]
+system-libs = ["xcb-imdkit/use-system-lib"]
 
 [dependencies]
 async-channel = "1.6"


### PR DESCRIPTION
### window: allow to build gui with system-provided xcb-imdkit library

This commit adds a new feature gate "system-libs" into the window and
wezterm-gui crates. If enabled, xcb-imdkit is dynamically linked with
system-provided libxcb-imdkit library instead of building and bundling
vendored libxcb-imdkit.

This feature is intended mainly for distro maintainers.

### codec: allow to build with system-provided libzstd

It reuses feature "system-libs" introduced in the previous commit
for xcb-imdkit.