### PR TITLE
Add left arrow before first right-status cell

### DIFF
--- a/docs/config/lua/window/set_right_status.md
+++ b/docs/config/lua/window/set_right_status.md
@@ -103,6 +103,10 @@ wezterm.on('update-right-status', function(window, pane)
   -- How many cells have been formatted
   local num_cells = 0
 
+  -- Insert initial left arrow
+  table.insert(elements, { Foreground = { Color = colors[1] } })
+  table.insert(elements, { Text = SOLID_LEFT_ARROW })
+
   -- Translate a cell into elements
   function push(text, is_last)
     local cell_no = num_cells + 1


### PR DESCRIPTION
Adds a powerline left arrow before the first cell of the right-status bar in `window:set_right_status.md`.

This prevents the first cell from having a square border if the tab_bar's background color is different from the right-status cell's background.