### PR TITLE
Integrated titlebar

### DIFF
--- a/config/src/color.rs
+++ b/config/src/color.rs
@@ -534,11 +534,12 @@ fn default_active_tab() -> TabBarColor {
 }
 
 // Colors for window buttons
-#[cfg(not(windows))]
+#[cfg(not(any(windows, target_os = "linux")))]
 fn default_window_button_color() -> TabBarColor {
     default_inactive_tab()
 }
-#[cfg(not(windows))]
+
+#[cfg(not(any(windows, target_os = "linux")))]
 fn default_window_button_hover_color() -> TabBarColor {
     default_inactive_tab_hover()
 }
@@ -591,6 +592,25 @@ fn default_window_button_hover_color() -> TabBarColor {
 fn default_window_close_hover_color() -> TabBarColor {
     TabBarColor {
         bg_color: (0xFF, 0x00, 0x00).into(),
+        fg_color: (0xFF, 0xFF, 0xFF).into(),
+        ..TabBarColor::default()
+    }
+}
+
+// Linux dependend colors for window buttons
+#[cfg(target_os = "linux")]
+fn default_window_button_color() -> TabBarColor {
+    TabBarColor {
+        bg_color: (0x45, 0x45, 0x45).into(),
+        fg_color: (0xFF, 0xFF, 0xFF).into(),
+        ..TabBarColor::default()
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn default_window_button_hover_color() -> TabBarColor {
+    TabBarColor {
+        bg_color: (0x4F, 0x4F, 0x4F).into(),
         fg_color: (0xFF, 0xFF, 0xFF).into(),
         ..TabBarColor::default()
     }

--- a/config/src/color.rs
+++ b/config/src/color.rs
@@ -372,24 +372,6 @@ pub struct TabBarColors {
 
     #[dynamic(default)]
     pub inactive_tab_edge_hover: Option<RgbaColor>,
-
-    #[dynamic(default)]
-    pub window_hide: Option<TabBarColor>,
-
-    #[dynamic(default)]
-    pub window_hide_hover: Option<TabBarColor>,
-
-    #[dynamic(default)]
-    pub window_maximize: Option<TabBarColor>,
-
-    #[dynamic(default)]
-    pub window_maximize_hover: Option<TabBarColor>,
-
-    #[dynamic(default)]
-    pub window_close: Option<TabBarColor>,
-
-    #[dynamic(default)]
-    pub window_close_hover: Option<TabBarColor>,
 }
 
 impl TabBarColors {
@@ -433,42 +415,6 @@ impl TabBarColors {
             .unwrap_or_else(default_inactive_tab_edge_hover)
     }
 
-    pub fn window_hide(&self) -> TabBarColor {
-        self.window_hide
-            .clone()
-            .unwrap_or_else(default_window_hide_color)
-    }
-
-    pub fn window_hide_hover(&self) -> TabBarColor {
-        self.window_hide_hover
-            .clone()
-            .unwrap_or_else(default_window_hide_hover_color)
-    }
-
-    pub fn window_maximize(&self) -> TabBarColor {
-        self.window_maximize
-            .clone()
-            .unwrap_or_else(default_window_maximize_color)
-    }
-
-    pub fn window_maximize_hover(&self) -> TabBarColor {
-        self.window_maximize_hover
-            .clone()
-            .unwrap_or_else(default_window_maximize_hover_color)
-    }
-
-    pub fn window_close(&self) -> TabBarColor {
-        self.window_close
-            .clone()
-            .unwrap_or_else(default_window_close_color)
-    }
-
-    pub fn window_close_hover(&self) -> TabBarColor {
-        self.window_close_hover
-            .clone()
-            .unwrap_or_else(default_window_close_hover_color)
-    }
-
     pub fn overlay_with(&self, other: &Self) -> Self {
         macro_rules! overlay {
             ($name:ident) => {
@@ -488,12 +434,35 @@ impl TabBarColors {
             inactive_tab_edge_hover: overlay!(inactive_tab_edge_hover),
             new_tab: overlay!(new_tab),
             new_tab_hover: overlay!(new_tab_hover),
-            window_hide: overlay!(window_hide),
-            window_hide_hover: overlay!(window_hide_hover),
-            window_maximize: overlay!(window_maximize),
-            window_maximize_hover: overlay!(window_maximize_hover),
-            window_close: overlay!(window_close),
-            window_close_hover: overlay!(window_close_hover),
+        }
+    }
+}
+
+#[derive(Default, Debug, Clone, PartialEq, FromDynamic, ToDynamic)]
+#[dynamic(try_from = "String")]
+pub enum IntegratedTitleButtonColor {
+    #[default]
+    Auto,
+    Custom(RgbaColor),
+}
+
+impl Into<String> for IntegratedTitleButtonColor {
+    fn into(self) -> String {
+        match self {
+            Self::Auto => "auto".to_string(),
+            Self::Custom(color) => color.into(),
+        }
+    }
+}
+
+impl TryFrom<String> for IntegratedTitleButtonColor {
+    type Error = <RgbaColor as TryFrom<String>>::Error;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        if value.to_lowercase() == "auto" {
+            Ok(Self::Auto)
+        } else {
+            Ok(Self::Custom(RgbaColor::try_from(value)?))
         }
     }
 }
@@ -529,89 +498,6 @@ fn default_active_tab() -> TabBarColor {
     TabBarColor {
         bg_color: (0x00, 0x00, 0x00).into(),
         fg_color: (0xc0, 0xc0, 0xc0).into(),
-        ..TabBarColor::default()
-    }
-}
-
-// Colors for window buttons
-#[cfg(not(any(windows, target_os = "linux")))]
-fn default_window_button_color() -> TabBarColor {
-    default_inactive_tab()
-}
-
-#[cfg(not(any(windows, target_os = "linux")))]
-fn default_window_button_hover_color() -> TabBarColor {
-    default_inactive_tab_hover()
-}
-
-fn default_window_hide_color() -> TabBarColor {
-    default_window_button_color()
-}
-
-fn default_window_hide_hover_color() -> TabBarColor {
-    default_window_button_hover_color()
-}
-
-fn default_window_maximize_color() -> TabBarColor {
-    default_window_button_color()
-}
-
-fn default_window_maximize_hover_color() -> TabBarColor {
-    default_window_button_hover_color()
-}
-
-fn default_window_close_color() -> TabBarColor {
-    default_window_button_color()
-}
-
-#[cfg(not(windows))]
-fn default_window_close_hover_color() -> TabBarColor {
-    default_window_button_hover_color()
-}
-
-// Windows dependend colors for window buttons
-#[cfg(windows)]
-fn default_window_button_color() -> TabBarColor {
-    TabBarColor {
-        bg_color: (0x33, 0x33, 0x33).into(),
-        fg_color: (0xFF, 0xFF, 0xFF).into(),
-        ..TabBarColor::default()
-    }
-}
-
-#[cfg(windows)]
-fn default_window_button_hover_color() -> TabBarColor {
-    TabBarColor {
-        bg_color: (0x45, 0x45, 0x45).into(),
-        fg_color: (0xFF, 0xFF, 0xFF).into(),
-        ..TabBarColor::default()
-    }
-}
-
-#[cfg(windows)]
-fn default_window_close_hover_color() -> TabBarColor {
-    TabBarColor {
-        bg_color: (0xFF, 0x00, 0x00).into(),
-        fg_color: (0xFF, 0xFF, 0xFF).into(),
-        ..TabBarColor::default()
-    }
-}
-
-// Linux dependend colors for window buttons
-#[cfg(target_os = "linux")]
-fn default_window_button_color() -> TabBarColor {
-    TabBarColor {
-        bg_color: (0x45, 0x45, 0x45).into(),
-        fg_color: (0xFF, 0xFF, 0xFF).into(),
-        ..TabBarColor::default()
-    }
-}
-
-#[cfg(target_os = "linux")]
-fn default_window_button_hover_color() -> TabBarColor {
-    TabBarColor {
-        bg_color: (0x4F, 0x4F, 0x4F).into(),
-        fg_color: (0xFF, 0xFF, 0xFF).into(),
         ..TabBarColor::default()
     }
 }

--- a/config/src/color.rs
+++ b/config/src/color.rs
@@ -479,6 +479,18 @@ pub struct TabBarStyle {
     pub new_tab: String,
     #[dynamic(default = "default_new_tab")]
     pub new_tab_hover: String,
+    #[dynamic(default = "default_window_hide")]
+    pub window_hide: String,
+    #[dynamic(default = "default_window_hide")]
+    pub window_hide_hover: String,
+    #[dynamic(default = "default_window_maximize")]
+    pub window_maximize: String,
+    #[dynamic(default = "default_window_maximize")]
+    pub window_maximize_hover: String,
+    #[dynamic(default = "default_window_close")]
+    pub window_close: String,
+    #[dynamic(default = "default_window_close")]
+    pub window_close_hover: String,
 }
 
 impl Default for TabBarStyle {
@@ -486,12 +498,30 @@ impl Default for TabBarStyle {
         Self {
             new_tab: default_new_tab(),
             new_tab_hover: default_new_tab(),
+            window_hide: default_window_hide(),
+            window_hide_hover: default_window_hide(),
+            window_maximize: default_window_maximize(),
+            window_maximize_hover: default_window_maximize(),
+            window_close: default_window_close(),
+            window_close_hover: default_window_close(),
         }
     }
 }
 
 fn default_new_tab() -> String {
     " + ".to_string()
+}
+
+fn default_window_hide() -> String {
+    " . ".to_string()
+}
+
+fn default_window_maximize() -> String {
+    " - ".to_string()
+}
+
+fn default_window_close() -> String {
+    " X ".to_string()
 }
 
 #[derive(Debug, Clone, FromDynamic, ToDynamic)]

--- a/config/src/color.rs
+++ b/config/src/color.rs
@@ -372,6 +372,24 @@ pub struct TabBarColors {
 
     #[dynamic(default)]
     pub inactive_tab_edge_hover: Option<RgbaColor>,
+
+    #[dynamic(default)]
+    pub window_hide: Option<TabBarColor>,
+
+    #[dynamic(default)]
+    pub window_hide_hover: Option<TabBarColor>,
+
+    #[dynamic(default)]
+    pub window_maximize: Option<TabBarColor>,
+
+    #[dynamic(default)]
+    pub window_maximize_hover: Option<TabBarColor>,
+
+    #[dynamic(default)]
+    pub window_close: Option<TabBarColor>,
+
+    #[dynamic(default)]
+    pub window_close_hover: Option<TabBarColor>,
 }
 
 impl TabBarColors {
@@ -415,6 +433,42 @@ impl TabBarColors {
             .unwrap_or_else(default_inactive_tab_edge_hover)
     }
 
+    pub fn window_hide(&self) -> TabBarColor {
+        self.window_hide
+            .clone()
+            .unwrap_or_else(default_window_hide_color)
+    }
+
+    pub fn window_hide_hover(&self) -> TabBarColor {
+        self.window_hide_hover
+            .clone()
+            .unwrap_or_else(default_window_hide_hover_color)
+    }
+
+    pub fn window_maximize(&self) -> TabBarColor {
+        self.window_maximize
+            .clone()
+            .unwrap_or_else(default_window_maximize_color)
+    }
+
+    pub fn window_maximize_hover(&self) -> TabBarColor {
+        self.window_maximize_hover
+            .clone()
+            .unwrap_or_else(default_window_maximize_hover_color)
+    }
+
+    pub fn window_close(&self) -> TabBarColor {
+        self.window_close
+            .clone()
+            .unwrap_or_else(default_window_close_color)
+    }
+
+    pub fn window_close_hover(&self) -> TabBarColor {
+        self.window_close_hover
+            .clone()
+            .unwrap_or_else(default_window_close_hover_color)
+    }
+
     pub fn overlay_with(&self, other: &Self) -> Self {
         macro_rules! overlay {
             ($name:ident) => {
@@ -434,6 +488,12 @@ impl TabBarColors {
             inactive_tab_edge_hover: overlay!(inactive_tab_edge_hover),
             new_tab: overlay!(new_tab),
             new_tab_hover: overlay!(new_tab_hover),
+            window_hide: overlay!(window_hide),
+            window_hide_hover: overlay!(window_hide_hover),
+            window_maximize: overlay!(window_maximize),
+            window_maximize_hover: overlay!(window_maximize_hover),
+            window_close: overlay!(window_close),
+            window_close_hover: overlay!(window_close_hover),
         }
     }
 }
@@ -469,6 +529,69 @@ fn default_active_tab() -> TabBarColor {
     TabBarColor {
         bg_color: (0x00, 0x00, 0x00).into(),
         fg_color: (0xc0, 0xc0, 0xc0).into(),
+        ..TabBarColor::default()
+    }
+}
+
+// Colors for window buttons
+#[cfg(not(windows))]
+fn default_window_button_color() -> TabBarColor {
+    default_inactive_tab()
+}
+#[cfg(not(windows))]
+fn default_window_button_hover_color() -> TabBarColor {
+    default_inactive_tab_hover()
+}
+
+fn default_window_hide_color() -> TabBarColor {
+    default_window_button_color()
+}
+
+fn default_window_hide_hover_color() -> TabBarColor {
+    default_window_button_hover_color()
+}
+
+fn default_window_maximize_color() -> TabBarColor {
+    default_window_button_color()
+}
+
+fn default_window_maximize_hover_color() -> TabBarColor {
+    default_window_button_hover_color()
+}
+
+fn default_window_close_color() -> TabBarColor {
+    default_window_button_color()
+}
+
+#[cfg(not(windows))]
+fn default_window_close_hover_color() -> TabBarColor {
+    default_window_button_hover_color()
+}
+
+// Windows dependend colors for window buttons
+#[cfg(windows)]
+fn default_window_button_color() -> TabBarColor {
+    TabBarColor {
+        bg_color: (0x33, 0x33, 0x33).into(),
+        fg_color: (0xFF, 0xFF, 0xFF).into(),
+        ..TabBarColor::default()
+    }
+}
+
+#[cfg(windows)]
+fn default_window_button_hover_color() -> TabBarColor {
+    TabBarColor {
+        bg_color: (0x45, 0x45, 0x45).into(),
+        fg_color: (0xFF, 0xFF, 0xFF).into(),
+        ..TabBarColor::default()
+    }
+}
+
+#[cfg(windows)]
+fn default_window_close_hover_color() -> TabBarColor {
+    TabBarColor {
+        bg_color: (0xFF, 0x00, 0x00).into(),
+        fg_color: (0xFF, 0xFF, 0xFF).into(),
         ..TabBarColor::default()
     }
 }

--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -40,7 +40,7 @@ use termwiz::surface::CursorShape;
 use wezterm_bidi::ParagraphDirectionHint;
 use wezterm_config_derive::ConfigMeta;
 use wezterm_dynamic::{FromDynamic, ToDynamic};
-use wezterm_input_types::{Modifiers, WindowDecorations};
+use wezterm_input_types::{FancyWindowDecorations, Modifiers, WindowDecorations};
 use wezterm_term::TerminalSize;
 
 #[derive(Debug, Clone, FromDynamic, ToDynamic, ConfigMeta)]
@@ -75,6 +75,9 @@ pub struct Config {
 
     #[dynamic(default)]
     pub window_decorations: WindowDecorations,
+
+    #[dynamic(default)]
+    pub fancy_window_decorations: FancyWindowDecorations,
 
     /// When using FontKitXXX font systems, a set of directories to
     /// search ahead of the standard font locations for fonts.

--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -40,7 +40,10 @@ use termwiz::surface::CursorShape;
 use wezterm_bidi::ParagraphDirectionHint;
 use wezterm_config_derive::ConfigMeta;
 use wezterm_dynamic::{FromDynamic, ToDynamic};
-use wezterm_input_types::{FancyWindowDecorations, Modifiers, WindowDecorations};
+use wezterm_input_types::{
+    IntegratedTitleButton, IntegratedTitleButtonAlignment, IntegratedTitleButtonStyle, Modifiers,
+    WindowDecorations,
+};
 use wezterm_term::TerminalSize;
 
 #[derive(Debug, Clone, FromDynamic, ToDynamic, ConfigMeta)]
@@ -76,11 +79,14 @@ pub struct Config {
     #[dynamic(default)]
     pub window_decorations: WindowDecorations,
 
-    /// Controls window buttons position and style
-    /// for fancy window decorations.
-    /// Has no effect on macOS or Windows.
+    #[dynamic(default = "default_integrated_title_buttons")]
+    pub integrated_title_buttons: Vec<IntegratedTitleButton>,
+
     #[dynamic(default)]
-    pub fancy_window_decorations: FancyWindowDecorations,
+    pub integrated_title_button_alignment: IntegratedTitleButtonAlignment,
+
+    #[dynamic(default)]
+    pub integrated_title_button_style: IntegratedTitleButtonStyle,
 
     /// When using FontKitXXX font systems, a set of directories to
     /// search ahead of the standard font locations for fonts.
@@ -1305,6 +1311,11 @@ fn default_pane_select_bg_color() -> RgbaColor {
 
 fn default_pane_select_font_size() -> f64 {
     36.0
+}
+
+fn default_integrated_title_buttons() -> Vec<IntegratedTitleButton> {
+    use IntegratedTitleButton::*;
+    vec![Hide, Maximize, Close]
 }
 
 fn default_char_select_font_size() -> f64 {

--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -22,8 +22,9 @@ use crate::unix::UnixDomain;
 use crate::wsl::WslDomain;
 use crate::{
     default_config_with_overrides_applied, default_one_point_oh, default_one_point_oh_f64,
-    default_true, KeyMapPreference, LoadedConfig, MouseEventTriggerMods, RgbaColor, CONFIG_DIR,
-    CONFIG_FILE_OVERRIDE, CONFIG_OVERRIDES, CONFIG_SKIP, HOME_DIR,
+    default_true, IntegratedTitleButtonColor, KeyMapPreference, LoadedConfig,
+    MouseEventTriggerMods, RgbaColor, CONFIG_DIR, CONFIG_FILE_OVERRIDE, CONFIG_OVERRIDES,
+    CONFIG_SKIP, HOME_DIR,
 };
 use anyhow::Context;
 use luahelper::impl_lua_conversion_dynamic;
@@ -87,6 +88,9 @@ pub struct Config {
 
     #[dynamic(default)]
     pub integrated_title_button_style: IntegratedTitleButtonStyle,
+
+    #[dynamic(default)]
+    pub integrated_title_button_color: IntegratedTitleButtonColor,
 
     /// When using FontKitXXX font systems, a set of directories to
     /// search ahead of the standard font locations for fonts.

--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -76,6 +76,9 @@ pub struct Config {
     #[dynamic(default)]
     pub window_decorations: WindowDecorations,
 
+    /// Controls window buttons position and style
+    /// for fancy window decorations.
+    /// Has no effect on macOS or Windows.
     #[dynamic(default)]
     pub fancy_window_decorations: FancyWindowDecorations,
 

--- a/wezterm-gui/src/customglyph.rs
+++ b/wezterm-gui/src/customglyph.rs
@@ -209,6 +209,7 @@ impl PolyCommand {
 #[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
 pub enum PolyStyle {
     Fill,
+    OutlineThin,
     // A line with the thickness as underlines
     Outline,
     // A line with twice the thickness of underlines
@@ -222,11 +223,13 @@ impl PolyStyle {
                 pixmap.fill_path(path, paint, FillRule::Winding, Transform::identity(), None);
             }
 
-            PolyStyle::Outline | PolyStyle::OutlineHeavy => {
+            PolyStyle::OutlineThin | PolyStyle::Outline | PolyStyle::OutlineHeavy => {
                 let mut stroke = Stroke::default();
                 stroke.width = width;
                 if self == PolyStyle::OutlineHeavy {
                     stroke.width *= 3.0; // NOTE: Using 2.0, the difference is almost invisible
+                } else if self == PolyStyle::OutlineThin {
+                    stroke.width = 1.2;
                 }
                 pixmap.stroke_path(path, paint, &stroke, Transform::identity(), None);
             }

--- a/wezterm-gui/src/customglyph.rs
+++ b/wezterm-gui/src/customglyph.rs
@@ -177,7 +177,14 @@ pub type BlockPoint = (BlockCoord, BlockCoord);
 pub enum PolyCommand {
     MoveTo(BlockCoord, BlockCoord),
     LineTo(BlockCoord, BlockCoord),
-    QuadTo { control: BlockPoint, to: BlockPoint },
+    QuadTo {
+        control: BlockPoint,
+        to: BlockPoint,
+    },
+    PushOval {
+        center: BlockPoint,
+        radiuses: BlockPoint,
+    },
     Close,
 }
 
@@ -201,6 +208,21 @@ impl PolyCommand {
                 x.to_pixel(width, underline_height),
                 y.to_pixel(height, underline_height),
             ),
+            Self::PushOval {
+                center: (x, y),
+                radiuses: (w, h),
+            } => {
+                let x = x.to_pixel(width, underline_height) - width as f32;
+                let y = y.to_pixel(height, underline_height) - height as f32;
+                let w = w.to_pixel(width, underline_height) * 2.0;
+                let h = h.to_pixel(height, underline_height) * 2.0;
+
+                if let Some(oval) = tiny_skia::Rect::from_xywh(x, y, w, h) {
+                    pb.push_oval(oval);
+                } else {
+                    log::error!("Can't push oval, values: {:?}", self);
+                }
+            }
             Self::Close => pb.close(),
         };
     }

--- a/wezterm-gui/src/glyph-frag.glsl
+++ b/wezterm-gui/src/glyph-frag.glsl
@@ -134,6 +134,7 @@ void main() {
     // Grayscale poly quad for non-aa text render layers
     colorMask = texture(atlas_nearest_sampler, o_tex);
     color = fg_color;
+    color.a = mix(o_fg_color.a, o_fg_color_alt.a, clamp(o_fg_color_mix, 0.0, 1.0));
     color.a *= colorMask.a;
   } else if (o_has_color == 0.0) {
     // the texture is the alpha channel/color mask

--- a/wezterm-gui/src/quad.rs
+++ b/wezterm-gui/src/quad.rs
@@ -35,6 +35,8 @@ pub struct Vertex {
     //        background image of the window
     // 3.0 -> like 2.0, except that instead of an
     //        image, we use the solid bg color
+    // 4.0 -> color and alpha will be multipled
+    //        with those in the texture
     pub has_color: f32,
     pub mix_value: f32,
 }

--- a/wezterm-gui/src/tabbar.rs
+++ b/wezterm-gui/src/tabbar.rs
@@ -302,7 +302,6 @@ impl TabBarState {
                 _ => continue,
             };
 
-            // let button_start = *x;
             let width = title.len();
 
             line.append_line(title.to_owned(), SEQ_ZERO);

--- a/wezterm-gui/src/tabbar.rs
+++ b/wezterm-gui/src/tabbar.rs
@@ -241,7 +241,13 @@ impl TabBarState {
             },
         );
 
-        let button_order = if config.fancy_window_decorations.is_left {
+        let window::FancyWindowDecorations {
+            is_left,
+            remove_hide_button,
+            remove_maximize_button,
+        } = config.fancy_window_decorations;
+
+        let button_order = if is_left {
             ['X', '.', '-']
         } else {
             ['.', '-', 'X']
@@ -250,7 +256,7 @@ impl TabBarState {
         for button in button_order {
             let (title, item) = match button {
                 // Window hide button
-                '.' => {
+                '.' if !remove_hide_button => {
                     let hover = is_tab_hover(mouse_x, *x, window_hide_hover.len());
 
                     let window_hide_button = if hover {
@@ -261,7 +267,7 @@ impl TabBarState {
 
                     (window_hide_button, TabBarItem::WindowHideButton)
                 }
-                '-' => {
+                '-' if !remove_maximize_button => {
                     // Window maximize button
                     let hover = is_tab_hover(mouse_x, *x, window_maximize_hover.len());
 
@@ -285,7 +291,7 @@ impl TabBarState {
 
                     (window_close_button, TabBarItem::WindowCloseButton)
                 }
-                _ => unreachable!(),
+                _ => continue,
             };
 
             // let button_start = *x;

--- a/wezterm-gui/src/tabbar.rs
+++ b/wezterm-gui/src/tabbar.rs
@@ -245,6 +245,7 @@ impl TabBarState {
             is_left,
             remove_hide_button,
             remove_maximize_button,
+            ..
         } = config.fancy_window_decorations;
 
         let button_order = if is_left {

--- a/wezterm-gui/src/tabbar.rs
+++ b/wezterm-gui/src/tabbar.rs
@@ -24,6 +24,9 @@ pub enum TabBarItem {
     RightStatus,
     Tab { tab_idx: usize, active: bool },
     NewTabButton,
+    WindowHideButton,
+    WindowMaximizeButton,
+    WindowCloseButton,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -218,6 +221,61 @@ impl TabBarState {
             },
         );
 
+        let fancy_window_decorations = config
+            .window_decorations
+            .contains(window::WindowDecorations::FANCY);
+
+        let window_hide = parse_status_text(
+            &config.tab_bar_style.window_hide,
+            if config.use_fancy_tab_bar {
+                CellAttributes::default()
+            } else {
+                new_tab_attrs.clone()
+            },
+        );
+        let window_hide_hover = parse_status_text(
+            &config.tab_bar_style.window_hide_hover,
+            if config.use_fancy_tab_bar {
+                CellAttributes::default()
+            } else {
+                new_tab_hover_attrs.clone()
+            },
+        );
+
+        let window_maximize = parse_status_text(
+            &config.tab_bar_style.window_maximize,
+            if config.use_fancy_tab_bar {
+                CellAttributes::default()
+            } else {
+                new_tab_attrs.clone()
+            },
+        );
+        let window_maximize_hover = parse_status_text(
+            &config.tab_bar_style.window_maximize_hover,
+            if config.use_fancy_tab_bar {
+                CellAttributes::default()
+            } else {
+                new_tab_hover_attrs.clone()
+            },
+        );
+
+        let window_close = parse_status_text(
+            &config.tab_bar_style.window_close,
+            if config.use_fancy_tab_bar {
+                CellAttributes::default()
+            } else {
+                new_tab_attrs.clone()
+            },
+        );
+        let window_close_hover = parse_status_text(
+            &config.tab_bar_style.window_close_hover,
+            if config.use_fancy_tab_bar {
+                CellAttributes::default()
+            } else {
+                new_tab_hover_attrs.clone()
+            },
+        );
+
         // We ultimately want to produce a line looking like this:
         // ` | tab1-title x | tab2-title x |  +      . - X `
         // Where the `+` sign will spawn a new tab (or show a context
@@ -354,6 +412,17 @@ impl TabBarState {
             x += width;
         }
 
+        // Reserve place for buttons
+        let title_width = if fancy_window_decorations {
+            let hide_len = window_hide.len().max(window_hide_hover.len());
+            let maximize_len = window_maximize.len().max(window_maximize_hover.len());
+            let close_len = window_close.len().max(window_close_hover.len());
+
+            title_width.saturating_sub(hide_len + maximize_len + close_len)
+        } else {
+            title_width
+        };
+
         let status_space_available = title_width.saturating_sub(x);
 
         let mut right_status_line = parse_status_text(right_status, black_cell.attrs().clone());
@@ -371,6 +440,85 @@ impl TabBarState {
         line.append_line(right_status_line, SEQ_ZERO);
         while line.len() < title_width {
             line.insert_cell(x, black_cell.clone(), title_width, SEQ_ZERO);
+        }
+
+        if fancy_window_decorations {
+            x = title_width;
+
+            // Window hide button
+            {
+                let hover = is_tab_hover(mouse_x, x, window_hide_hover.len());
+
+                let window_hide_button = if hover {
+                    &window_hide_hover
+                } else {
+                    &window_hide
+                };
+
+                let button_start = x;
+                let width = window_hide_button.len();
+
+                line.append_line(window_hide_button.clone(), SEQ_ZERO);
+
+                items.push(TabEntry {
+                    item: TabBarItem::WindowHideButton,
+                    title: window_hide_button.clone(),
+                    x: button_start,
+                    width,
+                });
+
+                x += width;
+            }
+
+            // Window maximize button
+            {
+                let hover = is_tab_hover(mouse_x, x, window_maximize_hover.len());
+
+                let window_maximize_button = if hover {
+                    &window_maximize_hover
+                } else {
+                    &window_maximize
+                };
+
+                let button_start = x;
+                let width = window_maximize_button.len();
+
+                line.append_line(window_maximize_button.clone(), SEQ_ZERO);
+
+                items.push(TabEntry {
+                    item: TabBarItem::WindowMaximizeButton,
+                    title: window_maximize_button.clone(),
+                    x: button_start,
+                    width,
+                });
+
+                x += width;
+            }
+
+            // Window close button
+            {
+                let hover = is_tab_hover(mouse_x, x, window_close_hover.len());
+
+                let window_close_button = if hover {
+                    &window_close_hover
+                } else {
+                    &window_close
+                };
+
+                let button_start = x;
+                let width = window_close_button.len();
+
+                line.append_line(window_close_button.clone(), SEQ_ZERO);
+
+                items.push(TabEntry {
+                    item: TabBarItem::WindowCloseButton,
+                    title: window_close_button.clone(),
+                    x: button_start,
+                    width,
+                });
+
+                // x += width;
+            }
         }
 
         Self { line, items }

--- a/wezterm-gui/src/tabbar.rs
+++ b/wezterm-gui/src/tabbar.rs
@@ -516,8 +516,6 @@ impl TabBarState {
                     x: button_start,
                     width,
                 });
-
-                // x += width;
             }
         }
 

--- a/wezterm-gui/src/tabbar.rs
+++ b/wezterm-gui/src/tabbar.rs
@@ -182,6 +182,8 @@ impl TabBarState {
         &self.items
     }
 
+    // MacOS uses native buttons.
+    #[cfg(not(target_os = "macos"))]
     fn fancy_window_decorations(
         mouse_x: Option<usize>,
         x: &mut usize,
@@ -402,6 +404,7 @@ impl TabBarState {
         let mut x = 0;
         let mut items = vec![];
 
+        #[cfg(not(target_os = "macos"))]
         if fancy_window_decorations && config.fancy_window_decorations.is_left && !cfg!(widnows) {
             Self::fancy_window_decorations(mouse_x, &mut x, config, &mut items, &mut line, &colors);
         }
@@ -411,6 +414,14 @@ impl TabBarState {
                 .set_background(ColorSpec::TrueColor(*colors.background()))
                 .clone(),
         );
+
+        #[cfg(target_os = "macos")]
+        if fancy_window_decorations && config.use_fancy_tab_bar == false {
+            for _ in 0..10 as usize {
+                line.insert_cell(x, black_cell.clone(), title_width, SEQ_ZERO);
+                x += 1;
+            }
+        }
 
         let left_status_line = parse_status_text(left_status, black_cell.attrs().clone());
         if left_status_line.len() > 0 {
@@ -500,6 +511,7 @@ impl TabBarState {
         }
 
         // Reserve place for buttons
+        #[cfg(not(target_os = "macos"))]
         let title_width = if fancy_window_decorations
             && !config.fancy_window_decorations.is_left
             && !cfg!(target_os = "macos")
@@ -556,10 +568,8 @@ impl TabBarState {
             line.insert_cell(x, black_cell.clone(), title_width, SEQ_ZERO);
         }
 
-        if fancy_window_decorations
-            && !config.fancy_window_decorations.is_left
-            && !cfg!(target_os = "macos")
-        {
+        #[cfg(not(target_os = "macos"))]
+        if fancy_window_decorations && !config.fancy_window_decorations.is_left {
             x = title_width;
             Self::fancy_window_decorations(mouse_x, &mut x, config, &mut items, &mut line, &colors);
         }

--- a/wezterm-gui/src/tabbar.rs
+++ b/wezterm-gui/src/tabbar.rs
@@ -10,6 +10,7 @@ use termwiz::escape::{Action, ControlCode, CSI};
 use termwiz::surface::SEQ_ZERO;
 use termwiz_funcs::{format_as_escapes, FormatItem};
 use wezterm_term::Line;
+use window::{IntegratedTitleButton, IntegratedTitleButtonAlignment};
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct TabBarState {
@@ -24,9 +25,7 @@ pub enum TabBarItem {
     RightStatus,
     Tab { tab_idx: usize, active: bool },
     NewTabButton,
-    WindowHideButton,
-    WindowMaximizeButton,
-    WindowCloseButton,
+    WindowButton(IntegratedTitleButton),
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -184,7 +183,7 @@ impl TabBarState {
 
     // MacOS uses native buttons.
     #[cfg(not(target_os = "macos"))]
-    fn fancy_window_decorations(
+    fn integrated_title_buttons(
         mouse_x: Option<usize>,
         x: &mut usize,
         config: &ConfigHandle,
@@ -243,71 +242,43 @@ impl TabBarState {
             },
         );
 
-        let window::FancyWindowDecorations {
-            is_left,
-            remove_hide_button,
-            remove_maximize_button,
-            ..
-        } = if cfg!(any(windows, target_os = "macos")) {
-            // Ignore changes to config on windows and macos
-            window::FancyWindowDecorations::default()
-        } else {
-            config.fancy_window_decorations.clone()
-        };
-
-        let button_order = if is_left {
-            ['X', '.', '-']
-        } else {
-            ['.', '-', 'X']
-        };
-
-        for button in button_order {
-            let (title, item) = match button {
-                // Window hide button
-                '.' if !remove_hide_button => {
+        for button in &config.integrated_title_buttons {
+            use IntegratedTitleButton as Button;
+            let title = match button {
+                Button::Hide => {
                     let hover = is_tab_hover(mouse_x, *x, window_hide_hover.len());
 
-                    let window_hide_button = if hover {
+                    if hover {
                         &window_hide_hover
                     } else {
                         &window_hide
-                    };
-
-                    (window_hide_button, TabBarItem::WindowHideButton)
+                    }
                 }
-                '-' if !remove_maximize_button => {
-                    // Window maximize button
+                Button::Maximize => {
                     let hover = is_tab_hover(mouse_x, *x, window_maximize_hover.len());
 
-                    let window_maximize_button = if hover {
+                    if hover {
                         &window_maximize_hover
                     } else {
                         &window_maximize
-                    };
-
-                    (window_maximize_button, TabBarItem::WindowMaximizeButton)
+                    }
                 }
-                'X' => {
-                    // Window close button
+                Button::Close => {
                     let hover = is_tab_hover(mouse_x, *x, window_close_hover.len());
 
-                    let window_close_button = if hover {
+                    if hover {
                         &window_close_hover
                     } else {
                         &window_close
-                    };
-
-                    (window_close_button, TabBarItem::WindowCloseButton)
+                    }
                 }
-                _ => continue,
             };
-
-            let width = title.len();
 
             line.append_line(title.to_owned(), SEQ_ZERO);
 
+            let width = title.len();
             items.push(TabEntry {
-                item,
+                item: TabBarItem::WindowButton(*button),
                 title: title.to_owned(),
                 x: *x,
                 width,
@@ -356,9 +327,9 @@ impl TabBarState {
             },
         );
 
-        let fancy_window_decorations = config
+        let use_integrated_title_buttons = config
             .window_decorations
-            .contains(window::WindowDecorations::FANCY);
+            .contains(window::WindowDecorations::INTEGRATED_BUTTONS);
 
         // We ultimately want to produce a line looking like this:
         // ` | tab1-title x | tab2-title x |  +      . - X `
@@ -404,8 +375,11 @@ impl TabBarState {
         let mut items = vec![];
 
         #[cfg(not(target_os = "macos"))]
-        if fancy_window_decorations && config.fancy_window_decorations.is_left && !cfg!(widnows) {
-            Self::fancy_window_decorations(mouse_x, &mut x, config, &mut items, &mut line, &colors);
+        if use_integrated_title_buttons
+            && config.integrated_title_button_alignment == IntegratedTitleButtonAlignment::Left
+            && !cfg!(widnows)
+        {
+            Self::integrated_title_buttons(mouse_x, &mut x, config, &mut items, &mut line, &colors);
         }
 
         let black_cell = Cell::blank_with_attrs(
@@ -415,7 +389,7 @@ impl TabBarState {
         );
 
         #[cfg(target_os = "macos")]
-        if fancy_window_decorations && config.use_fancy_tab_bar == false {
+        if integrated_title_buttons && config.use_fancy_tab_bar == false {
             for _ in 0..10 as usize {
                 line.insert_cell(x, black_cell.clone(), title_width, SEQ_ZERO);
                 x += 1;
@@ -509,10 +483,10 @@ impl TabBarState {
             x += width;
         }
 
-        // Reserve place for buttons
+        // Reserve place for integrated title buttons
         #[cfg(not(target_os = "macos"))]
-        let title_width = if fancy_window_decorations
-            && !config.fancy_window_decorations.is_left
+        let title_width = if use_integrated_title_buttons
+            && config.integrated_title_button_alignment == IntegratedTitleButtonAlignment::Right
             && !cfg!(target_os = "macos")
         {
             let window_hide =
@@ -543,7 +517,18 @@ impl TabBarState {
             let maximize_len = window_maximize.len().max(window_maximize_hover.len());
             let close_len = window_close.len().max(window_close_hover.len());
 
-            title_width.saturating_sub(hide_len + maximize_len + close_len)
+            let mut width_to_reserve = 0;
+            for button in &config.integrated_title_buttons {
+                use IntegratedTitleButton as Button;
+                let button_len = match button {
+                    Button::Hide => hide_len,
+                    Button::Maximize => maximize_len,
+                    Button::Close => close_len,
+                };
+                width_to_reserve += button_len;
+            }
+
+            title_width.saturating_sub(width_to_reserve)
         } else {
             title_width
         };
@@ -568,9 +553,11 @@ impl TabBarState {
         }
 
         #[cfg(not(target_os = "macos"))]
-        if fancy_window_decorations && !config.fancy_window_decorations.is_left {
+        if use_integrated_title_buttons
+            && config.integrated_title_button_alignment == IntegratedTitleButtonAlignment::Right
+        {
             x = title_width;
-            Self::fancy_window_decorations(mouse_x, &mut x, config, &mut items, &mut line, &colors);
+            Self::integrated_title_buttons(mouse_x, &mut x, config, &mut items, &mut line, &colors);
         }
 
         Self { line, items }

--- a/wezterm-gui/src/tabbar.rs
+++ b/wezterm-gui/src/tabbar.rs
@@ -377,7 +377,6 @@ impl TabBarState {
         #[cfg(not(target_os = "macos"))]
         if use_integrated_title_buttons
             && config.integrated_title_button_alignment == IntegratedTitleButtonAlignment::Left
-            && !cfg!(widnows)
         {
             Self::integrated_title_buttons(mouse_x, &mut x, config, &mut items, &mut line, &colors);
         }

--- a/wezterm-gui/src/tabbar.rs
+++ b/wezterm-gui/src/tabbar.rs
@@ -191,55 +191,37 @@ impl TabBarState {
         line: &mut Line,
         colors: &TabBarColors,
     ) {
-        let window_hide = parse_status_text(
-            &config.tab_bar_style.window_hide,
-            if config.use_fancy_tab_bar {
-                CellAttributes::default()
-            } else {
-                colors.window_hide().as_cell_attributes()
-            },
-        );
+        let default_cell = if config.use_fancy_tab_bar {
+            CellAttributes::default()
+        } else {
+            colors.new_tab().as_cell_attributes()
+        };
+
+        let default_cell_hover = if config.use_fancy_tab_bar {
+            CellAttributes::default()
+        } else {
+            colors.new_tab_hover().as_cell_attributes()
+        };
+
+        let window_hide =
+            parse_status_text(&config.tab_bar_style.window_hide, default_cell.clone());
         let window_hide_hover = parse_status_text(
             &config.tab_bar_style.window_hide_hover,
-            if config.use_fancy_tab_bar {
-                CellAttributes::default()
-            } else {
-                colors.window_hide_hover().as_cell_attributes()
-            },
+            default_cell_hover.clone(),
         );
 
-        let window_maximize = parse_status_text(
-            &config.tab_bar_style.window_maximize,
-            if config.use_fancy_tab_bar {
-                CellAttributes::default()
-            } else {
-                colors.window_maximize().as_cell_attributes()
-            },
-        );
+        let window_maximize =
+            parse_status_text(&config.tab_bar_style.window_maximize, default_cell.clone());
         let window_maximize_hover = parse_status_text(
             &config.tab_bar_style.window_maximize_hover,
-            if config.use_fancy_tab_bar {
-                CellAttributes::default()
-            } else {
-                colors.window_maximize_hover().as_cell_attributes()
-            },
+            default_cell_hover.clone(),
         );
 
-        let window_close = parse_status_text(
-            &config.tab_bar_style.window_close,
-            if config.use_fancy_tab_bar {
-                CellAttributes::default()
-            } else {
-                colors.window_close().as_cell_attributes()
-            },
-        );
+        let window_close =
+            parse_status_text(&config.tab_bar_style.window_close, default_cell.clone());
         let window_close_hover = parse_status_text(
             &config.tab_bar_style.window_close_hover,
-            if config.use_fancy_tab_bar {
-                CellAttributes::default()
-            } else {
-                colors.window_close_hover().as_cell_attributes()
-            },
+            default_cell_hover.clone(),
         );
 
         for button in &config.integrated_title_buttons {

--- a/wezterm-gui/src/tabbar.rs
+++ b/wezterm-gui/src/tabbar.rs
@@ -246,7 +246,12 @@ impl TabBarState {
             remove_hide_button,
             remove_maximize_button,
             ..
-        } = config.fancy_window_decorations;
+        } = if cfg!(any(windows, target_os = "macos")) {
+            // Ignore changes to config on windows and macos
+            window::FancyWindowDecorations::default()
+        } else {
+            config.fancy_window_decorations.clone()
+        };
 
         let button_order = if is_left {
             ['X', '.', '-']
@@ -397,7 +402,7 @@ impl TabBarState {
         let mut x = 0;
         let mut items = vec![];
 
-        if fancy_window_decorations && config.fancy_window_decorations.is_left {
+        if fancy_window_decorations && config.fancy_window_decorations.is_left && !cfg!(widnows) {
             Self::fancy_window_decorations(mouse_x, &mut x, config, &mut items, &mut line, &colors);
         }
 
@@ -495,7 +500,10 @@ impl TabBarState {
         }
 
         // Reserve place for buttons
-        let title_width = if fancy_window_decorations && !config.fancy_window_decorations.is_left {
+        let title_width = if fancy_window_decorations
+            && !config.fancy_window_decorations.is_left
+            && !cfg!(target_os = "macos")
+        {
             let window_hide =
                 parse_status_text(&config.tab_bar_style.window_hide, CellAttributes::default());
             let window_hide_hover = parse_status_text(
@@ -548,7 +556,10 @@ impl TabBarState {
             line.insert_cell(x, black_cell.clone(), title_width, SEQ_ZERO);
         }
 
-        if fancy_window_decorations && !config.fancy_window_decorations.is_left {
+        if fancy_window_decorations
+            && !config.fancy_window_decorations.is_left
+            && !cfg!(target_os = "macos")
+        {
             x = title_width;
             Self::fancy_window_decorations(mouse_x, &mut x, config, &mut items, &mut line, &colors);
         }

--- a/wezterm-gui/src/tabbar.rs
+++ b/wezterm-gui/src/tabbar.rs
@@ -182,6 +182,128 @@ impl TabBarState {
         &self.items
     }
 
+    fn fancy_window_decorations(
+        mouse_x: Option<usize>,
+        x: &mut usize,
+        config: &ConfigHandle,
+        items: &mut Vec<TabEntry>,
+        line: &mut Line,
+        colors: &TabBarColors,
+    ) {
+        let window_hide = parse_status_text(
+            &config.tab_bar_style.window_hide,
+            if config.use_fancy_tab_bar {
+                CellAttributes::default()
+            } else {
+                colors.window_hide().as_cell_attributes()
+            },
+        );
+        let window_hide_hover = parse_status_text(
+            &config.tab_bar_style.window_hide_hover,
+            if config.use_fancy_tab_bar {
+                CellAttributes::default()
+            } else {
+                colors.window_hide_hover().as_cell_attributes()
+            },
+        );
+
+        let window_maximize = parse_status_text(
+            &config.tab_bar_style.window_maximize,
+            if config.use_fancy_tab_bar {
+                CellAttributes::default()
+            } else {
+                colors.window_maximize().as_cell_attributes()
+            },
+        );
+        let window_maximize_hover = parse_status_text(
+            &config.tab_bar_style.window_maximize_hover,
+            if config.use_fancy_tab_bar {
+                CellAttributes::default()
+            } else {
+                colors.window_maximize_hover().as_cell_attributes()
+            },
+        );
+
+        let window_close = parse_status_text(
+            &config.tab_bar_style.window_close,
+            if config.use_fancy_tab_bar {
+                CellAttributes::default()
+            } else {
+                colors.window_close().as_cell_attributes()
+            },
+        );
+        let window_close_hover = parse_status_text(
+            &config.tab_bar_style.window_close_hover,
+            if config.use_fancy_tab_bar {
+                CellAttributes::default()
+            } else {
+                colors.window_close_hover().as_cell_attributes()
+            },
+        );
+
+        let button_order = if config.fancy_window_decorations.is_left {
+            ['X', '.', '-']
+        } else {
+            ['.', '-', 'X']
+        };
+
+        for button in button_order {
+            let (title, item) = match button {
+                // Window hide button
+                '.' => {
+                    let hover = is_tab_hover(mouse_x, *x, window_hide_hover.len());
+
+                    let window_hide_button = if hover {
+                        &window_hide_hover
+                    } else {
+                        &window_hide
+                    };
+
+                    (window_hide_button, TabBarItem::WindowHideButton)
+                }
+                '-' => {
+                    // Window maximize button
+                    let hover = is_tab_hover(mouse_x, *x, window_maximize_hover.len());
+
+                    let window_maximize_button = if hover {
+                        &window_maximize_hover
+                    } else {
+                        &window_maximize
+                    };
+
+                    (window_maximize_button, TabBarItem::WindowMaximizeButton)
+                }
+                'X' => {
+                    // Window close button
+                    let hover = is_tab_hover(mouse_x, *x, window_close_hover.len());
+
+                    let window_close_button = if hover {
+                        &window_close_hover
+                    } else {
+                        &window_close
+                    };
+
+                    (window_close_button, TabBarItem::WindowCloseButton)
+                }
+                _ => unreachable!(),
+            };
+
+            // let button_start = *x;
+            let width = title.len();
+
+            line.append_line(title.to_owned(), SEQ_ZERO);
+
+            items.push(TabEntry {
+                item,
+                title: title.to_owned(),
+                x: *x,
+                width,
+            });
+
+            *x += width;
+        }
+    }
+
     /// Build a new tab bar from the current state
     /// mouse_x is some if the mouse is on the same row as the tab bar.
     /// title_width is the total number of cell columns in the window.
@@ -225,57 +347,6 @@ impl TabBarState {
             .window_decorations
             .contains(window::WindowDecorations::FANCY);
 
-        let window_hide = parse_status_text(
-            &config.tab_bar_style.window_hide,
-            if config.use_fancy_tab_bar {
-                CellAttributes::default()
-            } else {
-                new_tab_attrs.clone()
-            },
-        );
-        let window_hide_hover = parse_status_text(
-            &config.tab_bar_style.window_hide_hover,
-            if config.use_fancy_tab_bar {
-                CellAttributes::default()
-            } else {
-                new_tab_hover_attrs.clone()
-            },
-        );
-
-        let window_maximize = parse_status_text(
-            &config.tab_bar_style.window_maximize,
-            if config.use_fancy_tab_bar {
-                CellAttributes::default()
-            } else {
-                new_tab_attrs.clone()
-            },
-        );
-        let window_maximize_hover = parse_status_text(
-            &config.tab_bar_style.window_maximize_hover,
-            if config.use_fancy_tab_bar {
-                CellAttributes::default()
-            } else {
-                new_tab_hover_attrs.clone()
-            },
-        );
-
-        let window_close = parse_status_text(
-            &config.tab_bar_style.window_close,
-            if config.use_fancy_tab_bar {
-                CellAttributes::default()
-            } else {
-                new_tab_attrs.clone()
-            },
-        );
-        let window_close_hover = parse_status_text(
-            &config.tab_bar_style.window_close_hover,
-            if config.use_fancy_tab_bar {
-                CellAttributes::default()
-            } else {
-                new_tab_hover_attrs.clone()
-            },
-        );
-
         // We ultimately want to produce a line looking like this:
         // ` | tab1-title x | tab2-title x |  +      . - X `
         // Where the `+` sign will spawn a new tab (or show a context
@@ -318,6 +389,10 @@ impl TabBarState {
 
         let mut x = 0;
         let mut items = vec![];
+
+        if fancy_window_decorations && config.fancy_window_decorations.is_left {
+            Self::fancy_window_decorations(mouse_x, &mut x, config, &mut items, &mut line, &colors);
+        }
 
         let black_cell = Cell::blank_with_attrs(
             CellAttributes::default()
@@ -413,7 +488,31 @@ impl TabBarState {
         }
 
         // Reserve place for buttons
-        let title_width = if fancy_window_decorations {
+        let title_width = if fancy_window_decorations && !config.fancy_window_decorations.is_left {
+            let window_hide =
+                parse_status_text(&config.tab_bar_style.window_hide, CellAttributes::default());
+            let window_hide_hover = parse_status_text(
+                &config.tab_bar_style.window_hide_hover,
+                CellAttributes::default(),
+            );
+
+            let window_maximize = parse_status_text(
+                &config.tab_bar_style.window_maximize,
+                CellAttributes::default(),
+            );
+            let window_maximize_hover = parse_status_text(
+                &config.tab_bar_style.window_maximize_hover,
+                CellAttributes::default(),
+            );
+            let window_close = parse_status_text(
+                &config.tab_bar_style.window_close,
+                CellAttributes::default(),
+            );
+            let window_close_hover = parse_status_text(
+                &config.tab_bar_style.window_close_hover,
+                CellAttributes::default(),
+            );
+
             let hide_len = window_hide.len().max(window_hide_hover.len());
             let maximize_len = window_maximize.len().max(window_maximize_hover.len());
             let close_len = window_close.len().max(window_close_hover.len());
@@ -442,81 +541,9 @@ impl TabBarState {
             line.insert_cell(x, black_cell.clone(), title_width, SEQ_ZERO);
         }
 
-        if fancy_window_decorations {
+        if fancy_window_decorations && !config.fancy_window_decorations.is_left {
             x = title_width;
-
-            // Window hide button
-            {
-                let hover = is_tab_hover(mouse_x, x, window_hide_hover.len());
-
-                let window_hide_button = if hover {
-                    &window_hide_hover
-                } else {
-                    &window_hide
-                };
-
-                let button_start = x;
-                let width = window_hide_button.len();
-
-                line.append_line(window_hide_button.clone(), SEQ_ZERO);
-
-                items.push(TabEntry {
-                    item: TabBarItem::WindowHideButton,
-                    title: window_hide_button.clone(),
-                    x: button_start,
-                    width,
-                });
-
-                x += width;
-            }
-
-            // Window maximize button
-            {
-                let hover = is_tab_hover(mouse_x, x, window_maximize_hover.len());
-
-                let window_maximize_button = if hover {
-                    &window_maximize_hover
-                } else {
-                    &window_maximize
-                };
-
-                let button_start = x;
-                let width = window_maximize_button.len();
-
-                line.append_line(window_maximize_button.clone(), SEQ_ZERO);
-
-                items.push(TabEntry {
-                    item: TabBarItem::WindowMaximizeButton,
-                    title: window_maximize_button.clone(),
-                    x: button_start,
-                    width,
-                });
-
-                x += width;
-            }
-
-            // Window close button
-            {
-                let hover = is_tab_hover(mouse_x, x, window_close_hover.len());
-
-                let window_close_button = if hover {
-                    &window_close_hover
-                } else {
-                    &window_close
-                };
-
-                let button_start = x;
-                let width = window_close_button.len();
-
-                line.append_line(window_close_button.clone(), SEQ_ZERO);
-
-                items.push(TabEntry {
-                    item: TabBarItem::WindowCloseButton,
-                    title: window_close_button.clone(),
-                    x: button_start,
-                    width,
-                });
-            }
+            Self::fancy_window_decorations(mouse_x, &mut x, config, &mut items, &mut line, &colors);
         }
 
         Self { line, items }

--- a/wezterm-gui/src/termwindow/mouseevent.rs
+++ b/wezterm-gui/src/termwindow/mouseevent.rs
@@ -415,6 +415,28 @@ impl super::TermWindow {
                     }
                     context.request_drag_move();
                 }
+                TabBarItem::WindowHideButton => {
+                    if let Some(ref window) = self.window {
+                        window.hide();
+                    }
+                }
+                TabBarItem::WindowMaximizeButton => {
+                    if let Some(ref window) = self.window {
+                        let maximized = self
+                            .window_state
+                            .intersects(WindowState::MAXIMIZED | WindowState::FULL_SCREEN);
+                        if maximized {
+                            window.restore();
+                        } else {
+                            window.maximize();
+                        }
+                    }
+                }
+                TabBarItem::WindowCloseButton => {
+                    if let Some(ref window) = self.window {
+                        self.close_requested(&window.clone());
+                    }
+                }
             },
             WMEK::Press(MousePress::Middle) => match item {
                 TabBarItem::Tab { tab_idx, .. } => {
@@ -423,7 +445,10 @@ impl super::TermWindow {
                 TabBarItem::NewTabButton { .. }
                 | TabBarItem::None
                 | TabBarItem::LeftStatus
-                | TabBarItem::RightStatus => {}
+                | TabBarItem::RightStatus
+                | TabBarItem::WindowHideButton
+                | TabBarItem::WindowMaximizeButton
+                | TabBarItem::WindowCloseButton => {}
             },
             WMEK::Press(MousePress::Right) => match item {
                 TabBarItem::Tab { .. } => {
@@ -432,7 +457,12 @@ impl super::TermWindow {
                 TabBarItem::NewTabButton { .. } => {
                     self.show_launcher();
                 }
-                TabBarItem::None | TabBarItem::LeftStatus | TabBarItem::RightStatus => {}
+                TabBarItem::None
+                | TabBarItem::LeftStatus
+                | TabBarItem::RightStatus
+                | TabBarItem::WindowHideButton
+                | TabBarItem::WindowMaximizeButton
+                | TabBarItem::WindowCloseButton => {}
             },
             WMEK::Move => match item {
                 TabBarItem::None => {

--- a/wezterm-gui/src/termwindow/mouseevent.rs
+++ b/wezterm-gui/src/termwindow/mouseevent.rs
@@ -415,26 +415,23 @@ impl super::TermWindow {
                     }
                     context.request_drag_move();
                 }
-                TabBarItem::WindowHideButton => {
+                TabBarItem::WindowButton(button) => {
+                    use window::IntegratedTitleButton as Button;
                     if let Some(ref window) = self.window {
-                        window.hide();
-                    }
-                }
-                TabBarItem::WindowMaximizeButton => {
-                    if let Some(ref window) = self.window {
-                        let maximized = self
-                            .window_state
-                            .intersects(WindowState::MAXIMIZED | WindowState::FULL_SCREEN);
-                        if maximized {
-                            window.restore();
-                        } else {
-                            window.maximize();
+                        match button {
+                            Button::Hide => window.hide(),
+                            Button::Maximize => {
+                                let maximized = self
+                                    .window_state
+                                    .intersects(WindowState::MAXIMIZED | WindowState::FULL_SCREEN);
+                                if maximized {
+                                    window.restore();
+                                } else {
+                                    window.maximize();
+                                }
+                            }
+                            Button::Close => self.close_requested(&window.clone()),
                         }
-                    }
-                }
-                TabBarItem::WindowCloseButton => {
-                    if let Some(ref window) = self.window {
-                        self.close_requested(&window.clone());
                     }
                 }
             },
@@ -446,9 +443,7 @@ impl super::TermWindow {
                 | TabBarItem::None
                 | TabBarItem::LeftStatus
                 | TabBarItem::RightStatus
-                | TabBarItem::WindowHideButton
-                | TabBarItem::WindowMaximizeButton
-                | TabBarItem::WindowCloseButton => {}
+                | TabBarItem::WindowButton(_) => {}
             },
             WMEK::Press(MousePress::Right) => match item {
                 TabBarItem::Tab { .. } => {
@@ -460,9 +455,7 @@ impl super::TermWindow {
                 TabBarItem::None
                 | TabBarItem::LeftStatus
                 | TabBarItem::RightStatus
-                | TabBarItem::WindowHideButton
-                | TabBarItem::WindowMaximizeButton
-                | TabBarItem::WindowCloseButton => {}
+                | TabBarItem::WindowButton(_) => {}
             },
             WMEK::Move => match item {
                 TabBarItem::None => {

--- a/wezterm-gui/src/termwindow/mouseevent.rs
+++ b/wezterm-gui/src/termwindow/mouseevent.rs
@@ -461,6 +461,11 @@ impl super::TermWindow {
                 TabBarItem::None => {
                     context.set_window_drag_position(event.screen_coords);
                 }
+                TabBarItem::WindowButton(window::IntegratedTitleButton::Maximize) => {
+                    if let Some(ref window) = self.window {
+                        window.hover_maximize_button();
+                    }
+                }
                 _ => {}
             },
             WMEK::VertWheel(n) => {

--- a/wezterm-gui/src/termwindow/render.rs
+++ b/wezterm-gui/src/termwindow/render.rs
@@ -242,6 +242,60 @@ mod window_buttons {
             }
         }
     }
+
+    pub(super) mod gnome {
+        use super::*;
+        pub const CLOSE: &[Poly] = &[Poly {
+            path: &[
+                PolyCommand::LineTo(BlockCoord::One, BlockCoord::One),
+                PolyCommand::MoveTo(BlockCoord::One, BlockCoord::Zero),
+                PolyCommand::LineTo(BlockCoord::Zero, BlockCoord::One),
+            ],
+            intensity: BlockAlpha::Full,
+            style: PolyStyle::Outline,
+        }];
+
+        pub const HIDE: &[Poly] = &[Poly {
+            path: &[
+                PolyCommand::MoveTo(BlockCoord::Zero, BlockCoord::Frac(15, 16)),
+                PolyCommand::LineTo(BlockCoord::One, BlockCoord::Frac(15, 16)),
+            ],
+            intensity: BlockAlpha::Full,
+            style: PolyStyle::Outline,
+        }];
+
+        pub const MAXIMIZE: &[Poly] = &[Poly {
+            path: &[
+                PolyCommand::LineTo(BlockCoord::Frac(1, 16), BlockCoord::Frac(15, 16)),
+                PolyCommand::LineTo(BlockCoord::Frac(15, 16), BlockCoord::Frac(15, 16)),
+                PolyCommand::LineTo(BlockCoord::Frac(15, 16), BlockCoord::Frac(1, 16)),
+                PolyCommand::LineTo(BlockCoord::Frac(1, 16), BlockCoord::Frac(1, 16)),
+            ],
+            intensity: BlockAlpha::Full,
+            style: PolyStyle::Outline,
+        }];
+
+        pub const RESTORE: &[Poly] = &[Poly {
+            path: &[
+                PolyCommand::MoveTo(BlockCoord::Frac(3, 16), BlockCoord::Frac(3, 16)),
+                PolyCommand::LineTo(BlockCoord::Frac(3, 16), BlockCoord::Frac(13, 16)),
+                PolyCommand::LineTo(BlockCoord::Frac(13, 16), BlockCoord::Frac(13, 16)),
+                PolyCommand::LineTo(BlockCoord::Frac(13, 16), BlockCoord::Frac(3, 16)),
+                PolyCommand::LineTo(BlockCoord::Frac(3, 16), BlockCoord::Frac(3, 16)),
+            ],
+            intensity: BlockAlpha::Full,
+            style: PolyStyle::Outline,
+        }];
+
+        pub fn sized_poly(poly: &'static [Poly]) -> SizedPoly {
+            let size = Dimension::Pixels(8.);
+            SizedPoly {
+                poly,
+                width: size,
+                height: size,
+            }
+        }
+    }
 }
 
 fn window_button_element(
@@ -265,6 +319,20 @@ fn window_button_element(
             TabBarItem::WindowCloseButton => CLOSE,
             _ => unreachable!(),
         }
+    } else if cfg!(target_os = "linux") {
+        use window_buttons::gnome::{CLOSE, HIDE, MAXIMIZE, RESTORE};
+        match window_button {
+            TabBarItem::WindowHideButton => HIDE,
+            TabBarItem::WindowMaximizeButton => {
+                if is_maximized {
+                    RESTORE
+                } else {
+                    MAXIMIZE
+                }
+            }
+            TabBarItem::WindowCloseButton => CLOSE,
+            _ => unreachable!(),
+        }
     } else {
         match window_button {
             TabBarItem::WindowHideButton => HIDE_BUTTON,
@@ -276,6 +344,8 @@ fn window_button_element(
 
     let poly = if cfg!(windows) {
         window_buttons::windows::sized_poly(poly)
+    } else if cfg!(target_os = "linux") {
+        window_buttons::gnome::sized_poly(poly)
     } else if cfg!(macos) {
         SizedPoly {
             poly: &[],
@@ -318,6 +388,45 @@ fn window_button_element(
                 right: Dimension::Points(18. * scale),
                 top: Dimension::Points(10. * scale),
                 bottom: Dimension::Points(10. * scale),
+            })
+    } else if cfg!(target_os = "linux") {
+        element
+            .zindex(1)
+            .vertical_align(VerticalAlign::Middle)
+            .padding(BoxDimension {
+                left: Dimension::Pixels(7.),
+                right: Dimension::Pixels(7.),
+                top: Dimension::Pixels(7.),
+                bottom: Dimension::Pixels(7.),
+            })
+            .border(BoxDimension::new(Dimension::Pixels(1.)))
+            .border_corners(Some(Corners {
+                top_left: SizedPoly {
+                    width: Dimension::Pixels(14.),
+                    height: Dimension::Pixels(14.),
+                    poly: TOP_LEFT_ROUNDED_CORNER,
+                },
+                top_right: SizedPoly {
+                    width: Dimension::Pixels(14.),
+                    height: Dimension::Pixels(14.),
+                    poly: TOP_RIGHT_ROUNDED_CORNER,
+                },
+                bottom_left: SizedPoly {
+                    width: Dimension::Pixels(14.),
+                    height: Dimension::Pixels(14.),
+                    poly: BOTTOM_LEFT_ROUNDED_CORNER,
+                },
+                bottom_right: SizedPoly {
+                    width: Dimension::Pixels(14.),
+                    height: Dimension::Pixels(14.),
+                    poly: BOTTOM_RIGHT_ROUNDED_CORNER,
+                },
+            }))
+            .margin(BoxDimension {
+                left: Dimension::Pixels(7.),
+                right: Dimension::Pixels(7.),
+                top: Dimension::Pixels(7.),
+                bottom: Dimension::Pixels(7.),
             })
     } else if cfg!(macos) {
         element

--- a/wezterm-gui/src/termwindow/render.rs
+++ b/wezterm-gui/src/termwindow/render.rs
@@ -276,6 +276,12 @@ fn window_button_element(
 
     let poly = if cfg!(windows) {
         window_buttons::windows::sized_poly(poly)
+    } else if cfg!(macos) {
+        SizedPoly {
+            poly: &[],
+            width: Dimension::Pixels(13.),
+            height: Dimension::Pixels(13.),
+        }
     } else {
         SizedPoly {
             poly,
@@ -313,6 +319,45 @@ fn window_button_element(
                 top: Dimension::Points(10. * scale),
                 bottom: Dimension::Points(10. * scale),
             })
+    } else if cfg!(macos) {
+        element
+            .zindex(1)
+            .vertical_align(VerticalAlign::Middle)
+            .padding(BoxDimension {
+                left: Dimension::default(),
+                right: Dimension::default(),
+                top: Dimension::default(),
+                bottom: Dimension::default(),
+            })
+            .border(BoxDimension::new(Dimension::Pixels(1.)))
+            .border_corners(Some(Corners {
+                top_left: SizedPoly {
+                    width: Dimension::Pixels(8.),
+                    height: Dimension::Pixels(8.),
+                    poly: TOP_LEFT_ROUNDED_CORNER,
+                },
+                top_right: SizedPoly {
+                    width: Dimension::Pixels(8.),
+                    height: Dimension::Pixels(8.),
+                    poly: TOP_RIGHT_ROUNDED_CORNER,
+                },
+                bottom_left: SizedPoly {
+                    width: Dimension::Pixels(8.),
+                    height: Dimension::Pixels(8.),
+                    poly: BOTTOM_LEFT_ROUNDED_CORNER,
+                },
+                bottom_right: SizedPoly {
+                    width: Dimension::Pixels(8.),
+                    height: Dimension::Pixels(8.),
+                    poly: BOTTOM_RIGHT_ROUNDED_CORNER,
+                },
+            }))
+            .margin(BoxDimension {
+                left: Dimension::Cells(0.5),
+                right: Dimension::Cells(0.5),
+                top: Dimension::Cells(0.5),
+                bottom: Dimension::Cells(0.5),
+            })
     } else {
         element
             .zindex(1)
@@ -343,12 +388,12 @@ fn window_button_element(
     let element = element
         .item_type(UIItemType::TabBar(window_button))
         .colors(ElementColors {
-            border: BorderColor::default(),
+            border: BorderColor::new(color.bg_color.to_linear()),
             bg: color.bg_color.to_linear().into(),
             text: color.fg_color.to_linear().into(),
         })
         .hover_colors(Some(ElementColors {
-            border: BorderColor::default(),
+            border: BorderColor::new(hover_colors.bg_color.to_linear()),
             bg: hover_colors.bg_color.to_linear().into(),
             text: hover_colors.fg_color.to_linear().into(),
         }));

--- a/wezterm-gui/src/termwindow/render.rs
+++ b/wezterm-gui/src/termwindow/render.rs
@@ -53,57 +53,37 @@ use window::color::LinearRgba;
 use window::{IntegratedTitleButton, IntegratedTitleButtonAlignment};
 
 pub const TOP_LEFT_ROUNDED_CORNER: &[Poly] = &[Poly {
-    path: &[
-        PolyCommand::MoveTo(BlockCoord::One, BlockCoord::One),
-        PolyCommand::LineTo(BlockCoord::One, BlockCoord::Zero),
-        PolyCommand::QuadTo {
-            control: (BlockCoord::Zero, BlockCoord::Zero),
-            to: (BlockCoord::Zero, BlockCoord::One),
-        },
-        PolyCommand::Close,
-    ],
+    path: &[PolyCommand::PushOval {
+        center: (BlockCoord::One, BlockCoord::One),
+        radiuses: (BlockCoord::One, BlockCoord::One),
+    }],
     intensity: BlockAlpha::Full,
     style: PolyStyle::Fill,
 }];
 
 pub const BOTTOM_LEFT_ROUNDED_CORNER: &[Poly] = &[Poly {
-    path: &[
-        PolyCommand::MoveTo(BlockCoord::One, BlockCoord::Zero),
-        PolyCommand::LineTo(BlockCoord::One, BlockCoord::One),
-        PolyCommand::QuadTo {
-            control: (BlockCoord::Zero, BlockCoord::One),
-            to: (BlockCoord::Zero, BlockCoord::Zero),
-        },
-        PolyCommand::Close,
-    ],
+    path: &[PolyCommand::PushOval {
+        center: (BlockCoord::One, BlockCoord::Zero),
+        radiuses: (BlockCoord::One, BlockCoord::One),
+    }],
     intensity: BlockAlpha::Full,
     style: PolyStyle::Fill,
 }];
 
 pub const TOP_RIGHT_ROUNDED_CORNER: &[Poly] = &[Poly {
-    path: &[
-        PolyCommand::MoveTo(BlockCoord::Zero, BlockCoord::One),
-        PolyCommand::LineTo(BlockCoord::Zero, BlockCoord::Zero),
-        PolyCommand::QuadTo {
-            control: (BlockCoord::One, BlockCoord::Zero),
-            to: (BlockCoord::One, BlockCoord::One),
-        },
-        PolyCommand::Close,
-    ],
+    path: &[PolyCommand::PushOval {
+        center: (BlockCoord::Zero, BlockCoord::One),
+        radiuses: (BlockCoord::One, BlockCoord::One),
+    }],
     intensity: BlockAlpha::Full,
     style: PolyStyle::Fill,
 }];
 
 pub const BOTTOM_RIGHT_ROUNDED_CORNER: &[Poly] = &[Poly {
-    path: &[
-        PolyCommand::MoveTo(BlockCoord::Zero, BlockCoord::Zero),
-        PolyCommand::LineTo(BlockCoord::Zero, BlockCoord::One),
-        PolyCommand::QuadTo {
-            control: (BlockCoord::One, BlockCoord::One),
-            to: (BlockCoord::One, BlockCoord::Zero),
-        },
-        PolyCommand::Close,
-    ],
+    path: &[PolyCommand::PushOval {
+        center: (BlockCoord::Zero, BlockCoord::Zero),
+        radiuses: (BlockCoord::One, BlockCoord::One),
+    }],
     intensity: BlockAlpha::Full,
     style: PolyStyle::Fill,
 }];
@@ -147,6 +127,28 @@ const PLUS_BUTTON: &[Poly] = &[
 ];
 
 mod window_buttons {
+    pub struct WindowButtonColors {
+        pub(super) colors: ElementColors,
+        pub(super) hover_colors: ElementColors,
+    }
+
+    pub(super) fn auto_button_color(
+        background_lightness: f64,
+        foreground: config::IntegratedTitleButtonColor,
+    ) -> LinearRgba {
+        use config::IntegratedTitleButtonColor as Color;
+        match foreground {
+            Color::Custom(color) => color.to_linear(),
+            Color::Auto => {
+                if background_lightness > 0.5 {
+                    LinearRgba(0.0, 0.0, 0.0, 1.0)
+                } else {
+                    LinearRgba(1.0, 1.0, 1.0, 1.0)
+                }
+            }
+        }
+    }
+
     use super::*;
     pub(super) mod windows {
         use super::*;
@@ -222,6 +224,38 @@ mod window_buttons {
                 height: size,
             }
         }
+
+        pub fn window_button_colors(
+            background_lightness: f64,
+            foreground: config::IntegratedTitleButtonColor,
+            window_button: IntegratedTitleButton,
+        ) -> WindowButtonColors {
+            let foreground = auto_button_color(background_lightness, foreground);
+            let colors = ElementColors {
+                border: BorderColor::new(LinearRgba::TRANSPARENT),
+                bg: LinearRgba::TRANSPARENT.into(),
+                text: foreground.into(),
+            };
+
+            let hover_colors = if window_button == IntegratedTitleButton::Close {
+                ElementColors {
+                    border: BorderColor::new(LinearRgba::TRANSPARENT),
+                    bg: LinearRgba(1.0, 0.0, 0.0, 1.0).into(),
+                    text: LinearRgba(1.0, 1.0, 1.0, 1.0).into(),
+                }
+            } else {
+                ElementColors {
+                    border: BorderColor::new(LinearRgba::TRANSPARENT),
+                    bg: foreground.mul_alpha(0.1).into(),
+                    text: foreground.into(),
+                }
+            };
+
+            WindowButtonColors {
+                colors,
+                hover_colors,
+            }
+        }
     }
 
     pub(super) mod gnome {
@@ -276,6 +310,26 @@ mod window_buttons {
                 height: size,
             }
         }
+
+        pub fn window_button_colors(
+            background_lightness: f64,
+            foreground: config::IntegratedTitleButtonColor,
+            _window_button: IntegratedTitleButton,
+        ) -> WindowButtonColors {
+            let foreground = auto_button_color(background_lightness, foreground);
+            WindowButtonColors {
+                colors: ElementColors {
+                    border: BorderColor::new(foreground.mul_alpha(0.1)),
+                    bg: LinearRgba::TRANSPARENT.into(),
+                    text: foreground.into(),
+                },
+                hover_colors: ElementColors {
+                    border: BorderColor::new(foreground.mul_alpha(0.15)),
+                    bg: LinearRgba::TRANSPARENT.into(),
+                    text: foreground.into(),
+                },
+            }
+        }
     }
 }
 
@@ -285,46 +339,40 @@ fn window_button_element(
     font: &Rc<LoadedFont>,
     metrics: &RenderMetrics,
     colors: &TabBarColors,
-    style: window::IntegratedTitleButtonStyle,
+    config: &ConfigHandle,
 ) -> Element {
     use window::IntegratedTitleButtonStyle as Style;
     use IntegratedTitleButton as Button;
 
-    let poly = match style {
-        Style::Windows => {
-            use window_buttons::windows::{CLOSE, HIDE, MAXIMIZE, RESTORE};
-            match window_button {
-                Button::Hide => HIDE,
-                Button::Maximize => {
-                    if is_maximized {
-                        RESTORE
-                    } else {
-                        MAXIMIZE
-                    }
-                }
-                Button::Close => CLOSE,
-            }
-        }
+    let style = config.integrated_title_button_style;
 
-        Style::Gnome => {
-            use window_buttons::gnome::{CLOSE, HIDE, MAXIMIZE, RESTORE};
-            match window_button {
-                Button::Hide => HIDE,
-                Button::Maximize => {
-                    if is_maximized {
-                        RESTORE
-                    } else {
-                        MAXIMIZE
-                    }
-                }
-                Button::Close => CLOSE,
+    let poly = {
+        let (CLOSE, HIDE, MAXIMIZE, RESTORE) = match style {
+            Style::Windows => {
+                use window_buttons::windows::{CLOSE, HIDE, MAXIMIZE, RESTORE};
+                (CLOSE, HIDE, MAXIMIZE, RESTORE)
             }
-        }
-    };
+            Style::Gnome => {
+                use window_buttons::gnome::{CLOSE, HIDE, MAXIMIZE, RESTORE};
+                (CLOSE, HIDE, MAXIMIZE, RESTORE)
+            }
+        };
+        let poly = match window_button {
+            Button::Hide => HIDE,
+            Button::Maximize => {
+                if is_maximized {
+                    RESTORE
+                } else {
+                    MAXIMIZE
+                }
+            }
+            Button::Close => CLOSE,
+        };
 
-    let poly = match style {
-        Style::Windows => window_buttons::windows::sized_poly(poly),
-        Style::Gnome => window_buttons::gnome::sized_poly(poly),
+        match style {
+            Style::Windows => window_buttons::windows::sized_poly(poly),
+            Style::Gnome => window_buttons::gnome::sized_poly(poly),
+        }
     };
 
     let element = Element::new(
@@ -353,64 +401,74 @@ fn window_button_element(
                     bottom: Dimension::Points(10. * scale),
                 })
         }
-        Style::Gnome => element
-            .zindex(1)
-            .vertical_align(VerticalAlign::Middle)
-            .padding(BoxDimension {
-                left: Dimension::Pixels(7.),
-                right: Dimension::Pixels(7.),
-                top: Dimension::Pixels(7.),
-                bottom: Dimension::Pixels(7.),
-            })
-            .border(BoxDimension::new(Dimension::Pixels(1.)))
-            .border_corners(Some(Corners {
-                top_left: SizedPoly {
-                    width: Dimension::Pixels(14.),
-                    height: Dimension::Pixels(14.),
-                    poly: TOP_LEFT_ROUNDED_CORNER,
-                },
-                top_right: SizedPoly {
-                    width: Dimension::Pixels(14.),
-                    height: Dimension::Pixels(14.),
-                    poly: TOP_RIGHT_ROUNDED_CORNER,
-                },
-                bottom_left: SizedPoly {
-                    width: Dimension::Pixels(14.),
-                    height: Dimension::Pixels(14.),
-                    poly: BOTTOM_LEFT_ROUNDED_CORNER,
-                },
-                bottom_right: SizedPoly {
-                    width: Dimension::Pixels(14.),
-                    height: Dimension::Pixels(14.),
-                    poly: BOTTOM_RIGHT_ROUNDED_CORNER,
-                },
-            }))
-            .margin(BoxDimension {
-                left: Dimension::Pixels(7.),
-                right: Dimension::Pixels(7.),
-                top: Dimension::Pixels(7.),
-                bottom: Dimension::Pixels(7.),
-            }),
+        Style::Gnome => {
+            let border_corners_size = Dimension::Pixels(12.);
+            element
+                .zindex(1)
+                .vertical_align(VerticalAlign::Middle)
+                .padding(BoxDimension {
+                    left: Dimension::Pixels(7.),
+                    right: Dimension::Pixels(7.),
+                    top: Dimension::Pixels(7.),
+                    bottom: Dimension::Pixels(7.),
+                })
+                .border(BoxDimension::new(Dimension::Pixels(1.)))
+                .border_corners(Some(Corners {
+                    top_left: SizedPoly {
+                        width: border_corners_size,
+                        height: border_corners_size,
+                        poly: TOP_LEFT_ROUNDED_CORNER,
+                    },
+                    top_right: SizedPoly {
+                        width: border_corners_size,
+                        height: border_corners_size,
+                        poly: TOP_RIGHT_ROUNDED_CORNER,
+                    },
+                    bottom_left: SizedPoly {
+                        width: border_corners_size,
+                        height: border_corners_size,
+                        poly: BOTTOM_LEFT_ROUNDED_CORNER,
+                    },
+                    bottom_right: SizedPoly {
+                        width: border_corners_size,
+                        height: border_corners_size,
+                        poly: BOTTOM_RIGHT_ROUNDED_CORNER,
+                    },
+                }))
+                .margin(BoxDimension {
+                    left: Dimension::Pixels(7.),
+                    right: Dimension::Pixels(7.),
+                    top: Dimension::Pixels(7.),
+                    bottom: Dimension::Pixels(7.),
+                })
+        }
     };
 
-    let (color, hover_colors) = match window_button {
-        Button::Hide => (colors.window_hide(), colors.window_hide_hover()),
-        Button::Maximize => (colors.window_maximize(), colors.window_maximize_hover()),
-        Button::Close => (colors.window_close(), colors.window_close_hover()),
+    let foreground = config.integrated_title_button_color.clone();
+    let background_lightness = {
+        let (r, g, b) = config
+            .window_frame
+            .active_titlebar_bg
+            .to_tuple_rgb8()
+            .clone();
+
+        let max = r.max(g.max(b)) as f64;
+        let min = r.min(g.min(b)) as f64;
+
+        (max + min) / 510.0
     };
+
+    let window_button_colors_fn = match style {
+        Style::Windows => window_buttons::windows::window_button_colors,
+        Style::Gnome => window_buttons::gnome::window_button_colors,
+    };
+
+    let colors = window_button_colors_fn(background_lightness, foreground, window_button);
 
     let element = element
         .item_type(UIItemType::TabBar(TabBarItem::WindowButton(window_button)))
-        .colors(ElementColors {
-            border: BorderColor::new(color.bg_color.to_linear()),
-            bg: color.bg_color.to_linear().into(),
-            text: color.fg_color.to_linear().into(),
-        })
-        .hover_colors(Some(ElementColors {
-            border: BorderColor::new(hover_colors.bg_color.to_linear()),
-            bg: hover_colors.bg_color.to_linear().into(),
-            text: hover_colors.fg_color.to_linear().into(),
-        }));
+        .colors(colors.colors)
+        .hover_colors(Some(colors.hover_colors));
 
     element
 }
@@ -1077,7 +1135,7 @@ impl super::TermWindow {
                     &font,
                     &metrics,
                     &colors,
-                    self.config.integrated_title_button_style,
+                    &self.config,
                 ),
             }
         };

--- a/wezterm-gui/src/termwindow/render.rs
+++ b/wezterm-gui/src/termwindow/render.rs
@@ -249,6 +249,7 @@ fn window_button_element(
     is_maximized: bool,
     font: &Rc<LoadedFont>,
     metrics: &RenderMetrics,
+    colors: &TabBarColors,
 ) -> Element {
     let poly = if cfg!(windows) {
         use window_buttons::windows::{CLOSE, HIDE, MAXIMIZE, RESTORE};
@@ -296,7 +297,7 @@ fn window_button_element(
         },
     );
 
-    if cfg!(windows) {
+    let element = if cfg!(windows) {
         let left_padding = match window_button {
             TabBarItem::WindowHideButton => 17.0,
             _ => 18.0,
@@ -328,7 +329,31 @@ fn window_button_element(
                 top: Dimension::Cells(0.6),
                 bottom: Dimension::Cells(0.6),
             })
-    }
+    };
+
+    let (color, hover_colors) = match window_button {
+        TabBarItem::WindowHideButton => (colors.window_hide(), colors.window_hide_hover()),
+        TabBarItem::WindowMaximizeButton => {
+            (colors.window_maximize(), colors.window_maximize_hover())
+        }
+        TabBarItem::WindowCloseButton => (colors.window_close(), colors.window_close_hover()),
+        _ => unreachable!(),
+    };
+
+    let element = element
+        .item_type(UIItemType::TabBar(window_button))
+        .colors(ElementColors {
+            border: BorderColor::default(),
+            bg: color.bg_color.to_linear().into(),
+            text: color.fg_color.to_linear().into(),
+        })
+        .hover_colors(Some(ElementColors {
+            border: BorderColor::default(),
+            bg: hover_colors.bg_color.to_linear().into(),
+            text: hover_colors.fg_color.to_linear().into(),
+        }));
+
+    element
 }
 
 /// The data that we associate with a line; we use this to cache it shape hash
@@ -992,18 +1017,8 @@ impl super::TermWindow {
                     self.window_state.contains(window::WindowState::MAXIMIZED),
                     &font,
                     &metrics,
-                )
-                .item_type(UIItemType::TabBar(item.item.clone()))
-                .colors(ElementColors {
-                    border: BorderColor::default(),
-                    bg: new_tab.bg_color.to_linear().into(),
-                    text: new_tab.fg_color.to_linear().into(),
-                })
-                .hover_colors(Some(ElementColors {
-                    border: BorderColor::default(),
-                    bg: new_tab_hover.bg_color.to_linear().into(),
-                    text: new_tab_hover.fg_color.to_linear().into(),
-                })),
+                    &colors,
+                ),
             }
         };
 

--- a/wezterm-gui/src/termwindow/render.rs
+++ b/wezterm-gui/src/termwindow/render.rs
@@ -290,9 +290,6 @@ fn window_button_element(
     use window::IntegratedTitleButtonStyle as Style;
     use IntegratedTitleButton as Button;
 
-    #[cfg(windows)]
-    let style = Style::Windows;
-
     let poly = match style {
         Style::Windows => {
             use window_buttons::windows::{CLOSE, HIDE, MAXIMIZE, RESTORE};
@@ -1103,7 +1100,6 @@ impl super::TermWindow {
                 TabBarItem::WindowButton(_) => {
                     if self.config.integrated_title_button_alignment
                         == IntegratedTitleButtonAlignment::Left
-                        && cfg!(not(windows))
                     {
                         left_eles.push(item_to_elem(item))
                     } else {
@@ -1196,7 +1192,7 @@ impl super::TermWindow {
             == window::WindowDecorations::INTEGRATED_BUTTONS
             && (self.config.integrated_title_button_alignment
                 == IntegratedTitleButtonAlignment::Left
-                || (cfg!(target_os = "macos")) && cfg!(not(windows)));
+                || (cfg!(target_os = "macos")));
 
         let left_padding = if window_buttons_at_left {
             if cfg!(target_os = "macos") {

--- a/wezterm-gui/src/termwindow/render.rs
+++ b/wezterm-gui/src/termwindow/render.rs
@@ -50,6 +50,7 @@ use wezterm_term::color::{ColorAttribute, ColorPalette, RgbColor};
 use wezterm_term::{CellAttributes, Line, StableRowIndex};
 use window::bitmaps::Texture2d;
 use window::color::LinearRgba;
+use window::{IntegratedTitleButton, IntegratedTitleButtonAlignment};
 
 pub const TOP_LEFT_ROUNDED_CORNER: &[Poly] = &[Poly {
     path: &[
@@ -279,14 +280,15 @@ mod window_buttons {
 }
 
 fn window_button_element(
-    window_button: TabBarItem,
+    window_button: IntegratedTitleButton,
     is_maximized: bool,
     font: &Rc<LoadedFont>,
     metrics: &RenderMetrics,
     colors: &TabBarColors,
-    style: window::FancyWindowDecorationsStyle,
+    style: window::IntegratedTitleButtonStyle,
 ) -> Element {
-    use window::FancyWindowDecorationsStyle as Style;
+    use window::IntegratedTitleButtonStyle as Style;
+    use IntegratedTitleButton as Button;
 
     #[cfg(windows)]
     let style = Style::Windows;
@@ -295,31 +297,30 @@ fn window_button_element(
         Style::Windows => {
             use window_buttons::windows::{CLOSE, HIDE, MAXIMIZE, RESTORE};
             match window_button {
-                TabBarItem::WindowHideButton => HIDE,
-                TabBarItem::WindowMaximizeButton => {
+                Button::Hide => HIDE,
+                Button::Maximize => {
                     if is_maximized {
                         RESTORE
                     } else {
                         MAXIMIZE
                     }
                 }
-                TabBarItem::WindowCloseButton => CLOSE,
-                _ => unreachable!(),
+                Button::Close => CLOSE,
             }
         }
+
         Style::Gnome => {
             use window_buttons::gnome::{CLOSE, HIDE, MAXIMIZE, RESTORE};
             match window_button {
-                TabBarItem::WindowHideButton => HIDE,
-                TabBarItem::WindowMaximizeButton => {
+                Button::Hide => HIDE,
+                Button::Maximize => {
                     if is_maximized {
                         RESTORE
                     } else {
                         MAXIMIZE
                     }
                 }
-                TabBarItem::WindowCloseButton => CLOSE,
-                _ => unreachable!(),
+                Button::Close => CLOSE,
             }
         }
     };
@@ -340,7 +341,7 @@ fn window_button_element(
     let element = match style {
         Style::Windows => {
             let left_padding = match window_button {
-                TabBarItem::WindowHideButton => 17.0,
+                Button::Hide => 17.0,
                 _ => 18.0,
             };
             let scale = 72.0 / 96.0;
@@ -396,16 +397,13 @@ fn window_button_element(
     };
 
     let (color, hover_colors) = match window_button {
-        TabBarItem::WindowHideButton => (colors.window_hide(), colors.window_hide_hover()),
-        TabBarItem::WindowMaximizeButton => {
-            (colors.window_maximize(), colors.window_maximize_hover())
-        }
-        TabBarItem::WindowCloseButton => (colors.window_close(), colors.window_close_hover()),
-        _ => unreachable!(),
+        Button::Hide => (colors.window_hide(), colors.window_hide_hover()),
+        Button::Maximize => (colors.window_maximize(), colors.window_maximize_hover()),
+        Button::Close => (colors.window_close(), colors.window_close_hover()),
     };
 
     let element = element
-        .item_type(UIItemType::TabBar(window_button))
+        .item_type(UIItemType::TabBar(TabBarItem::WindowButton(window_button)))
         .colors(ElementColors {
             border: BorderColor::new(color.bg_color.to_linear()),
             bg: color.bg_color.to_linear().into(),
@@ -1076,15 +1074,13 @@ impl super::TermWindow {
                                 .into(),
                         })
                     }),
-                TabBarItem::WindowHideButton
-                | TabBarItem::WindowMaximizeButton
-                | TabBarItem::WindowCloseButton => window_button_element(
-                    item.item.clone(),
+                TabBarItem::WindowButton(button) => window_button_element(
+                    button,
                     self.window_state.contains(window::WindowState::MAXIMIZED),
                     &font,
                     &metrics,
                     &colors,
-                    self.config.fancy_window_decorations.style,
+                    self.config.integrated_title_button_style,
                 ),
             }
         };
@@ -1104,10 +1100,11 @@ impl super::TermWindow {
             match item.item {
                 TabBarItem::LeftStatus => left_status.push(item_to_elem(item)),
                 TabBarItem::None | TabBarItem::RightStatus => right_eles.push(item_to_elem(item)),
-                TabBarItem::WindowHideButton
-                | TabBarItem::WindowMaximizeButton
-                | TabBarItem::WindowCloseButton => {
-                    if self.config.fancy_window_decorations.is_left && cfg!(not(windows)) {
+                TabBarItem::WindowButton(_) => {
+                    if self.config.integrated_title_button_alignment
+                        == IntegratedTitleButtonAlignment::Left
+                        && cfg!(not(windows))
+                    {
                         left_eles.push(item_to_elem(item))
                     } else {
                         right_eles.push(item_to_elem(item))
@@ -1196,8 +1193,9 @@ impl super::TermWindow {
         }
 
         let window_buttons_at_left = self.config.window_decorations
-            == window::WindowDecorations::FANCY
-            && (self.config.fancy_window_decorations.is_left
+            == window::WindowDecorations::INTEGRATED_BUTTONS
+            && (self.config.integrated_title_button_alignment
+                == IntegratedTitleButtonAlignment::Left
                 || (cfg!(target_os = "macos")) && cfg!(not(windows)));
 
         let left_padding = if window_buttons_at_left {

--- a/wezterm-gui/src/termwindow/render.rs
+++ b/wezterm-gui/src/termwindow/render.rs
@@ -145,6 +145,36 @@ const PLUS_BUTTON: &[Poly] = &[
     },
 ];
 
+const HIDE_BUTTON: &[Poly] = &[Poly {
+    path: &[
+        PolyCommand::MoveTo(BlockCoord::Zero, BlockCoord::One),
+        PolyCommand::LineTo(BlockCoord::One, BlockCoord::One),
+    ],
+    intensity: BlockAlpha::Full,
+    style: PolyStyle::Outline,
+}];
+
+const MAXIMIZE_BUTTON: &[Poly] = &[Poly {
+    path: &[
+        // PolyCommand::MoveTo(BlockCoord::Zero, BlockCoord::One),
+        PolyCommand::LineTo(BlockCoord::Zero, BlockCoord::One),
+        PolyCommand::LineTo(BlockCoord::One, BlockCoord::One),
+        PolyCommand::LineTo(BlockCoord::One, BlockCoord::Zero),
+        PolyCommand::LineTo(BlockCoord::Zero, BlockCoord::Zero),
+    ],
+    intensity: BlockAlpha::Full,
+    style: PolyStyle::Outline,
+}];
+
+fn poly_for_window_button(window_button: TabBarItem) -> &'static [Poly] {
+    match window_button {
+        TabBarItem::WindowHideButton => HIDE_BUTTON,
+        TabBarItem::WindowMaximizeButton => MAXIMIZE_BUTTON,
+        TabBarItem::WindowCloseButton => X_BUTTON,
+        _ => unreachable!(),
+    }
+}
+
 /// The data that we associate with a line; we use this to cache it shape hash
 #[derive(Debug)]
 pub struct CachedLineState {
@@ -799,6 +829,45 @@ impl super::TermWindow {
                                 .into(),
                         })
                     }),
+                TabBarItem::WindowHideButton
+                | TabBarItem::WindowMaximizeButton
+                | TabBarItem::WindowCloseButton => Element::new(
+                    &font,
+                    ElementContent::Poly {
+                        line_width: metrics.underline_height.max(2),
+                        poly: SizedPoly {
+                            poly: poly_for_window_button(item.item.clone()),
+                            width: Dimension::Pixels(metrics.cell_size.height as f32 / 2.),
+                            height: Dimension::Pixels(metrics.cell_size.height as f32 / 2.),
+                        },
+                    },
+                )
+                .zindex(1)
+                .vertical_align(VerticalAlign::Middle)
+                .item_type(UIItemType::TabBar(item.item.clone()))
+                .margin(BoxDimension {
+                    left: Dimension::Cells(0.),
+                    right: Dimension::Cells(0.),
+                    top: Dimension::Cells(0.),
+                    bottom: Dimension::Cells(0.),
+                })
+                .padding(BoxDimension {
+                    left: Dimension::Cells(1.0),
+                    right: Dimension::Cells(1.0),
+                    top: Dimension::Cells(0.6),
+                    bottom: Dimension::Cells(0.6),
+                })
+                // .border(BoxDimension::new(Dimension::Pixels(1.)))
+                .colors(ElementColors {
+                    border: BorderColor::default(),
+                    bg: new_tab.bg_color.to_linear().into(),
+                    text: new_tab.fg_color.to_linear().into(),
+                })
+                .hover_colors(Some(ElementColors {
+                    border: BorderColor::default(),
+                    bg: new_tab_hover.bg_color.to_linear().into(),
+                    text: new_tab_hover.fg_color.to_linear().into(),
+                })),
             }
         };
 
@@ -817,6 +886,12 @@ impl super::TermWindow {
             match item.item {
                 TabBarItem::LeftStatus => left_status.push(item_to_elem(item)),
                 TabBarItem::None | TabBarItem::RightStatus => right_eles.push(item_to_elem(item)),
+                TabBarItem::WindowHideButton
+                | TabBarItem::WindowMaximizeButton
+                | TabBarItem::WindowCloseButton => {
+                    // TODO: Window buttons can be placed either at left and right
+                    right_eles.push(item_to_elem(item))
+                }
                 TabBarItem::Tab { tab_idx, active } => {
                     let mut elem = item_to_elem(item);
                     elem.max_width = Some(Dimension::Pixels(max_tab_width));

--- a/wezterm-gui/src/termwindow/render.rs
+++ b/wezterm-gui/src/termwindow/render.rs
@@ -308,8 +308,8 @@ fn window_button_element(
 ) -> Element {
     use window::FancyWindowDecorationsStyle as Style;
 
-    #[cfg(any(windows, targer_os = "macos"))]
-    let style = Style::default();
+    #[cfg(windows)]
+    let style = Style::Windows;
 
     let poly = match style {
         Style::Windows => {
@@ -1270,16 +1270,28 @@ impl super::TermWindow {
         let window_buttons_at_left = self.config.window_decorations
             == window::WindowDecorations::FANCY
             && (self.config.fancy_window_decorations.is_left
-                || cfg!(target_os = "macos") && cfg!(not(windows)));
+                || (cfg!(target_os = "macos")) && cfg!(not(windows)));
 
-        let left_padding = if window_buttons_at_left { 0.0 } else { 0.5 };
+        let left_padding = if window_buttons_at_left {
+            if cfg!(target_os = "macos") {
+                if !self.window_state.contains(window::WindowState::FULL_SCREEN) {
+                    Dimension::Pixels(70.0)
+                } else {
+                    Dimension::Cells(0.5)
+                }
+            } else {
+                Dimension::Pixels(0.0)
+            }
+        } else {
+            Dimension::Cells(0.5)
+        };
 
         children.push(
             Element::new(&font, ElementContent::Children(left_eles))
                 .vertical_align(VerticalAlign::Bottom)
                 .colors(bar_colors.clone())
                 .padding(BoxDimension {
-                    left: Dimension::Cells(left_padding),
+                    left: left_padding,
                     right: Dimension::Cells(0.),
                     top: Dimension::Cells(0.),
                     bottom: Dimension::Cells(0.),

--- a/wezterm-gui/src/termwindow/render.rs
+++ b/wezterm-gui/src/termwindow/render.rs
@@ -304,66 +304,58 @@ fn window_button_element(
     font: &Rc<LoadedFont>,
     metrics: &RenderMetrics,
     colors: &TabBarColors,
+    style: window::FancyWindowDecorationsStyle,
 ) -> Element {
-    let poly = if cfg!(windows) {
-        use window_buttons::windows::{CLOSE, HIDE, MAXIMIZE, RESTORE};
-        match window_button {
-            TabBarItem::WindowHideButton => HIDE,
-            TabBarItem::WindowMaximizeButton => {
-                if is_maximized {
-                    RESTORE
-                } else {
-                    MAXIMIZE
+    use window::FancyWindowDecorationsStyle as Style;
+
+    let poly = match style {
+        Style::Windows => {
+            use window_buttons::windows::{CLOSE, HIDE, MAXIMIZE, RESTORE};
+            match window_button {
+                TabBarItem::WindowHideButton => HIDE,
+                TabBarItem::WindowMaximizeButton => {
+                    if is_maximized {
+                        RESTORE
+                    } else {
+                        MAXIMIZE
+                    }
                 }
+                TabBarItem::WindowCloseButton => CLOSE,
+                _ => unreachable!(),
             }
-            TabBarItem::WindowCloseButton => CLOSE,
-            _ => unreachable!(),
         }
-    } else if cfg!(target_os = "linux") {
-        use window_buttons::gnome::{CLOSE, HIDE, MAXIMIZE, RESTORE};
-        match window_button {
-            TabBarItem::WindowHideButton => HIDE,
-            TabBarItem::WindowMaximizeButton => {
-                if is_maximized {
-                    RESTORE
-                } else {
-                    MAXIMIZE
+        Style::Gnome => {
+            use window_buttons::gnome::{CLOSE, HIDE, MAXIMIZE, RESTORE};
+            match window_button {
+                TabBarItem::WindowHideButton => HIDE,
+                TabBarItem::WindowMaximizeButton => {
+                    if is_maximized {
+                        RESTORE
+                    } else {
+                        MAXIMIZE
+                    }
                 }
+                TabBarItem::WindowCloseButton => CLOSE,
+                _ => unreachable!(),
             }
-            TabBarItem::WindowCloseButton => CLOSE,
-            _ => unreachable!(),
         }
-    } else {
-        match window_button {
+        Style::MacOs => match window_button {
             TabBarItem::WindowHideButton => HIDE_BUTTON,
             TabBarItem::WindowMaximizeButton => MAXIMIZE_BUTTON,
             TabBarItem::WindowCloseButton => X_BUTTON,
             _ => unreachable!(),
-        }
+        },
     };
 
-    let poly = if cfg!(windows) {
-        window_buttons::windows::sized_poly(poly)
-    } else if cfg!(target_os = "linux") {
-        window_buttons::gnome::sized_poly(poly)
-    } else if cfg!(macos) {
-        SizedPoly {
+    let poly = match style {
+        Style::Windows => window_buttons::windows::sized_poly(poly),
+        Style::Gnome => window_buttons::gnome::sized_poly(poly),
+        Style::MacOs => SizedPoly {
             poly: &[],
             width: Dimension::Pixels(13.),
             height: Dimension::Pixels(13.),
-        }
-    } else {
-        SizedPoly {
-            poly,
-            width: Dimension::Pixels(metrics.cell_size.height as f32 / 2.),
-            height: Dimension::Pixels(metrics.cell_size.height as f32 / 2.),
-        }
+        },
     };
-
-    match window_button {
-        TabBarItem::WindowHideButton => log::debug!("BTN"),
-        _ => {}
-    }
 
     let element = Element::new(
         &font,
@@ -373,24 +365,25 @@ fn window_button_element(
         },
     );
 
-    let element = if cfg!(windows) {
-        let left_padding = match window_button {
-            TabBarItem::WindowHideButton => 17.0,
-            _ => 18.0,
-        };
-        let scale = 72.0 / 96.0;
+    let element = match style {
+        Style::Windows => {
+            let left_padding = match window_button {
+                TabBarItem::WindowHideButton => 17.0,
+                _ => 18.0,
+            };
+            let scale = 72.0 / 96.0;
 
-        element
-            .zindex(1)
-            .vertical_align(VerticalAlign::Middle)
-            .padding(BoxDimension {
-                left: Dimension::Points(left_padding * scale),
-                right: Dimension::Points(18. * scale),
-                top: Dimension::Points(10. * scale),
-                bottom: Dimension::Points(10. * scale),
-            })
-    } else if cfg!(target_os = "linux") {
-        element
+            element
+                .zindex(1)
+                .vertical_align(VerticalAlign::Middle)
+                .padding(BoxDimension {
+                    left: Dimension::Points(left_padding * scale),
+                    right: Dimension::Points(18. * scale),
+                    top: Dimension::Points(10. * scale),
+                    bottom: Dimension::Points(10. * scale),
+                })
+        }
+        Style::Gnome => element
             .zindex(1)
             .vertical_align(VerticalAlign::Middle)
             .padding(BoxDimension {
@@ -427,9 +420,9 @@ fn window_button_element(
                 right: Dimension::Pixels(7.),
                 top: Dimension::Pixels(7.),
                 bottom: Dimension::Pixels(7.),
-            })
-    } else if cfg!(macos) {
-        element
+            }),
+
+        Style::MacOs => element
             .zindex(1)
             .vertical_align(VerticalAlign::Middle)
             .padding(BoxDimension {
@@ -466,23 +459,7 @@ fn window_button_element(
                 right: Dimension::Cells(0.5),
                 top: Dimension::Cells(0.5),
                 bottom: Dimension::Cells(0.5),
-            })
-    } else {
-        element
-            .zindex(1)
-            .vertical_align(VerticalAlign::Middle)
-            .margin(BoxDimension {
-                left: Dimension::Cells(0.),
-                right: Dimension::Cells(0.),
-                top: Dimension::Cells(0.),
-                bottom: Dimension::Cells(0.),
-            })
-            .padding(BoxDimension {
-                left: Dimension::Cells(1.0),
-                right: Dimension::Cells(1.0),
-                top: Dimension::Cells(0.6),
-                bottom: Dimension::Cells(0.6),
-            })
+            }),
     };
 
     let (color, hover_colors) = match window_button {
@@ -1174,6 +1151,7 @@ impl super::TermWindow {
                     &font,
                     &metrics,
                     &colors,
+                    self.config.fancy_window_decorations.style,
                 ),
             }
         };

--- a/wezterm-gui/src/termwindow/render.rs
+++ b/wezterm-gui/src/termwindow/render.rs
@@ -338,7 +338,6 @@ fn window_button_element(
     is_maximized: bool,
     font: &Rc<LoadedFont>,
     metrics: &RenderMetrics,
-    colors: &TabBarColors,
     config: &ConfigHandle,
 ) -> Element {
     use window::IntegratedTitleButtonStyle as Style;
@@ -346,8 +345,12 @@ fn window_button_element(
 
     let style = config.integrated_title_button_style;
 
+    if style == Style::Native {
+        return Element::new(font, ElementContent::Text(String::new()));
+    }
+
     let poly = {
-        let (CLOSE, HIDE, MAXIMIZE, RESTORE) = match style {
+        let (close, hide, maximize, restore) = match style {
             Style::Windows => {
                 use window_buttons::windows::{CLOSE, HIDE, MAXIMIZE, RESTORE};
                 (CLOSE, HIDE, MAXIMIZE, RESTORE)
@@ -356,22 +359,24 @@ fn window_button_element(
                 use window_buttons::gnome::{CLOSE, HIDE, MAXIMIZE, RESTORE};
                 (CLOSE, HIDE, MAXIMIZE, RESTORE)
             }
+            Style::Native => unreachable!(),
         };
         let poly = match window_button {
-            Button::Hide => HIDE,
+            Button::Hide => hide,
             Button::Maximize => {
                 if is_maximized {
-                    RESTORE
+                    restore
                 } else {
-                    MAXIMIZE
+                    maximize
                 }
             }
-            Button::Close => CLOSE,
+            Button::Close => close,
         };
 
         match style {
             Style::Windows => window_buttons::windows::sized_poly(poly),
             Style::Gnome => window_buttons::gnome::sized_poly(poly),
+            Style::Native => unreachable!(),
         }
     };
 
@@ -442,6 +447,7 @@ fn window_button_element(
                     bottom: Dimension::Pixels(7.),
                 })
         }
+        Style::Native => unreachable!(),
     };
 
     let foreground = config.integrated_title_button_color.clone();
@@ -461,6 +467,7 @@ fn window_button_element(
     let window_button_colors_fn = match style {
         Style::Windows => window_buttons::windows::window_button_colors,
         Style::Gnome => window_buttons::gnome::window_button_colors,
+        Style::Native => unreachable!(),
     };
 
     let colors = window_button_colors_fn(background_lightness, foreground, window_button);
@@ -1134,7 +1141,6 @@ impl super::TermWindow {
                     self.window_state.contains(window::WindowState::MAXIMIZED),
                     &font,
                     &metrics,
-                    &colors,
                     &self.config,
                 ),
             }

--- a/wezterm-gui/src/termwindow/render.rs
+++ b/wezterm-gui/src/termwindow/render.rs
@@ -145,26 +145,6 @@ const PLUS_BUTTON: &[Poly] = &[
     },
 ];
 
-const HIDE_BUTTON: &[Poly] = &[Poly {
-    path: &[
-        PolyCommand::MoveTo(BlockCoord::Zero, BlockCoord::One),
-        PolyCommand::LineTo(BlockCoord::One, BlockCoord::One),
-    ],
-    intensity: BlockAlpha::Full,
-    style: PolyStyle::Outline,
-}];
-
-const MAXIMIZE_BUTTON: &[Poly] = &[Poly {
-    path: &[
-        PolyCommand::LineTo(BlockCoord::Zero, BlockCoord::One),
-        PolyCommand::LineTo(BlockCoord::One, BlockCoord::One),
-        PolyCommand::LineTo(BlockCoord::One, BlockCoord::Zero),
-        PolyCommand::LineTo(BlockCoord::Zero, BlockCoord::Zero),
-    ],
-    intensity: BlockAlpha::Full,
-    style: PolyStyle::Outline,
-}];
-
 mod window_buttons {
     use super::*;
     pub(super) mod windows {
@@ -342,22 +322,11 @@ fn window_button_element(
                 _ => unreachable!(),
             }
         }
-        Style::MacOs => match window_button {
-            TabBarItem::WindowHideButton => HIDE_BUTTON,
-            TabBarItem::WindowMaximizeButton => MAXIMIZE_BUTTON,
-            TabBarItem::WindowCloseButton => X_BUTTON,
-            _ => unreachable!(),
-        },
     };
 
     let poly = match style {
         Style::Windows => window_buttons::windows::sized_poly(poly),
         Style::Gnome => window_buttons::gnome::sized_poly(poly),
-        Style::MacOs => SizedPoly {
-            poly: &[],
-            width: Dimension::Pixels(13.),
-            height: Dimension::Pixels(13.),
-        },
     };
 
     let element = Element::new(
@@ -423,45 +392,6 @@ fn window_button_element(
                 right: Dimension::Pixels(7.),
                 top: Dimension::Pixels(7.),
                 bottom: Dimension::Pixels(7.),
-            }),
-
-        Style::MacOs => element
-            .zindex(1)
-            .vertical_align(VerticalAlign::Middle)
-            .padding(BoxDimension {
-                left: Dimension::default(),
-                right: Dimension::default(),
-                top: Dimension::default(),
-                bottom: Dimension::default(),
-            })
-            .border(BoxDimension::new(Dimension::Pixels(1.)))
-            .border_corners(Some(Corners {
-                top_left: SizedPoly {
-                    width: Dimension::Pixels(8.),
-                    height: Dimension::Pixels(8.),
-                    poly: TOP_LEFT_ROUNDED_CORNER,
-                },
-                top_right: SizedPoly {
-                    width: Dimension::Pixels(8.),
-                    height: Dimension::Pixels(8.),
-                    poly: TOP_RIGHT_ROUNDED_CORNER,
-                },
-                bottom_left: SizedPoly {
-                    width: Dimension::Pixels(8.),
-                    height: Dimension::Pixels(8.),
-                    poly: BOTTOM_LEFT_ROUNDED_CORNER,
-                },
-                bottom_right: SizedPoly {
-                    width: Dimension::Pixels(8.),
-                    height: Dimension::Pixels(8.),
-                    poly: BOTTOM_RIGHT_ROUNDED_CORNER,
-                },
-            }))
-            .margin(BoxDimension {
-                left: Dimension::Cells(0.5),
-                right: Dimension::Cells(0.5),
-                top: Dimension::Cells(0.5),
-                bottom: Dimension::Cells(0.5),
             }),
     };
 
@@ -1177,9 +1107,7 @@ impl super::TermWindow {
                 TabBarItem::WindowHideButton
                 | TabBarItem::WindowMaximizeButton
                 | TabBarItem::WindowCloseButton => {
-                    if (self.config.fancy_window_decorations.is_left || cfg!(target_os = "macos"))
-                        && cfg!(not(windows))
-                    {
+                    if self.config.fancy_window_decorations.is_left && cfg!(not(windows)) {
                         left_eles.push(item_to_elem(item))
                     } else {
                         right_eles.push(item_to_elem(item))

--- a/wezterm-gui/src/termwindow/render.rs
+++ b/wezterm-gui/src/termwindow/render.rs
@@ -1046,6 +1046,7 @@ impl super::TermWindow {
                     text: new_tab_hover.fg_color.to_linear().into(),
                 })),
                 TabBarItem::Tab { active, .. } if active => element
+                    .vertical_align(VerticalAlign::Bottom)
                     .item_type(UIItemType::TabBar(item.item.clone()))
                     .margin(BoxDimension {
                         left: Dimension::Cells(0.),
@@ -1090,6 +1091,7 @@ impl super::TermWindow {
                             .into(),
                     }),
                 TabBarItem::Tab { .. } => element
+                    .vertical_align(VerticalAlign::Bottom)
                     .item_type(UIItemType::TabBar(item.item.clone()))
                     .margin(BoxDimension {
                         left: Dimension::Cells(0.),
@@ -1194,8 +1196,11 @@ impl super::TermWindow {
                 TabBarItem::WindowHideButton
                 | TabBarItem::WindowMaximizeButton
                 | TabBarItem::WindowCloseButton => {
-                    // TODO: Window buttons can be placed either at left and right
-                    right_eles.push(item_to_elem(item))
+                    if self.config.fancy_window_decorations.is_left {
+                        left_eles.push(item_to_elem(item))
+                    } else {
+                        right_eles.push(item_to_elem(item))
+                    }
                 }
                 TabBarItem::Tab { tab_idx, active } => {
                     let mut elem = item_to_elem(item);
@@ -1279,12 +1284,18 @@ impl super::TermWindow {
             );
         }
 
+        let window_buttons_at_left = self.config.window_decorations
+            == window::WindowDecorations::FANCY
+            && self.config.fancy_window_decorations.is_left;
+
+        let left_padding = if window_buttons_at_left { 0.0 } else { 0.5 };
+
         children.push(
             Element::new(&font, ElementContent::Children(left_eles))
                 .vertical_align(VerticalAlign::Bottom)
                 .colors(bar_colors.clone())
                 .padding(BoxDimension {
-                    left: Dimension::Cells(0.5),
+                    left: Dimension::Cells(left_padding),
                     right: Dimension::Cells(0.),
                     top: Dimension::Cells(0.),
                     bottom: Dimension::Cells(0.),

--- a/wezterm-gui/src/termwindow/render.rs
+++ b/wezterm-gui/src/termwindow/render.rs
@@ -156,7 +156,6 @@ const HIDE_BUTTON: &[Poly] = &[Poly {
 
 const MAXIMIZE_BUTTON: &[Poly] = &[Poly {
     path: &[
-        // PolyCommand::MoveTo(BlockCoord::Zero, BlockCoord::One),
         PolyCommand::LineTo(BlockCoord::Zero, BlockCoord::One),
         PolyCommand::LineTo(BlockCoord::One, BlockCoord::One),
         PolyCommand::LineTo(BlockCoord::One, BlockCoord::Zero),
@@ -166,12 +165,169 @@ const MAXIMIZE_BUTTON: &[Poly] = &[Poly {
     style: PolyStyle::Outline,
 }];
 
-fn poly_for_window_button(window_button: TabBarItem) -> &'static [Poly] {
+mod window_buttons {
+    use super::*;
+    pub(super) mod windows {
+        use super::*;
+        pub const CLOSE: &[Poly] = &[Poly {
+            path: &[
+                PolyCommand::LineTo(BlockCoord::One, BlockCoord::One),
+                PolyCommand::MoveTo(BlockCoord::One, BlockCoord::Zero),
+                PolyCommand::LineTo(BlockCoord::Zero, BlockCoord::One),
+            ],
+            intensity: BlockAlpha::Full,
+            style: PolyStyle::OutlineThin,
+        }];
+
+        pub const HIDE: &[Poly] = &[Poly {
+            path: &[
+                PolyCommand::MoveTo(BlockCoord::Zero, BlockCoord::Frac(6, 10)),
+                PolyCommand::LineTo(BlockCoord::One, BlockCoord::Frac(6, 10)),
+            ],
+            intensity: BlockAlpha::Full,
+            style: PolyStyle::OutlineThin,
+        }];
+
+        pub const MAXIMIZE: &[Poly] = &[Poly {
+            path: &[
+                PolyCommand::MoveTo(BlockCoord::Frac(2, 10), BlockCoord::Frac(1, 10)),
+                PolyCommand::LineTo(BlockCoord::Frac(9, 10), BlockCoord::Frac(1, 10)),
+                PolyCommand::LineTo(BlockCoord::Frac(10, 10), BlockCoord::Frac(2, 10)),
+                PolyCommand::LineTo(BlockCoord::Frac(10, 10), BlockCoord::Frac(9, 10)),
+                PolyCommand::LineTo(BlockCoord::Frac(9, 10), BlockCoord::Frac(10, 10)),
+                PolyCommand::LineTo(BlockCoord::Frac(2, 10), BlockCoord::Frac(10, 10)),
+                PolyCommand::LineTo(BlockCoord::Frac(1, 10), BlockCoord::Frac(9, 10)),
+                PolyCommand::LineTo(BlockCoord::Frac(1, 10), BlockCoord::Frac(2, 10)),
+                PolyCommand::LineTo(BlockCoord::Frac(2, 10), BlockCoord::Frac(1, 10)),
+            ],
+            intensity: BlockAlpha::Full,
+            style: PolyStyle::OutlineThin,
+        }];
+
+        pub const RESTORE: &[Poly] = &[
+            Poly {
+                path: &[
+                    PolyCommand::MoveTo(BlockCoord::Frac(5, 20), BlockCoord::Frac(1, 10)),
+                    PolyCommand::LineTo(BlockCoord::Frac(8, 10), BlockCoord::Frac(1, 10)),
+                    PolyCommand::LineTo(BlockCoord::Frac(10, 10), BlockCoord::Frac(3, 10)),
+                    PolyCommand::LineTo(BlockCoord::Frac(10, 10), BlockCoord::Frac(15, 20)),
+                ],
+                intensity: BlockAlpha::Full,
+                style: PolyStyle::OutlineThin,
+            },
+            Poly {
+                path: &[
+                    PolyCommand::MoveTo(BlockCoord::Frac(2, 10), BlockCoord::Frac(3, 10)),
+                    PolyCommand::LineTo(BlockCoord::Frac(7, 10), BlockCoord::Frac(3, 10)),
+                    PolyCommand::LineTo(BlockCoord::Frac(8, 10), BlockCoord::Frac(4, 10)),
+                    PolyCommand::LineTo(BlockCoord::Frac(8, 10), BlockCoord::Frac(9, 10)),
+                    PolyCommand::LineTo(BlockCoord::Frac(7, 10), BlockCoord::Frac(10, 10)),
+                    PolyCommand::LineTo(BlockCoord::Frac(2, 10), BlockCoord::Frac(10, 10)),
+                    PolyCommand::LineTo(BlockCoord::Frac(1, 10), BlockCoord::Frac(9, 10)),
+                    PolyCommand::LineTo(BlockCoord::Frac(1, 10), BlockCoord::Frac(4, 10)),
+                    PolyCommand::LineTo(BlockCoord::Frac(2, 10), BlockCoord::Frac(3, 10)),
+                ],
+                intensity: BlockAlpha::Full,
+                style: PolyStyle::OutlineThin,
+            },
+        ];
+
+        pub fn sized_poly(poly: &'static [Poly]) -> SizedPoly {
+            let scale = 72.0 / 96.0;
+            let size = Dimension::Points(10. * scale);
+            SizedPoly {
+                poly,
+                width: size,
+                height: size,
+            }
+        }
+    }
+}
+
+fn window_button_element(
+    window_button: TabBarItem,
+    is_maximized: bool,
+    font: &Rc<LoadedFont>,
+    metrics: &RenderMetrics,
+) -> Element {
+    let poly = if cfg!(windows) {
+        use window_buttons::windows::{CLOSE, HIDE, MAXIMIZE, RESTORE};
+        match window_button {
+            TabBarItem::WindowHideButton => HIDE,
+            TabBarItem::WindowMaximizeButton => {
+                if is_maximized {
+                    RESTORE
+                } else {
+                    MAXIMIZE
+                }
+            }
+            TabBarItem::WindowCloseButton => CLOSE,
+            _ => unreachable!(),
+        }
+    } else {
+        match window_button {
+            TabBarItem::WindowHideButton => HIDE_BUTTON,
+            TabBarItem::WindowMaximizeButton => MAXIMIZE_BUTTON,
+            TabBarItem::WindowCloseButton => X_BUTTON,
+            _ => unreachable!(),
+        }
+    };
+
+    let poly = if cfg!(windows) {
+        window_buttons::windows::sized_poly(poly)
+    } else {
+        SizedPoly {
+            poly,
+            width: Dimension::Pixels(metrics.cell_size.height as f32 / 2.),
+            height: Dimension::Pixels(metrics.cell_size.height as f32 / 2.),
+        }
+    };
+
     match window_button {
-        TabBarItem::WindowHideButton => HIDE_BUTTON,
-        TabBarItem::WindowMaximizeButton => MAXIMIZE_BUTTON,
-        TabBarItem::WindowCloseButton => X_BUTTON,
-        _ => unreachable!(),
+        TabBarItem::WindowHideButton => log::debug!("BTN"),
+        _ => {}
+    }
+
+    let element = Element::new(
+        &font,
+        ElementContent::Poly {
+            line_width: metrics.underline_height.max(2),
+            poly,
+        },
+    );
+
+    if cfg!(windows) {
+        let left_padding = match window_button {
+            TabBarItem::WindowHideButton => 17.0,
+            _ => 18.0,
+        };
+        let scale = 72.0 / 96.0;
+
+        element
+            .zindex(1)
+            .vertical_align(VerticalAlign::Middle)
+            .padding(BoxDimension {
+                left: Dimension::Points(left_padding * scale),
+                right: Dimension::Points(18. * scale),
+                top: Dimension::Points(10. * scale),
+                bottom: Dimension::Points(10. * scale),
+            })
+    } else {
+        element
+            .zindex(1)
+            .vertical_align(VerticalAlign::Middle)
+            .margin(BoxDimension {
+                left: Dimension::Cells(0.),
+                right: Dimension::Cells(0.),
+                top: Dimension::Cells(0.),
+                bottom: Dimension::Cells(0.),
+            })
+            .padding(BoxDimension {
+                left: Dimension::Cells(1.0),
+                right: Dimension::Cells(1.0),
+                top: Dimension::Cells(0.6),
+                bottom: Dimension::Cells(0.6),
+            })
     }
 }
 
@@ -831,33 +987,13 @@ impl super::TermWindow {
                     }),
                 TabBarItem::WindowHideButton
                 | TabBarItem::WindowMaximizeButton
-                | TabBarItem::WindowCloseButton => Element::new(
+                | TabBarItem::WindowCloseButton => window_button_element(
+                    item.item.clone(),
+                    self.window_state.contains(window::WindowState::MAXIMIZED),
                     &font,
-                    ElementContent::Poly {
-                        line_width: metrics.underline_height.max(2),
-                        poly: SizedPoly {
-                            poly: poly_for_window_button(item.item.clone()),
-                            width: Dimension::Pixels(metrics.cell_size.height as f32 / 2.),
-                            height: Dimension::Pixels(metrics.cell_size.height as f32 / 2.),
-                        },
-                    },
+                    &metrics,
                 )
-                .zindex(1)
-                .vertical_align(VerticalAlign::Middle)
                 .item_type(UIItemType::TabBar(item.item.clone()))
-                .margin(BoxDimension {
-                    left: Dimension::Cells(0.),
-                    right: Dimension::Cells(0.),
-                    top: Dimension::Cells(0.),
-                    bottom: Dimension::Cells(0.),
-                })
-                .padding(BoxDimension {
-                    left: Dimension::Cells(1.0),
-                    right: Dimension::Cells(1.0),
-                    top: Dimension::Cells(0.6),
-                    bottom: Dimension::Cells(0.6),
-                })
-                // .border(BoxDimension::new(Dimension::Pixels(1.)))
                 .colors(ElementColors {
                     border: BorderColor::default(),
                     bg: new_tab.bg_color.to_linear().into(),

--- a/wezterm-gui/src/termwindow/render.rs
+++ b/wezterm-gui/src/termwindow/render.rs
@@ -308,6 +308,9 @@ fn window_button_element(
 ) -> Element {
     use window::FancyWindowDecorationsStyle as Style;
 
+    #[cfg(any(windows, targer_os = "macos"))]
+    let style = Style::default();
+
     let poly = match style {
         Style::Windows => {
             use window_buttons::windows::{CLOSE, HIDE, MAXIMIZE, RESTORE};
@@ -1174,7 +1177,9 @@ impl super::TermWindow {
                 TabBarItem::WindowHideButton
                 | TabBarItem::WindowMaximizeButton
                 | TabBarItem::WindowCloseButton => {
-                    if self.config.fancy_window_decorations.is_left {
+                    if (self.config.fancy_window_decorations.is_left || cfg!(target_os = "macos"))
+                        && cfg!(not(windows))
+                    {
                         left_eles.push(item_to_elem(item))
                     } else {
                         right_eles.push(item_to_elem(item))
@@ -1264,7 +1269,8 @@ impl super::TermWindow {
 
         let window_buttons_at_left = self.config.window_decorations
             == window::WindowDecorations::FANCY
-            && self.config.fancy_window_decorations.is_left;
+            && (self.config.fancy_window_decorations.is_left
+                || cfg!(target_os = "macos") && cfg!(not(windows)));
 
         let left_padding = if window_buttons_at_left { 0.0 } else { 0.5 };
 

--- a/wezterm-input-types/src/lib.rs
+++ b/wezterm-input-types/src/lib.rs
@@ -1322,11 +1322,52 @@ pub enum IntegratedTitleButtonAlignment {
     Left,
 }
 
-#[derive(Debug, Default, FromDynamic, ToDynamic, PartialEq, Eq, Clone, Copy)]
+#[derive(Debug, Default, ToDynamic, PartialEq, Eq, Clone, Copy)]
 pub enum IntegratedTitleButtonStyle {
     #[default]
     Windows,
     Gnome,
+    // macos only
+    Native,
+}
+
+impl FromDynamic for IntegratedTitleButtonStyle {
+    fn from_dynamic(
+        value: &wezterm_dynamic::Value,
+        _options: wezterm_dynamic::FromDynamicOptions,
+    ) -> Result<Self, wezterm_dynamic::Error>
+    where
+        Self: Sized,
+    {
+        let type_name = "integrated_title_button_style";
+
+        if let wezterm_dynamic::Value::String(string) = value {
+            let style = match string.as_str() {
+                "Windows" => Self::Windows,
+                "Gnome" => Self::Gnome,
+                "Native" if cfg!(target_os = "macos") => Self::Native,
+                _ => {
+                    let possible: &[&str] = if cfg!(target_os = "macos") {
+                        &["Windows", "Gnome", "Native"]
+                    } else {
+                        &["Windows", "Gnome"]
+                    };
+                    return Err(wezterm_dynamic::Error::InvalidVariantForType {
+                        variant_name: string.to_string(),
+                        type_name,
+                        possible,
+                    });
+                }
+            };
+            Ok(style)
+        } else {
+            Err(wezterm_dynamic::Error::InvalidVariantForType {
+                variant_name: value.variant_name().to_string(),
+                type_name,
+                possible: &["String"],
+            })
+        }
+    }
 }
 
 /// Map c to its Ctrl equivalent.

--- a/wezterm-input-types/src/lib.rs
+++ b/wezterm-input-types/src/lib.rs
@@ -1308,6 +1308,12 @@ impl Default for WindowDecorations {
     }
 }
 
+#[derive(Debug, Default, FromDynamic, ToDynamic, Clone)]
+pub struct FancyWindowDecorations {
+    #[dynamic(default)]
+    pub is_left: bool,
+}
+
 /// Map c to its Ctrl equivalent.
 /// In theory, this mapping is simply translating alpha characters
 /// to upper case and then masking them by 0x1f, but xterm inherits

--- a/wezterm-input-types/src/lib.rs
+++ b/wezterm-input-types/src/lib.rs
@@ -1275,7 +1275,7 @@ bitflags! {
     pub struct WindowDecorations: u8 {
         const TITLE = 1;
         const RESIZE = 2;
-        const FANCY = 4;
+        const INTEGRATED_BUTTONS = 4;
         const NONE = 0;
     }
 }
@@ -1292,8 +1292,8 @@ impl TryFrom<String> for WindowDecorations {
                 flags = Self::NONE;
             } else if ele == "RESIZE" {
                 flags |= Self::RESIZE;
-            } else if ele == "FANCY" {
-                flags |= Self::FANCY;
+            } else if ele == "INTEGRATED_BUTTONS" {
+                flags |= Self::INTEGRATED_BUTTONS;
             } else {
                 return Err(format!("invalid WindowDecoration name {} in {}", ele, s));
             }
@@ -1308,82 +1308,25 @@ impl Default for WindowDecorations {
     }
 }
 
-#[derive(Debug, FromDynamic, ToDynamic, Clone)]
-pub struct FancyWindowDecorations {
-    #[dynamic(default)]
-    pub is_left: bool,
-    #[dynamic(default)]
-    pub remove_hide_button: bool,
-    #[dynamic(default)]
-    pub remove_maximize_button: bool,
-    #[dynamic(default)]
-    pub style: FancyWindowDecorationsStyle,
+#[derive(Debug, FromDynamic, ToDynamic, PartialEq, Eq, Clone, Copy)]
+pub enum IntegratedTitleButton {
+    Hide,
+    Maximize,
+    Close,
 }
 
-#[cfg(not(target_os = "macos"))]
-impl Default for FancyWindowDecorations {
-    fn default() -> Self {
-        FancyWindowDecorations {
-            is_left: false,
-            remove_hide_button: false,
-            remove_maximize_button: false,
-            style: Default::default(),
-        }
-    }
+#[derive(Debug, Default, FromDynamic, ToDynamic, PartialEq, Eq, Clone, Copy)]
+pub enum IntegratedTitleButtonAlignment {
+    #[default]
+    Right,
+    Left,
 }
 
-#[cfg(target_os = "macos")]
-impl Default for FancyWindowDecorations {
-    fn default() -> Self {
-        FancyWindowDecorations {
-            is_left: true,
-            remove_hide_button: false,
-            remove_maximize_button: false,
-            style: Default::default(),
-        }
-    }
-}
-
-#[derive(Debug, Deserialize, Serialize, FromDynamic, ToDynamic, Clone, Copy)]
-#[dynamic(try_from = "String")]
-pub enum FancyWindowDecorationsStyle {
+#[derive(Debug, Default, FromDynamic, ToDynamic, Clone, Copy)]
+pub enum IntegratedTitleButtonStyle {
+    #[default]
     Windows,
     Gnome,
-}
-
-#[cfg(not(target_os = "linux"))]
-impl Default for FancyWindowDecorationsStyle {
-    fn default() -> Self {
-        Self::Windows
-    }
-}
-
-#[cfg(target_os = "linux")]
-impl Default for FancyWindowDecorationsStyle {
-    fn default() -> Self {
-        Self::Gnome
-    }
-}
-
-impl Into<String> for FancyWindowDecorationsStyle {
-    fn into(self) -> String {
-        match self {
-            Self::Windows => "windows",
-            Self::Gnome => "gnome",
-        }
-        .to_string()
-    }
-}
-
-impl TryFrom<String> for FancyWindowDecorationsStyle {
-    type Error = String;
-    fn try_from(value: String) -> Result<Self, Self::Error> {
-        match value.to_lowercase().as_str() {
-            "windows" => Ok(Self::Windows),
-            "gnome" => Ok(Self::Gnome),
-            _ => Err(format!("invalid fancy_window_decoratins.style {}", value)),
-        }
-    }
 }
 
 /// Map c to its Ctrl equivalent.

--- a/wezterm-input-types/src/lib.rs
+++ b/wezterm-input-types/src/lib.rs
@@ -1275,6 +1275,7 @@ bitflags! {
     pub struct WindowDecorations: u8 {
         const TITLE = 1;
         const RESIZE = 2;
+        const FANCY = 4;
         const NONE = 0;
     }
 }
@@ -1291,6 +1292,8 @@ impl TryFrom<String> for WindowDecorations {
                 flags = Self::NONE;
             } else if ele == "RESIZE" {
                 flags |= Self::RESIZE;
+            } else if ele == "FANCY" {
+                flags |= Self::FANCY;
             } else {
                 return Err(format!("invalid WindowDecoration name {} in {}", ele, s));
             }

--- a/wezterm-input-types/src/lib.rs
+++ b/wezterm-input-types/src/lib.rs
@@ -1322,7 +1322,7 @@ pub enum IntegratedTitleButtonAlignment {
     Left,
 }
 
-#[derive(Debug, Default, FromDynamic, ToDynamic, Clone, Copy)]
+#[derive(Debug, Default, FromDynamic, ToDynamic, PartialEq, Eq, Clone, Copy)]
 pub enum IntegratedTitleButtonStyle {
     #[default]
     Windows,

--- a/wezterm-input-types/src/lib.rs
+++ b/wezterm-input-types/src/lib.rs
@@ -1348,11 +1348,10 @@ impl Default for FancyWindowDecorations {
 #[dynamic(try_from = "String")]
 pub enum FancyWindowDecorationsStyle {
     Windows,
-    MacOs,
     Gnome,
 }
 
-#[cfg(any(windows, target_os = "freebsd"))]
+#[cfg(not(target_os = "linux"))]
 impl Default for FancyWindowDecorationsStyle {
     fn default() -> Self {
         Self::Windows
@@ -1366,18 +1365,10 @@ impl Default for FancyWindowDecorationsStyle {
     }
 }
 
-#[cfg(target_os = "macos")]
-impl Default for FancyWindowDecorationsStyle {
-    fn default() -> Self {
-        Self::MacOs
-    }
-}
-
 impl Into<String> for FancyWindowDecorationsStyle {
     fn into(self) -> String {
         match self {
             Self::Windows => "windows",
-            Self::MacOs => "macos",
             Self::Gnome => "gnome",
         }
         .to_string()
@@ -1389,7 +1380,6 @@ impl TryFrom<String> for FancyWindowDecorationsStyle {
     fn try_from(value: String) -> Result<Self, Self::Error> {
         match value.to_lowercase().as_str() {
             "windows" => Ok(Self::Windows),
-            "macos" => Ok(Self::MacOs),
             "gnome" => Ok(Self::Gnome),
             _ => Err(format!("invalid fancy_window_decoratins.style {}", value)),
         }

--- a/wezterm-input-types/src/lib.rs
+++ b/wezterm-input-types/src/lib.rs
@@ -1308,7 +1308,7 @@ impl Default for WindowDecorations {
     }
 }
 
-#[derive(Debug, Default, FromDynamic, ToDynamic, Clone)]
+#[derive(Debug, FromDynamic, ToDynamic, Clone)]
 pub struct FancyWindowDecorations {
     #[dynamic(default)]
     pub is_left: bool,
@@ -1316,6 +1316,84 @@ pub struct FancyWindowDecorations {
     pub remove_hide_button: bool,
     #[dynamic(default)]
     pub remove_maximize_button: bool,
+    #[dynamic(default)]
+    pub style: FancyWindowDecorationsStyle,
+}
+
+#[cfg(not(target_os = "macos"))]
+impl Default for FancyWindowDecorations {
+    fn default() -> Self {
+        FancyWindowDecorations {
+            is_left: false,
+            remove_hide_button: false,
+            remove_maximize_button: false,
+            style: Default::default(),
+        }
+    }
+}
+
+#[cfg(target_os = "macos")]
+impl Default for FancyWindowDecorations {
+    fn default() -> Self {
+        FancyWindowDecorations {
+            is_left: true,
+            remove_hide_button: false,
+            remove_maximize_button: false,
+            style: Default::default(),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize, FromDynamic, ToDynamic, Clone, Copy)]
+#[dynamic(try_from = "String")]
+pub enum FancyWindowDecorationsStyle {
+    Windows,
+    MacOs,
+    Gnome,
+}
+
+#[cfg(any(windows, target_os = "freebsd"))]
+impl Default for FancyWindowDecorationsStyle {
+    fn default() -> Self {
+        Self::Windows
+    }
+}
+
+#[cfg(target_os = "linux")]
+impl Default for FancyWindowDecorationsStyle {
+    fn default() -> Self {
+        Self::Gnome
+    }
+}
+
+#[cfg(target_os = "macos")]
+impl Default for FancyWindowDecorationsStyle {
+    fn default() -> Self {
+        Self::MacOs
+    }
+}
+
+impl Into<String> for FancyWindowDecorationsStyle {
+    fn into(self) -> String {
+        match self {
+            Self::Windows => "windows",
+            Self::MacOs => "macos",
+            Self::Gnome => "gnome",
+        }
+        .to_string()
+    }
+}
+
+impl TryFrom<String> for FancyWindowDecorationsStyle {
+    type Error = String;
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        match value.to_lowercase().as_str() {
+            "windows" => Ok(Self::Windows),
+            "macos" => Ok(Self::MacOs),
+            "gnome" => Ok(Self::Gnome),
+            _ => Err(format!("invalid fancy_window_decoratins.style {}", value)),
+        }
+    }
 }
 
 /// Map c to its Ctrl equivalent.

--- a/wezterm-input-types/src/lib.rs
+++ b/wezterm-input-types/src/lib.rs
@@ -1312,6 +1312,10 @@ impl Default for WindowDecorations {
 pub struct FancyWindowDecorations {
     #[dynamic(default)]
     pub is_left: bool,
+    #[dynamic(default)]
+    pub remove_hide_button: bool,
+    #[dynamic(default)]
+    pub remove_maximize_button: bool,
 }
 
 /// Map c to its Ctrl equivalent.

--- a/window/src/lib.rs
+++ b/window/src/lib.rs
@@ -251,6 +251,9 @@ pub trait WindowOps {
     /// Resize the inner or client area of the window
     fn set_inner_size(&self, width: usize, height: usize);
 
+    /// Use for windows snap layouts
+    fn hover_maximize_button(&self) {}
+
     /// Requests the windowing system to start a window drag.
     ///
     /// This is only implemented on backends that handle

--- a/window/src/os/macos/window.rs
+++ b/window/src/os/macos/window.rs
@@ -1118,7 +1118,9 @@ fn apply_decorations_to_window(window: &StrongPtr, decorations: WindowDecoration
     unsafe {
         window.setStyleMask_(mask);
 
-        let hidden = if decorations.contains(WindowDecorations::TITLE) {
+        let hidden = if decorations.contains(WindowDecorations::TITLE)
+            || decorations.contains(WindowDecorations::FANCY)
+        {
             NO
         } else {
             YES
@@ -1139,7 +1141,11 @@ fn apply_decorations_to_window(window: &StrongPtr, decorations: WindowDecoration
         } else {
             appkit::NSWindowTitleVisibility::NSWindowTitleHidden
         });
-        window.setTitlebarAppearsTransparent_(hidden);
+        if decorations == WindowDecorations::FANCY {
+            window.setTitlebarAppearsTransparent_(YES);
+        } else {
+            window.setTitlebarAppearsTransparent_(hidden);
+        }
     }
 }
 
@@ -1149,7 +1155,7 @@ fn decoration_to_mask(decorations: WindowDecorations) -> NSWindowStyleMask {
             | NSWindowStyleMask::NSClosableWindowMask
             | NSWindowStyleMask::NSMiniaturizableWindowMask
             | NSWindowStyleMask::NSResizableWindowMask
-    } else if decorations == WindowDecorations::RESIZE {
+    } else if decorations == WindowDecorations::RESIZE || decorations == WindowDecorations::FANCY {
         NSWindowStyleMask::NSTitledWindowMask
             | NSWindowStyleMask::NSClosableWindowMask
             | NSWindowStyleMask::NSMiniaturizableWindowMask

--- a/window/src/os/macos/window.rs
+++ b/window/src/os/macos/window.rs
@@ -1119,7 +1119,7 @@ fn apply_decorations_to_window(window: &StrongPtr, decorations: WindowDecoration
         window.setStyleMask_(mask);
 
         let hidden = if decorations.contains(WindowDecorations::TITLE)
-            || decorations.contains(WindowDecorations::FANCY)
+            || decorations.contains(WindowDecorations::INTEGRATED_BUTTONS)
         {
             NO
         } else {
@@ -1141,7 +1141,7 @@ fn apply_decorations_to_window(window: &StrongPtr, decorations: WindowDecoration
         } else {
             appkit::NSWindowTitleVisibility::NSWindowTitleHidden
         });
-        if decorations == WindowDecorations::FANCY {
+        if decorations == WindowDecorations::INTEGRATED_BUTTONS {
             window.setTitlebarAppearsTransparent_(YES);
         } else {
             window.setTitlebarAppearsTransparent_(hidden);
@@ -1155,7 +1155,7 @@ fn decoration_to_mask(decorations: WindowDecorations) -> NSWindowStyleMask {
             | NSWindowStyleMask::NSClosableWindowMask
             | NSWindowStyleMask::NSMiniaturizableWindowMask
             | NSWindowStyleMask::NSResizableWindowMask
-    } else if decorations == WindowDecorations::RESIZE || decorations == WindowDecorations::FANCY {
+    } else if decorations == WindowDecorations::RESIZE || decorations == WindowDecorations::INTEGRATED_BUTTONS {
         NSWindowStyleMask::NSTitledWindowMask
             | NSWindowStyleMask::NSClosableWindowMask
             | NSWindowStyleMask::NSMiniaturizableWindowMask

--- a/window/src/os/windows/window.rs
+++ b/window/src/os/windows/window.rs
@@ -2,8 +2,7 @@ use super::*;
 use crate::connection::ConnectionOps;
 use crate::parameters::{self, Parameters};
 use crate::{
-    Appearance, Clipboard, DeadKeyStatus, Dimensions, Handled, IntegratedTitleButton,
-    IntegratedTitleButtonAlignment, IntegratedTitleButtonStyle, KeyCode, KeyEvent, Modifiers,
+    Appearance, Clipboard, DeadKeyStatus, Dimensions, Handled, KeyCode, KeyEvent, Modifiers,
     MouseButtons, MouseCursor, MouseEvent, MouseEventKind, MousePress, Point, RawKeyEvent, Rect,
     RequestedWindowGeometry, ResolvedGeometry, ScreenPoint, ULength, WindowDecorations,
     WindowEvent, WindowEventSender, WindowOps, WindowState,
@@ -797,6 +796,12 @@ impl WindowOps for Window {
         });
     }
 
+    fn hover_maximize_button(&self) {
+        unsafe {
+            MAXBTN_HOVERED = true;
+        }
+    }
+
     fn set_window_position(&self, coords: ScreenPoint) {
         Connection::with_window_inner(self.0, move |inner| {
             inner.set_window_position(coords);
@@ -1018,6 +1023,8 @@ unsafe fn wm_nccalcsize(hwnd: HWND, _msg: UINT, wparam: WPARAM, lparam: LPARAM) 
     Some(0)
 }
 
+static mut MAXBTN_HOVERED: bool = false;
+
 unsafe fn wm_nchittest(hwnd: HWND, msg: UINT, wparam: WPARAM, lparam: LPARAM) -> Option<LRESULT> {
     let inner = rc_from_hwnd(hwnd)?;
     let inner = inner.borrow_mut();
@@ -1095,29 +1102,10 @@ unsafe fn wm_nchittest(hwnd: HWND, msg: UINT, wparam: WPARAM, lparam: LPARAM) ->
         }
     }
 
-    // When you can predict maximize button position
-    let use_snap_layouts = !*IS_WIN10
-        && inner.config.window_decorations == WindowDecorations::INTEGRATED_BUTTONS
-        && inner.config.integrated_title_button_style == IntegratedTitleButtonStyle::Windows
-        && inner.config.integrated_title_button_alignment == IntegratedTitleButtonAlignment::Right
-        && matches!(
-            &inner.config.integrated_title_buttons[..],
-            &[.., IntegratedTitleButton::Maximize, _]
-        )
-        && inner.config.use_fancy_tab_bar;
-
-    if use_snap_layouts {
-        let scale = GetDpiForWindow(inner.hwnd.0) as f64 / 96.0;
-        let button_height = (30.0 * scale) as isize;
-        if cursor_point.y >= client_rect.top as isize
-            && cursor_point.y < client_rect.top as isize + button_height
-        {
-            let btn_width = (45.0 * scale) as isize;
-            let maximize_btn_pos = (client_rect.right as isize).saturating_sub(btn_width * 2);
-            if cursor_point.x >= maximize_btn_pos && cursor_point.x < maximize_btn_pos + btn_width {
-                return Some(HTMAXBUTTON);
-            }
-        }
+    let use_snap_layouts = !*IS_WIN10;
+    if use_snap_layouts && MAXBTN_HOVERED {
+        MAXBTN_HOVERED = false;
+        return Some(HTMAXBUTTON);
     }
 
     Some(HTCLIENT)
@@ -2629,21 +2617,7 @@ unsafe fn do_wnd_proc(hwnd: HWND, msg: UINT, wparam: WPARAM, lparam: LPARAM) -> 
                 msg,
                 WM_NCMOUSEMOVE | WM_NCMOUSELEAVE | WM_NCLBUTTONDOWN | WM_NCLBUTTONDBLCLK
             ) {
-                let inner = rc_from_hwnd(hwnd)?;
-                let inner = inner.borrow();
-                // When you can predict maximize button position
-                let use_snap_layouts = !*IS_WIN10
-                    && inner.config.window_decorations == WindowDecorations::INTEGRATED_BUTTONS
-                    && inner.config.integrated_title_button_style
-                        == IntegratedTitleButtonStyle::Windows
-                    && inner.config.integrated_title_button_alignment
-                        == IntegratedTitleButtonAlignment::Right
-                    && matches!(
-                        &inner.config.integrated_title_buttons[..],
-                        &[.., IntegratedTitleButton::Maximize, _]
-                    )
-                    && inner.config.use_fancy_tab_bar;
-                std::mem::drop(inner);
+                let use_snap_layouts = !*IS_WIN10;
                 if use_snap_layouts {
                     return match msg {
                         WM_NCMOUSEMOVE => nc_mouse_move(hwnd, msg, wparam, lparam),

--- a/window/src/os/windows/window.rs
+++ b/window/src/os/windows/window.rs
@@ -972,7 +972,9 @@ unsafe fn wm_nccalcsize(hwnd: HWND, _msg: UINT, wparam: WPARAM, lparam: LPARAM) 
     let inner = rc_from_hwnd(hwnd)?;
     let inner = inner.borrow_mut();
 
-    if !(wparam == 1 && inner.config.window_decorations == WindowDecorations::RESIZE) {
+    if !(wparam == 1 && (inner.config.window_decorations == WindowDecorations::RESIZE)
+        || (inner.config.window_decorations == WindowDecorations::FANCY))
+    {
         return None;
     }
 
@@ -1012,12 +1014,29 @@ unsafe fn wm_nccalcsize(hwnd: HWND, _msg: UINT, wparam: WPARAM, lparam: LPARAM) 
     Some(0)
 }
 
+unsafe fn maximize_button_coords(
+    hwnd: HWND,
+) -> euclid::Point2D<isize, wezterm_input_types::PixelUnit> {
+    let mut client_rect = RECT::default();
+    GetClientRect(hwnd, &mut client_rect);
+
+    let scale = GetDpiForWindow(hwnd) as f64 / 96.0;
+
+    let mut coords = mouse_coords(0);
+
+    coords.x = client_rect.right as isize - (60.0 * scale) as isize;
+    coords.y = 5;
+
+    coords
+}
+
 unsafe fn wm_nchittest(hwnd: HWND, msg: UINT, wparam: WPARAM, lparam: LPARAM) -> Option<LRESULT> {
     let inner = rc_from_hwnd(hwnd)?;
     let inner = inner.borrow_mut();
 
-    if inner.config.window_decorations != WindowDecorations::RESIZE {
-        return None;
+    match inner.config.window_decorations {
+        WindowDecorations::FANCY | WindowDecorations::RESIZE => {}
+        _ => return None,
     }
 
     // Let the default procedure handle resizing areas
@@ -1085,6 +1104,21 @@ unsafe fn wm_nchittest(hwnd: HWND, msg: UINT, wparam: WPARAM, lparam: LPARAM) ->
     if let Some(coords) = inner.window_drag_position {
         if coords == screen_point && inner.saved_placement.is_none() {
             return Some(HTCAPTION);
+        }
+    }
+
+    if inner.config.window_decorations == WindowDecorations::FANCY && inner.config.use_fancy_tab_bar
+    {
+        let scale = GetDpiForWindow(inner.hwnd.0) as f64 / 96.0;
+        let button_height = (30.0 * scale) as isize;
+        if cursor_point.y >= client_rect.top as isize
+            && cursor_point.y < client_rect.top as isize + button_height
+        {
+            let btn_width = (45.0 * scale) as isize;
+            let maximize_btn_pos = (client_rect.right as isize).saturating_sub(btn_width * 2);
+            if cursor_point.x >= maximize_btn_pos && cursor_point.x < maximize_btn_pos + btn_width {
+                return Some(HTMAXBUTTON);
+            }
         }
     }
 
@@ -1454,6 +1488,48 @@ unsafe fn mouse_button(hwnd: HWND, msg: UINT, wparam: WPARAM, lparam: LPARAM) ->
     Some(0)
 }
 
+unsafe fn nc_mouse_button(
+    hwnd: HWND,
+    msg: UINT,
+    wparam: WPARAM,
+    _lparam: LPARAM,
+) -> Option<LRESULT> {
+    let inner = rc_from_hwnd(hwnd)?;
+    // To support dragging the window, capture when the left
+    // button goes down and release when it goes up.
+    // Without this, the drag state can be confused when dragging
+    // the mouse up outside of the client area.
+
+    if msg == WM_LBUTTONDOWN {
+        SetCapture(hwnd);
+    } else if msg == WM_LBUTTONUP {
+        ReleaseCapture();
+    }
+
+    if wparam != HTMAXBUTTON as _ {
+        return None;
+    }
+
+    let (modifiers, mouse_buttons) = mods_and_buttons(0);
+    let coords = maximize_button_coords(hwnd);
+
+    let event = MouseEvent {
+        kind: match msg {
+            WM_NCLBUTTONDOWN | WM_NCLBUTTONDBLCLK => MouseEventKind::Press(MousePress::Left),
+            _ => return None,
+        },
+        coords,
+        screen_coords: client_to_screen(hwnd, coords),
+        mouse_buttons,
+        modifiers,
+    };
+    inner
+        .borrow_mut()
+        .events
+        .dispatch(WindowEvent::MouseEvent(event));
+    Some(0)
+}
+
 unsafe fn mouse_move(hwnd: HWND, _msg: UINT, wparam: WPARAM, lparam: LPARAM) -> Option<LRESULT> {
     let inner = rc_from_hwnd(hwnd)?;
     let mut inner = inner.borrow_mut();
@@ -1482,6 +1558,49 @@ unsafe fn mouse_move(hwnd: HWND, _msg: UINT, wparam: WPARAM, lparam: LPARAM) -> 
     };
 
     inner.events.dispatch(WindowEvent::MouseEvent(event));
+    Some(0)
+}
+
+unsafe fn nc_mouse_move(
+    hwnd: HWND,
+    _msg: UINT,
+    wparam: WPARAM,
+    _lparam: LPARAM,
+) -> Option<LRESULT> {
+    let inner = rc_from_hwnd(hwnd)?;
+    let mut inner = inner.borrow_mut();
+
+    if !inner.track_mouse_leave {
+        inner.track_mouse_leave = true;
+
+        let mut trk = TRACKMOUSEEVENT {
+            cbSize: std::mem::size_of::<TRACKMOUSEEVENT>() as u32,
+            dwFlags: TME_LEAVE | TME_NONCLIENT,
+            hwndTrack: hwnd,
+            dwHoverTime: 0,
+        };
+
+        inner.track_mouse_leave = TrackMouseEvent(&mut trk) == winapi::shared::minwindef::TRUE;
+    }
+
+    if wparam != HTMAXBUTTON as _ {
+        return None;
+    }
+
+    let (modifiers, mouse_buttons) = mods_and_buttons(0);
+    let coords = maximize_button_coords(hwnd);
+
+    let event = MouseEvent {
+        kind: MouseEventKind::Move,
+        coords,
+        screen_coords: client_to_screen(hwnd, coords),
+        mouse_buttons,
+        modifiers,
+    };
+
+    inner.events.dispatch(WindowEvent::MouseEvent(event));
+    inner.events.dispatch(WindowEvent::NeedRepaint);
+
     Some(0)
 }
 
@@ -2506,7 +2625,30 @@ unsafe fn do_wnd_proc(hwnd: HWND, msg: UINT, wparam: WPARAM, lparam: LPARAM) -> 
             }
             None
         }
-        _ => None,
+        _ => {
+            if matches!(
+                msg,
+                WM_NCMOUSEMOVE | WM_NCMOUSELEAVE | WM_NCLBUTTONDOWN | WM_NCLBUTTONDBLCLK
+            ) {
+                let inner = rc_from_hwnd(hwnd)?;
+                let inner = inner.borrow();
+                let use_shap_layouts = inner.config.window_decorations == WindowDecorations::FANCY
+                    && inner.config.use_fancy_tab_bar;
+                std::mem::drop(inner);
+                if use_shap_layouts {
+                    return match msg {
+                        WM_NCMOUSEMOVE => nc_mouse_move(hwnd, msg, wparam, lparam),
+                        WM_NCMOUSELEAVE => mouse_leave(hwnd, msg, wparam, lparam),
+                        WM_NCLBUTTONDOWN | WM_NCLBUTTONDBLCLK => {
+                            nc_mouse_button(hwnd, msg, wparam, lparam)
+                        }
+                        _ => None,
+                    };
+                }
+            }
+
+            None
+        }
     }
 }
 

--- a/window/src/os/windows/window.rs
+++ b/window/src/os/windows/window.rs
@@ -2,7 +2,8 @@ use super::*;
 use crate::connection::ConnectionOps;
 use crate::parameters::{self, Parameters};
 use crate::{
-    Appearance, Clipboard, DeadKeyStatus, Dimensions, Handled, KeyCode, KeyEvent, Modifiers,
+    Appearance, Clipboard, DeadKeyStatus, Dimensions, Handled, IntegratedTitleButton,
+    IntegratedTitleButtonAlignment, IntegratedTitleButtonStyle, KeyCode, KeyEvent, Modifiers,
     MouseButtons, MouseCursor, MouseEvent, MouseEventKind, MousePress, Point, RawKeyEvent, Rect,
     RequestedWindowGeometry, ResolvedGeometry, ScreenPoint, ULength, WindowDecorations,
     WindowEvent, WindowEventSender, WindowOps, WindowState,
@@ -972,8 +973,11 @@ unsafe fn wm_nccalcsize(hwnd: HWND, _msg: UINT, wparam: WPARAM, lparam: LPARAM) 
     let inner = rc_from_hwnd(hwnd)?;
     let inner = inner.borrow_mut();
 
-    if !(wparam == 1 && (inner.config.window_decorations == WindowDecorations::RESIZE)
-        || (inner.config.window_decorations == WindowDecorations::INTEGRATED_BUTTONS))
+    if !(wparam == 1
+        && (matches!(
+            inner.config.window_decorations,
+            WindowDecorations::RESIZE | WindowDecorations::INTEGRATED_BUTTONS
+        )))
     {
         return None;
     }
@@ -1012,22 +1016,6 @@ unsafe fn wm_nccalcsize(hwnd: HWND, _msg: UINT, wparam: WPARAM, lparam: LPARAM) 
     }
 
     Some(0)
-}
-
-unsafe fn maximize_button_coords(
-    hwnd: HWND,
-) -> euclid::Point2D<isize, wezterm_input_types::PixelUnit> {
-    let mut client_rect = RECT::default();
-    GetClientRect(hwnd, &mut client_rect);
-
-    let scale = GetDpiForWindow(hwnd) as f64 / 96.0;
-
-    let mut coords = mouse_coords(0);
-
-    coords.x = client_rect.right as isize - (60.0 * scale) as isize;
-    coords.y = 5;
-
-    coords
 }
 
 unsafe fn wm_nchittest(hwnd: HWND, msg: UINT, wparam: WPARAM, lparam: LPARAM) -> Option<LRESULT> {
@@ -1107,8 +1095,18 @@ unsafe fn wm_nchittest(hwnd: HWND, msg: UINT, wparam: WPARAM, lparam: LPARAM) ->
         }
     }
 
-    if inner.config.window_decorations == WindowDecorations::INTEGRATED_BUTTONS && inner.config.use_fancy_tab_bar
-    {
+    // When you can predict maximize button position
+    let use_snap_layouts = !*IS_WIN10
+        && inner.config.window_decorations == WindowDecorations::INTEGRATED_BUTTONS
+        && inner.config.integrated_title_button_style == IntegratedTitleButtonStyle::Windows
+        && inner.config.integrated_title_button_alignment == IntegratedTitleButtonAlignment::Right
+        && matches!(
+            &inner.config.integrated_title_buttons[..],
+            &[.., IntegratedTitleButton::Maximize, _]
+        )
+        && inner.config.use_fancy_tab_bar;
+
+    if use_snap_layouts {
         let scale = GetDpiForWindow(inner.hwnd.0) as f64 / 96.0;
         let button_height = (30.0 * scale) as isize;
         if cursor_point.y >= client_rect.top as isize
@@ -1415,6 +1413,12 @@ fn mouse_coords(lparam: LPARAM) -> Point {
     Point::new(point.x as _, point.y as _)
 }
 
+fn nc_mouse_coords(hwnd: HWND, lparam: LPARAM) -> Point {
+    let point = MAKEPOINTS(lparam as _);
+    let point = ScreenPoint::new(point.x as _, point.y as _);
+    screen_to_client(hwnd, point)
+}
+
 fn screen_to_client(hwnd: HWND, point: ScreenPoint) -> Point {
     let mut point = POINT {
         x: point.x.try_into().unwrap(),
@@ -1492,7 +1496,7 @@ unsafe fn nc_mouse_button(
     hwnd: HWND,
     msg: UINT,
     wparam: WPARAM,
-    _lparam: LPARAM,
+    lparam: LPARAM,
 ) -> Option<LRESULT> {
     let inner = rc_from_hwnd(hwnd)?;
     // To support dragging the window, capture when the left
@@ -1511,7 +1515,7 @@ unsafe fn nc_mouse_button(
     }
 
     let (modifiers, mouse_buttons) = mods_and_buttons(0);
-    let coords = maximize_button_coords(hwnd);
+    let coords = nc_mouse_coords(hwnd, lparam);
 
     let event = MouseEvent {
         kind: match msg {
@@ -1561,12 +1565,7 @@ unsafe fn mouse_move(hwnd: HWND, _msg: UINT, wparam: WPARAM, lparam: LPARAM) -> 
     Some(0)
 }
 
-unsafe fn nc_mouse_move(
-    hwnd: HWND,
-    _msg: UINT,
-    wparam: WPARAM,
-    _lparam: LPARAM,
-) -> Option<LRESULT> {
+unsafe fn nc_mouse_move(hwnd: HWND, _msg: UINT, wparam: WPARAM, lparam: LPARAM) -> Option<LRESULT> {
     let inner = rc_from_hwnd(hwnd)?;
     let mut inner = inner.borrow_mut();
 
@@ -1588,7 +1587,7 @@ unsafe fn nc_mouse_move(
     }
 
     let (modifiers, mouse_buttons) = mods_and_buttons(0);
-    let coords = maximize_button_coords(hwnd);
+    let coords = nc_mouse_coords(hwnd, lparam);
 
     let event = MouseEvent {
         kind: MouseEventKind::Move,
@@ -2632,10 +2631,20 @@ unsafe fn do_wnd_proc(hwnd: HWND, msg: UINT, wparam: WPARAM, lparam: LPARAM) -> 
             ) {
                 let inner = rc_from_hwnd(hwnd)?;
                 let inner = inner.borrow();
-                let use_shap_layouts = inner.config.window_decorations == WindowDecorations::INTEGRATED_BUTTONS
+                // When you can predict maximize button position
+                let use_snap_layouts = !*IS_WIN10
+                    && inner.config.window_decorations == WindowDecorations::INTEGRATED_BUTTONS
+                    && inner.config.integrated_title_button_style
+                        == IntegratedTitleButtonStyle::Windows
+                    && inner.config.integrated_title_button_alignment
+                        == IntegratedTitleButtonAlignment::Right
+                    && matches!(
+                        &inner.config.integrated_title_buttons[..],
+                        &[.., IntegratedTitleButton::Maximize, _]
+                    )
                     && inner.config.use_fancy_tab_bar;
                 std::mem::drop(inner);
-                if use_shap_layouts {
+                if use_snap_layouts {
                     return match msg {
                         WM_NCMOUSEMOVE => nc_mouse_move(hwnd, msg, wparam, lparam),
                         WM_NCMOUSELEAVE => mouse_leave(hwnd, msg, wparam, lparam),

--- a/window/src/os/windows/window.rs
+++ b/window/src/os/windows/window.rs
@@ -973,7 +973,7 @@ unsafe fn wm_nccalcsize(hwnd: HWND, _msg: UINT, wparam: WPARAM, lparam: LPARAM) 
     let inner = inner.borrow_mut();
 
     if !(wparam == 1 && (inner.config.window_decorations == WindowDecorations::RESIZE)
-        || (inner.config.window_decorations == WindowDecorations::FANCY))
+        || (inner.config.window_decorations == WindowDecorations::INTEGRATED_BUTTONS))
     {
         return None;
     }
@@ -1035,7 +1035,7 @@ unsafe fn wm_nchittest(hwnd: HWND, msg: UINT, wparam: WPARAM, lparam: LPARAM) ->
     let inner = inner.borrow_mut();
 
     match inner.config.window_decorations {
-        WindowDecorations::FANCY | WindowDecorations::RESIZE => {}
+        WindowDecorations::INTEGRATED_BUTTONS | WindowDecorations::RESIZE => {}
         _ => return None,
     }
 
@@ -1107,7 +1107,7 @@ unsafe fn wm_nchittest(hwnd: HWND, msg: UINT, wparam: WPARAM, lparam: LPARAM) ->
         }
     }
 
-    if inner.config.window_decorations == WindowDecorations::FANCY && inner.config.use_fancy_tab_bar
+    if inner.config.window_decorations == WindowDecorations::INTEGRATED_BUTTONS && inner.config.use_fancy_tab_bar
     {
         let scale = GetDpiForWindow(inner.hwnd.0) as f64 / 96.0;
         let button_height = (30.0 * scale) as isize;
@@ -2632,7 +2632,7 @@ unsafe fn do_wnd_proc(hwnd: HWND, msg: UINT, wparam: WPARAM, lparam: LPARAM) -> 
             ) {
                 let inner = rc_from_hwnd(hwnd)?;
                 let inner = inner.borrow();
-                let use_shap_layouts = inner.config.window_decorations == WindowDecorations::FANCY
+                let use_shap_layouts = inner.config.window_decorations == WindowDecorations::INTEGRATED_BUTTONS
                     && inner.config.use_fancy_tab_bar;
                 std::mem::drop(inner);
                 if use_shap_layouts {

--- a/window/src/os/x11/window.rs
+++ b/window/src/os/x11/window.rs
@@ -935,7 +935,7 @@ impl XWindowInner {
         let decorations = if decorations == WindowDecorations::TITLE | WindowDecorations::RESIZE {
             FUNC_ALL
         } else if decorations == WindowDecorations::RESIZE
-            || decorations == WindowDecorations::FANCY
+            || decorations == WindowDecorations::INTEGRATED_BUTTONS
         {
             FUNC_RESIZE
         } else if decorations == WindowDecorations::TITLE {

--- a/window/src/os/x11/window.rs
+++ b/window/src/os/x11/window.rs
@@ -934,7 +934,9 @@ impl XWindowInner {
 
         let decorations = if decorations == WindowDecorations::TITLE | WindowDecorations::RESIZE {
             FUNC_ALL
-        } else if decorations == WindowDecorations::RESIZE {
+        } else if decorations == WindowDecorations::RESIZE
+            || decorations == WindowDecorations::FANCY
+        {
             FUNC_RESIZE
         } else if decorations == WindowDecorations::TITLE {
             FUNC_MOVE | FUNC_MINIMIZE | FUNC_MAXIMIZE | FUNC_CLOSE


### PR DESCRIPTION
I made simple version of chrome-like integrated titlebar #1180

With fancy tab bar:
![Screenshot from 2022-11-07 21-30-38](https://user-images.githubusercontent.com/63008755/200389387-04a13638-2432-4f49-b305-6ad56a6fcfd1.png)

Without fancy tab bar
![Screenshot from 2022-11-07 21-30-28](https://user-images.githubusercontent.com/63008755/200389383-d6163ae1-140a-40bc-a47d-8debc7245d27.png)

Video recording with buttons in action

[Kooha-2022-11-07-21-51-16.webm](https://user-images.githubusercontent.com/63008755/200391085-48f5179c-32c7-48d7-b7b6-790b7ef5ec0f.webm)

I have linux (with gnome), macos and windows, so I think I can make it for those platforms, but I don't have freebsd

**Todo:**
- [x] use two icons for maximize button
- [x] use custom config colors (currently used colors from the new tab button)
- [x] use different button styles (windows | macos | gnome | ??)
- [x] use the current system layout (left | right and hide useless buttons)
- [x] finish macos style
- [ ] Other suggestions
