### PR TITLE
wayland: hide mouse cursor when typing

### DIFF
--- a/window/src/os/wayland/pointer.rs
+++ b/window/src/os/wayland/pointer.rs
@@ -340,11 +340,16 @@ impl PointerDispatcher {
             .insert(surface.as_ref().id(), Arc::clone(pending));
     }
 
-    pub fn set_cursor(&self, name: &str, serial: Option<u32>) {
+    pub fn set_cursor(&self, name: Option<&str>, serial: Option<u32>) {
         let inner = self.inner.lock().unwrap();
         let serial = serial.unwrap_or(inner.serial);
-        if let Err(err) = self.auto_pointer.set_cursor(name, Some(serial)) {
-            log::error!("Unable to set cursor to {}: {:#}", name, err);
+
+        if let Some(name) = name {
+            if let Err(err) = self.auto_pointer.set_cursor(name, Some(serial)) {
+                log::error!("Unable to set cursor to {}: {:#}", name, err);
+            }
+        } else {
+            (*self.auto_pointer).set_cursor(0, None, 0, 0);
         }
     }
 }

--- a/window/src/os/wayland/window.rs
+++ b/window/src/os/wayland/window.rs
@@ -1075,14 +1075,13 @@ impl WaylandWindowInner {
     }
 
     fn set_cursor(&mut self, cursor: Option<MouseCursor>) {
-        let cursor = match cursor {
-            Some(MouseCursor::Arrow) => "arrow",
-            Some(MouseCursor::Hand) => "hand",
-            Some(MouseCursor::SizeUpDown) => "ns-resize",
-            Some(MouseCursor::SizeLeftRight) => "ew-resize",
-            Some(MouseCursor::Text) => "xterm",
-            None => return,
-        };
+        let cursor = cursor.map(|cursor| match cursor {
+            MouseCursor::Arrow => "arrow",
+            MouseCursor::Hand => "hand",
+            MouseCursor::SizeUpDown => "ns-resize",
+            MouseCursor::SizeLeftRight => "ew-resize",
+            MouseCursor::Text => "xterm",
+        });
         let conn = Connection::get().unwrap().wayland();
         conn.pointer.borrow().set_cursor(cursor, None);
     }


### PR DESCRIPTION
Fixes wayland not hiding the cursor when typing from issue #618.