### PR TITLE
Change to the homebrew command to upgrade wezterm-nightly

### DIFF
--- a/docs/install/macos.markdown
+++ b/docs/install/macos.markdown
@@ -39,7 +39,7 @@ $ brew install --cask wez/wezterm/wezterm-nightly
 to upgrade to a newer nightly (normal `brew upgrade` will not upgrade it!):
 
 ```bash
-$ brew upgrade --cask wezterm-nightly --no-quarantine --greedy-latest
+$ brew upgrade --cask wez/wezterm/wezterm-nightly --no-quarantine --greedy-latest
 ```
 
 ## MacPorts


### PR DESCRIPTION
Hi,

I encountered an error while trying to upgrade Wezterm to a newer nightly build on MacOS using the previous brew command. The error message was:

> Error: Cask wezterm-nightly exists in multiple taps: 
> homebrew/cask-versions/wezterm-nightly
> wez/wezterm/wezterm-nightly

To resolve this issue temporarily, I modified the shell script to use the "wez/wezterm/wezterm-nightly" tap. 

```bash
$ brew upgrade --cask wez/wezterm/wezterm-nightly --no-quarantine --greedy-latest
```
However, I wanted to check if it's preferable to use the "homebrew/cask-versions/wezterm-nightly" tap instead. Please let me know your thoughts on this.

Thanks!