### PR TITLE
Fix relative CWD path given on command line being wrongly

### DIFF
--- a/wezterm-gui-subcommands/src/lib.rs
+++ b/wezterm-gui-subcommands/src/lib.rs
@@ -2,6 +2,7 @@ use clap::builder::ValueParser;
 use clap::{Parser, ValueHint};
 use config::{Dimension, GeometryOrigin, SshParameters};
 use std::ffi::OsString;
+use std::path::PathBuf;
 use std::str::FromStr;
 
 pub const DEFAULT_WINDOW_CLASS: &str = "org.wezfurlong.wezterm";
@@ -161,7 +162,7 @@ pub struct StartCommand {
     /// Specify the current working directory for the initially
     /// spawned program
     #[arg(long = "cwd", value_parser, value_hint=ValueHint::DirPath)]
-    pub cwd: Option<OsString>,
+    pub cwd: Option<PathBuf>,
 
     /// Override the default windowing system class.
     /// The default is "org.wezfurlong.wezterm".

--- a/wezterm-gui/src/main.rs
+++ b/wezterm-gui/src/main.rs
@@ -15,7 +15,9 @@ use mux::ssh::RemoteSshDomain;
 use mux::Mux;
 use portable_pty::cmdbuilder::CommandBuilder;
 use promise::spawn::block_on;
+use std::borrow::Cow;
 use std::collections::HashMap;
+use std::env::current_dir;
 use std::ffi::OsString;
 use std::path::PathBuf;
 use std::rc::Rc;
@@ -689,7 +691,11 @@ fn run_terminal_gui(opts: StartCommand) -> anyhow::Result<()> {
             config.default_cwd.as_ref(),
         )?;
         if let Some(cwd) = &opts.cwd {
-            builder.cwd(cwd);
+            builder.cwd(if cwd.is_relative() {
+                current_dir()?.join(cwd).into_os_string().into()
+            } else {
+                Cow::Borrowed(cwd.as_ref())
+            });
         }
         Some(builder)
     } else {


### PR DESCRIPTION
This allows `wezterm start --cwd .` to work when another terminal window is already open in another directory

This has worked before, but it might be that the server wasn't spawned automatically?