### PR TITLE
Add the hidden alias `-e` for the `start` subcommand.

### DIFF
--- a/wezterm-gui-subcommands/src/lib.rs
+++ b/wezterm-gui-subcommands/src/lib.rs
@@ -146,6 +146,7 @@ mod test {
 
 #[derive(Debug, Parser, Default, Clone)]
 #[command(trailing_var_arg = true)]
+#[command(short_flag_alias = 'e')]
 pub struct StartCommand {
     /// If true, do not connect to domains marked as connect_automatically
     /// in your wezterm configuration file.

--- a/wezterm-gui-subcommands/src/lib.rs
+++ b/wezterm-gui-subcommands/src/lib.rs
@@ -146,7 +146,7 @@ mod test {
 
 #[derive(Debug, Parser, Default, Clone)]
 #[command(trailing_var_arg = true)]
-#[command(short_flag_alias = 'e')]
+#[command(visible_short_flag_alias = 'e')]
 pub struct StartCommand {
     /// If true, do not connect to domains marked as connect_automatically
     /// in your wezterm configuration file.


### PR DESCRIPTION
Adding the short flag alias gives us the hidden alias `-e` that can be consumed by third parties while maintaining `start` and `start -e`.

The following commands will work as expected:
```
wezterm -e vim
wezterm start vim
wezterm start -e vim
```
resolves: #2782