### PR TITLE
Enable control key in macOS IME

### DIFF
--- a/window/src/os/macos/window.rs
+++ b/window/src/os/macos/window.rs
@@ -2233,7 +2233,8 @@ impl WindowView {
         // Also respect `send_composed_key_when_(left|right)_alt_is_pressed` configs
         // when `use_ime` is true.
         let forward_to_ime = {
-            if modifiers.is_empty() || modifiers == Modifiers::SHIFT {
+            if modifiers.is_empty() || modifiers == Modifiers::SHIFT || modifiers == Modifiers::CTRL
+            {
                 true
             } else if only_left_alt && !send_composed_key_when_left_alt_is_pressed {
                 false


### PR DESCRIPTION
This PR enables the control key in the macOS IME.

When using the IME, Ctrl +h is expected to behave the same as a backspace.
As shown in the following image.
![expected_ctrlh](https://user-images.githubusercontent.com/29335192/185748313-6388acbb-da14-40a9-a915-7742edf5652f.gif)

However, currently it behaves as shown in the following image.
![actual_ctrlh](https://user-images.githubusercontent.com/29335192/185748339-f0b0badf-e522-4a73-bd2e-7fc56851393c.gif)

Similarly, Ctrl+m is expected to behave the same as Enter.
As in the following image.
![expected_ctrlm](https://user-images.githubusercontent.com/29335192/185748385-fc47d4d9-7d1e-4ff6-be43-7d40ebf324ae.gif)

Currently, it behaves like the following image.
![actual_ctrlm](https://user-images.githubusercontent.com/29335192/185748405-33346f37-f309-43ef-85ed-dec6b4b1cdb3.gif)

So I modified it to behave as expected.
As far as I know, with this PR fix, it behaves the same as wezterm on Windows and X11.

However, I only use Japanese IMEs and have only tested the behavior with some Japanese IMEs. Therefore, I did not know if the problem occurs in other language IMEs.
I also read the source code, but could not determine if the exclusion of the control key was intentional or not.

Please let me know what you think about this PR. I would like to help in resolving this issue.