### PR TITLE
Ensure parse_first_as_vec groups ST with OSC sequence

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5018,7 +5018,7 @@ dependencies = [
 
 [[package]]
 name = "vtparse"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "k9",
  "utf8parse",

--- a/termwiz/Cargo.toml
+++ b/termwiz/Cargo.toml
@@ -39,7 +39,7 @@ terminfo = "0.7"
 thiserror = "1.0"
 unicode-segmentation = "1.8"
 ucd-trie = "0.1"
-vtparse = { version="0.6", path="../vtparse" }
+vtparse = { version="0.6.2", path="../vtparse" }
 wezterm-bidi = { path = "../bidi", version="0.1" }
 wezterm-color-types = { path = "../color-types", version="0.1" }
 wezterm-dynamic = { path = "../wezterm-dynamic" }

--- a/vtparse/Cargo.toml
+++ b/vtparse/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Wez Furlong <wez@wezfurlong.org>"]
 name = "vtparse"
-version = "0.6.1"
+version = "0.6.2"
 edition = "2018"
 repository = "https://github.com/wez/wezterm"
 description = "Low level escape sequence parser"

--- a/vtparse/src/lib.rs
+++ b/vtparse/src/lib.rs
@@ -432,6 +432,12 @@ impl VTParser {
         }
     }
 
+    /// Returns if the state machine is in the ground state,
+    /// i.e. there is no pending state held by the state machine.
+    pub fn is_ground(&self) -> bool {
+        self.state == State::Ground
+    }
+
     fn as_integer_params(&self) -> [i64; MAX_PARAMS] {
         let mut res = [0i64; MAX_PARAMS];
         let mut i = 0;


### PR DESCRIPTION
When `parse_first_as_vec` is parsing an OSC sequence termined by an ST encoded at `ESC \`, we must ensure we process the `\` and return the parser to its ground state before returning, so that the caller gets a complete set of actions and the offset returned describes a valid span of the input.

Fixes https://github.com/markbt/streampager/issues/57