### PR TITLE
refactor: replace the deprecated usage of `chrono::TimeZone::ymd`

### DIFF
--- a/frecency/src/lib.rs
+++ b/frecency/src/lib.rs
@@ -127,7 +127,7 @@ mod tests {
     #[test]
     fn serialize() {
         use chrono::TimeZone;
-        let now = Utc.ymd(2022, 08, 31).and_hms(22, 16, 0);
+        let now = Utc.with_ymd_and_hms(2022, 08, 31, 22, 16, 0).unwrap();
         let f = Frecency::new_at_time(now);
         assert_eq!(serde_json::to_string(&f).unwrap(), "{\"half_life\":259200,\"last_accessed\":1661984160,\"frecency\":0.0,\"num_accesses\":0}");
     }


### PR DESCRIPTION
Since `chrono` 0.4.23, `chrono::TimeZone::ymd` is deprecated in favor of `with_ymd_and_hms()`.

```
warning: use of deprecated associated function `chrono::TimeZone::ymd`: use `with_ymd_and_hms()` instead
   --> frecency/src/lib.rs:130:23
    |
130 |         let now = Utc.ymd(2022, 08, 31).and_hms(22, 16, 0);
    |                       ^^^
    |
    = note: `#[warn(deprecated)]` on by default
```

This PR removes the deprecated usage.
