### PR TITLE
Hide mouse cursor when typing

### DIFF
--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -581,6 +581,11 @@ pub struct Config {
     #[dynamic(default = "linear_ease")]
     pub text_blink_rapid_ease_out: EasingFunction,
 
+    /// If true, the mouse cursor will be hidden while typing.
+    /// This option is true by default.
+    #[dynamic(default = "default_true")]
+    pub hide_mouse_cursor_when_typing: bool,
+
     /// If non-zero, specifies the period (in seconds) at which various
     /// statistics are logged.  Note that there is a minimum period of
     /// 10 seconds.

--- a/docs/config/lua/config/hide_mouse_cursor_when_typing.md
+++ b/docs/config/lua/config/hide_mouse_cursor_when_typing.md
@@ -1,0 +1,12 @@
+# `hide_mouse_cursor_when_typing`
+
+If `true`, the mouse cursor will be hidden when typing, if your mouse cursor is
+hovering over the window.
+
+The default is `true`. Set to `false` to disable this behavior.
+
+```lua
+return {
+  hide_mouse_cursor_when_typing = true,
+}
+```

--- a/docs/config/lua/config/hide_mouse_cursor_when_typing.md
+++ b/docs/config/lua/config/hide_mouse_cursor_when_typing.md
@@ -1,5 +1,7 @@
 # `hide_mouse_cursor_when_typing`
 
+*Since: nightly builds only*
+
 If `true`, the mouse cursor will be hidden when typing, if your mouse cursor is
 hovering over the window.
 

--- a/wezterm-gui/src/termwindow/keyevent.rs
+++ b/wezterm-gui/src/termwindow/keyevent.rs
@@ -391,7 +391,9 @@ impl super::TermWindow {
                         {
                             self.maybe_scroll_to_bottom_for_input(&pane);
                         }
-                        context.set_cursor(None);
+                        if self.config.hide_mouse_cursor_when_typing {
+                            context.set_cursor(None);
+                        }
                         if !keycode.is_modifier() {
                             context.invalidate();
                         }
@@ -646,7 +648,9 @@ impl super::TermWindow {
                     {
                         self.maybe_scroll_to_bottom_for_input(&pane);
                     }
-                    context.set_cursor(None);
+                    if self.config.hide_mouse_cursor_when_typing {
+                        context.set_cursor(None);
+                    }
                     if !key.is_modifier() {
                         context.invalidate();
                     }


### PR DESCRIPTION
This implements the `hide_mouse_cursor_when_typing` config option that allows you to disable the behavior.

Closes #2943.