### PR TITLE
termwiz: allow to disable default image formats

### DIFF
--- a/termwiz/Cargo.toml
+++ b/termwiz/Cargo.toml
@@ -21,7 +21,7 @@ filedescriptor = { version="0.8", path = "../filedescriptor" }
 fixedbitset = "0.4"
 fnv = {version="1.0", optional=true}
 hex = "0.4"
-image = {version="0.24", optional=true}
+image = {version="0.24", default-features=false, optional=true}
 lazy_static = "1.4"
 libc = "0.2"
 log = "0.4"
@@ -45,6 +45,7 @@ wezterm-color-types = { path = "../color-types", version="0.1" }
 wezterm-dynamic = { path = "../wezterm-dynamic" }
 
 [features]
+default = ["image?/default"]
 widgets = ["cassowary", "fnv"]
 use_serde = ["serde", "wezterm-color-types/use_serde"]
 use_image = ["image"]


### PR DESCRIPTION
The image crate includes support for many image formats by default,
including PNM, TGA, DDS, OpenEXR and other little-used formats.
Termwiz is not an image editor, is it?

All the default image features are still included by default, for
backward compatibility. However, the consumers of this crate can exclude
them by disabling default-features.