### PR TITLE
x11: ignore pointer focus events

### DIFF
--- a/window/src/os/x11/window.rs
+++ b/window/src/os/x11/window.rs
@@ -585,12 +585,18 @@ impl XWindowInner {
                     self.verify_focus = true;
                 }
             }
-            Event::X(xcb::x::Event::FocusIn(_)) => {
-                self.focus_changed(true);
-            }
-            Event::X(xcb::x::Event::FocusOut(_)) => {
-                self.focus_changed(false);
-            }
+            Event::X(xcb::x::Event::FocusIn(e)) => match e.detail() {
+                xcb::x::NotifyDetail::Pointer => (),
+                _ => {
+                    self.focus_changed(true);
+                }
+            },
+            Event::X(xcb::x::Event::FocusOut(e)) => match e.detail() {
+                xcb::x::NotifyDetail::Pointer => (),
+                _ => {
+                    self.focus_changed(false);
+                }
+            },
             Event::X(xcb::x::Event::LeaveNotify(_)) => {
                 self.events.dispatch(WindowEvent::MouseLeave);
             }


### PR DESCRIPTION
X11 generates `Pointer` focus events, which are irrelevant to our use case and cause spurious `FocusIn/Out` events if the pointer is located in the wezterm window. The only relevant details seem to be `Ancestor` and `Nonlinear`. I've tested this with bspwm and i3.

Protocol doc: https://www.x.org/releases/current/doc/xproto/x11protocol.html#events:FocusIn