### PR TITLE
bidi: update license tag to match the actual license

### DIFF
--- a/bidi/Cargo.toml
+++ b/bidi/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 repository = "https://github.com/wez/wezterm"
 description = "The Unicode Bidi Algorithm (UBA)"
-license = "MIT"
+license = "MIT AND Unicode-DFS-2016"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
According to the README and LICENSE files, this crate contains data and code from Unicode, so update the crate license tag accordingly. This was raised as part of the Fedora packaging review in https://bugzilla.redhat.com/show_bug.cgi?id=2105831