### PR TITLE
Kitty Image Protocol - don't remove images with ID 0

### DIFF
--- a/term/src/terminalstate/kitty.rs
+++ b/term/src/terminalstate/kitty.rs
@@ -34,7 +34,9 @@ impl KittyImageState {
     }
 
     fn record_id_to_data(&mut self, image_id: u32, data: Arc<ImageData>) {
-        self.remove_data_for_id(image_id);
+        if image_id != 0 {
+            self.remove_data_for_id(image_id);
+        }
         self.prune_unreferenced();
         self.used_memory += data.len();
         self.id_to_data.insert(image_id, data);
@@ -97,7 +99,9 @@ impl TerminalState {
             placement,
             verbosity
         );
-        self.kitty_remove_placement(image_id, placement.placement_id);
+        if image_id != 0 {
+            self.kitty_remove_placement(image_id, placement.placement_id);
+        }
         let img = Arc::clone(self.kitty_img.id_to_data.get(&image_id).ok_or_else(|| {
             anyhow::anyhow!(
                 "no matching image id {} in id_to_data for image_number {:?}",


### PR DESCRIPTION
This is a naive fix for the #2084 . As mentioned by @kovidgoyal, there can be multiple images with ID=0, so this fix checks the image ID and does not remove the placements if the ID is 0.

(I feel that there will be some subtleties that I've missed but I'm opening this as it looks like it achieves what is required.)