### PR TITLE
Use SVG icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Wez's Terminal
 
-<img alt="WezTerm Icon" src="https://raw.githubusercontent.com/wez/wezterm/main/assets/icon/terminal.png" align="left"> *A GPU-accelerated cross-platform terminal emulator and multiplexer written by <a href="https://github.com/wez">@wez</a> and implemented in <a href="https://www.rust-lang.org/">Rust</a>*
+<img height="128" alt="WezTerm Icon" src="https://raw.githubusercontent.com/wez/wezterm/main/assets/icon/wezterm-icon.svg" align="left"> *A GPU-accelerated cross-platform terminal emulator and multiplexer written by <a href="https://github.com/wez">@wez</a> and implemented in <a href="https://www.rust-lang.org/">Rust</a>*
 
 User facing docs and guide at: https://wezfurlong.org/wezterm/
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,5 @@
 
-<img alt="WezTerm Icon" src="https://raw.githubusercontent.com/wez/wezterm/master/assets/icon/terminal.png" align="left" style="padding-right: 1em"> *WezTerm is a GPU-accelerated cross-platform terminal emulator and multiplexer written by <a href="https://github.com/wez/">@wez</a> and implemented in <a href="https://www.rust-lang.org/">Rust</a>*
+<img alt="WezTerm Icon" height="128" src="https://raw.githubusercontent.com/wez/wezterm/master/assets/icon/wezterm-icon.svg" align="left" style="padding-right: 1em"> *WezTerm is a GPU-accelerated cross-platform terminal emulator and multiplexer written by <a href="https://github.com/wez/">@wez</a> and implemented in <a href="https://www.rust-lang.org/">Rust</a>*
 
 <a class="btn" href="installation.html">Download</a>
 


### PR DESCRIPTION
### Preview

|Before|After|
|:-:|:-:|
|<img height="256" src="https://raw.githubusercontent.com/wez/wezterm/master/assets/icon/terminal.png" />|<img height="256" src="https://raw.githubusercontent.com/wez/wezterm/master/assets/icon/wezterm-icon.svg" />|

The actual size is 128x128. I doubled its size here for a better preview. Their visual difference is especially noticeable on Retina display monitors.

BTW, I noticed this icon problem while working on https://github.com/simple-icons/simple-icons/pull/7774.

