### PR TITLE
Improve get-deps script for Gentoo Linux

### DIFF
--- a/get-deps
+++ b/get-deps
@@ -227,7 +227,7 @@ gentoo_deps() {
     'cmake' \
     'fontconfig' \
     'openssl' \
-    'git' \
+    'dev-vcs/git' \
     'libX11' \
     'libxkbcommon' \
     'pkgconf' \

--- a/get-deps
+++ b/get-deps
@@ -223,7 +223,7 @@ gentoo_deps() {
   portageq envvar USE | xargs -n 1 | grep '^X$' \
   || (echo 'X is not found in USE flags' && exit 1)
   EMERGE="$SUDO emerge"
-  $EMERGE --select \
+  for pkg in \
     'cmake' \
     'fontconfig' \
     'openssl' \
@@ -239,6 +239,9 @@ gentoo_deps() {
     'xcb-util-image' \
     'xcb-util-keysyms' \
     'xcb-util-wm'
+  do
+	  equery l "$pkg" > /dev/null || $EMERGE --select $pkg
+  done
 }
 
 fallback_method() {


### PR DESCRIPTION
There's some difficulty running the `get-deps` script on Gentoo Linux. I've got two commits here that fix the problems I've seen so far.

1) there are several ebuilds called `git`; we need to select the right one. (I hope I got it right! I've assumed we need `dev-vcs/git`, which is the version control system)

2) installing a package on Gentoo really means recompiling it, so installing a lot of packages will take a long time. Therefore I've tweaked the script to not reinstall the dependencies that we've already got.