### PR TITLE
feat: support Natilus 4.0 API

### DIFF
--- a/assets/wezterm-nautilus.py
+++ b/assets/wezterm-nautilus.py
@@ -17,7 +17,6 @@
 import os.path
 
 from gi import require_version
-require_version('Nautilus', '3.0')
 from gi.repository import Nautilus, GObject, Gio, GLib
 
 
@@ -77,14 +76,18 @@ class OpenInWezTermAction(GObject.GObject, Nautilus.MenuProvider):
         else:
             return paths
 
-    def get_file_items(self, window, files):
+    def get_file_items(self, *args):
+        # Nautilus 3.0 API passes args (window, files), 4.0 API just passes files
+        files = args[0] if len(args) == 1 else args[1]
         paths = self._paths_to_open(files)
         if paths:
             return [self._make_item(name='WezTermNautilus::open_in_wezterm', paths=paths)]
         else:
             return []
 
-    def get_background_items(self, window, file):
+    def get_background_items(self, *args):
+        # Nautilus 3.0 API passes args (window, file), 4.0 API just passes file
+        file = args[0] if len(args) == 1 else args[1]
         paths = self._paths_to_open([file])
         if paths:
             return [self._make_item(name='WezTermNautilus::open_folder_in_wezterm', paths=paths)]


### PR DESCRIPTION
As explained in the comments, the Nautilus 4.0 API just passes files without the window object (which was unused anyway). This small fix keeps compatibility with the 3.0 API and checks the number of arguments.

In addition, `require_version` raises an error since version 4.0 has already been required by Nautilus itself, so I just removed it.

Would be really nice if you could make this count towards hacktoberfest as well!