### PR TITLE
font: fix the function signature for log_buffer_message

### DIFF
--- a/wezterm-font/src/hbwrap.rs
+++ b/wezterm-font/src/hbwrap.rs
@@ -335,7 +335,7 @@ impl Drop for Buffer {
 extern "C" fn log_buffer_message(
     _buf: *mut hb_buffer_t,
     _font: *mut hb_font_t,
-    message: *const i8,
+    message: *const c_char,
     _user_data: *mut c_void,
 ) -> i32 {
     unsafe {


### PR DESCRIPTION
This pull request fixes the function signature for log_buffer_message.

This will fix the build on non-x86 architectures (where `c_char` is an `u8` instead of an `i8`).