### PR TITLE
Add “New Window” to the dock menu on macOS

### DIFF
--- a/window/src/os/macos/menu.rs
+++ b/window/src/os/macos/menu.rs
@@ -25,8 +25,8 @@ impl Menu {
         }
     }
 
-    pub fn autorelease(self) {
-        self.menu.autorelease();
+    pub fn autorelease(self) -> *mut Object {
+        self.menu.autorelease()
     }
 
     pub fn item_at_index(&self, index: usize) -> Option<MenuItem> {


### PR DESCRIPTION
This patch adds a dock menu *New Window* on macOS, which mimics Terminal.app and iTerm.  It looks like below:

<img width="283" alt="“New Window” showing up on WezTerm's dock menu" src="https://user-images.githubusercontent.com/12431/216784410-93bfdd0b-f0d0-4993-bff4-c43f25cb0402.png">

(You might wonder when this menu would be helpful…  It's the only way I'm aware of to spawn a new window without switching macOS Spaces when there are multiple Spaces and your current Space has no WezTerm window but there are any Spaces having WezTerm windows.)

It's my first time to contribute here, so there probably are several misplaced parts.  Please let me know so that I can adjust them!