### PR TITLE
Add `fig` to shells for shell completion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -539,6 +539,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete_fig"
+version = "3.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed37b4c0c1214673eba6ad8ea31666626bf72be98ffb323067d973c48b4964b9"
+dependencies = [
+ "clap 3.2.17",
+ "clap_complete",
+]
+
+[[package]]
 name = "clap_derive"
 version = "3.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5253,6 +5263,7 @@ dependencies = [
  "chrono",
  "clap 3.2.17",
  "clap_complete",
+ "clap_complete_fig",
  "codec",
  "config",
  "env-bootstrap",

--- a/wezterm/Cargo.toml
+++ b/wezterm/Cargo.toml
@@ -14,6 +14,7 @@ anyhow = "1.0"
 chrono = "0.4"
 clap = {version="3.1", features=["derive"]}
 clap_complete = "3.1"
+clap_complete_fig = "3.2"
 codec = { path = "../codec" }
 config = { path = "../config" }
 env-bootstrap = { path = "../env-bootstrap" }


### PR DESCRIPTION
Adds support for generating [Fig](https://github.com/withfig/autocomplete) completions using [`clap_complete_fig`](https://github.com/clap-rs/clap/tree/HEAD/clap_complete_fig).