### PR TITLE
Detect ALT key for mouse events on Windows

### DIFF
--- a/window/src/os/windows/window.rs
+++ b/window/src/os/windows/window.rs
@@ -1428,6 +1428,9 @@ fn mods_and_buttons(wparam: WPARAM) -> (Modifiers, MouseButtons) {
     if wparam & MK_SHIFT != 0 {
         modifiers |= Modifiers::SHIFT;
     }
+    if unsafe { GetKeyState(VK_MENU) } as u16 & 0x8000 != 0 {
+        modifiers |= Modifiers::ALT;
+    }
     if wparam & MK_LBUTTON != 0 {
         buttons |= MouseButtons::LEFT;
     }


### PR DESCRIPTION
This adds detection of ALT key presses for mouse events, which fixes the [default mouse bindings](https://wezfurlong.org/wezterm/config/mouse.html) that use this key as a modifier.

The code is basically lifted from Microsoft's own example for handling this case: <https://learn.microsoft.com/en-us/windows/win32/learnwin32/keyboard-input#keyboard-state>.