### PR TITLE
fix: temp fix for Android build error

### DIFF
--- a/termwiz/src/escape/apc.rs
+++ b/termwiz/src/escape/apc.rs
@@ -255,7 +255,7 @@ impl KittyImageData {
     }
 }
 
-#[cfg(unix)]
+#[cfg(all(unix, not(target_os = "android")))]
 fn read_shared_memory_data(
     name: &str,
     data_offset: Option<u32>,
@@ -299,6 +299,15 @@ fn read_shared_memory_data(
         );
     }
     Ok(data)
+}
+
+#[cfg(all(unix, target_os = "android"))]
+fn read_shared_memory_data(
+    _name: &str,
+    _data_offset: Option<u32>,
+    _data_size: Option<u32>,
+) -> std::result::Result<std::vec::Vec<u8>, std::io::Error> {
+    Err(std::io::ErrorKind::Unsupported.into())
 }
 
 #[cfg(windows)]


### PR DESCRIPTION
Currently the `termwiz` crate does not build on Android due to the lack of shared memory in the OS. The "fix" I'm proposing here is to simply panic on Android. Obviously, this is not very helpful as it still doesn't **work** on Android, but it's also harmless (hopefully).

The reason I'm sending this PR is to make applications that only make use of other parts of `termwiz` work on Android, notably Zellij:

https://github.com/zellij-org/zellij/pull/1833#issuecomment-1292943102

_(Honestly I'm not entirely sure if Zellij does not use this function in question, but I've tried changing it to simply panic on **any** platform, and it's working for me so far on Linux)_

Would be amazing if this can be merged so that we can stop using a fork for Android support.