### PR TITLE
Fix compiler warning (for_loops_over_fallibles)

### DIFF
--- a/lua-api-crates/filesystem/src/lib.rs
+++ b/lua-api-crates/filesystem/src/lib.rs
@@ -15,7 +15,7 @@ async fn read_dir<'lua>(_: &'lua Lua, path: String) -> mlua::Result<Vec<String>>
         .await
         .map_err(|e| mlua::Error::external(e))?;
     let mut entries = vec![];
-    for entry in dir.next().await {
+    while let Some(entry) = dir.next().await {
         let entry = entry.map_err(|e| mlua::Error::external(e))?;
         if let Some(utf8) = entry.path().to_str() {
             entries.push(utf8.to_string());


### PR DESCRIPTION
The most recent time that I built WezTerm (with the nightly compiler), I saw [this warning](https://doc.rust-lang.org/nightly/nightly-rustc/rustc_lint/for_loops_over_fallibles/static.FOR_LOOPS_OVER_FALLIBLES.html):

> Both `Option` and `Result` implement `IntoIterator` trait, which allows using them in a `for` loop. `for` loop over `Option` or `Result` will iterate either 0 (if the value is `None`/`Err(_)`) or 1 time (if the value is `Some(_)`/`Ok(_)`). This is not very useful and is more clearly expressed via `if let`.

> `for` loop can also be accidentally written with the intention to call a function multiple times, while the function returns `Some(_)`; in these cases `while let` loop should be used instead.

I suppose the minimal-intervention fix here is to change the `for` loop to `while let`. That's what I've done. But it is possible (likely?) that `if let` would suffice. It's up to you, of course…