### PR TITLE
Accept empty table as None

### DIFF
--- a/wezterm-dynamic/src/fromdynamic.rs
+++ b/wezterm-dynamic/src/fromdynamic.rs
@@ -85,6 +85,7 @@ impl<T: FromDynamic> FromDynamic for Option<T> {
     fn from_dynamic(value: &Value, options: FromDynamicOptions) -> Result<Self, Error> {
         match value {
             Value::Null => Ok(None),
+            Value::Object(table) if table.is_empty() => Ok(None),
             value => Ok(Some(T::from_dynamic(value, options)?)),
         }
     }


### PR DESCRIPTION
This PR allows `wezterm.actions.CopyMode{SetSelectionMode={}}` to work.

This feature was introduced in 957cc592a6e4974efbefefd98aed904c206677ad but was removed at some point.