### PR TITLE
ci: correctly set the tag for release description

### DIFF
--- a/ci/create-release.sh
+++ b/ci/create-release.sh
@@ -2,7 +2,7 @@
 set -x
 name="$1"
 
-notes=$(cat <<'EOT'
+notes=$(cat <<EOT
 See https://wezfurlong.org/wezterm/changelog.html#$name for the changelog
 
 If you're looking for nightly downloads or more detailed installation instructions:


### PR DESCRIPTION
The latest release have a release description as follows:

```md
See https://wezfurlong.org/wezterm/changelog.html#$name for the changelog
```

This PR sets the correct tag for this message instead of `$name`.

### Additional context

Quotes prevent parameter expansion while using [here-doc](https://en.wikipedia.org/wiki/Here_document#Unix_shells):

Without quotes:

```
a=0
cat <<EOF
$a
EOF

0
```

With quotes:

```
a=0
cat <<'EOF'
$a
EOF

$a
```

From `man bash`:

> If any part of word is quoted, the delimiter is the result of quote removal on word, and the lines in the here-document  are  not  expanded.
If word is unquoted, all lines of the here-document are subjected to parameter expansion, command substitution, and arithmetic expansion

