### PR TITLE
palette: add CTRL-p / CTRL-n key bindings to move up/down

### DIFF
--- a/wezterm-gui/src/termwindow/palette.rs
+++ b/wezterm-gui/src/termwindow/palette.rs
@@ -443,10 +443,10 @@ impl Modal for CommandPalette {
             (KeyCode::Escape, KeyModifiers::NONE) | (KeyCode::Char('g'), KeyModifiers::CTRL) => {
                 term_window.cancel_modal();
             }
-            (KeyCode::UpArrow, KeyModifiers::NONE) => {
+            (KeyCode::UpArrow, KeyModifiers::NONE) | (KeyCode::Char('p'), KeyModifiers::CTRL) => {
                 self.move_up();
             }
-            (KeyCode::DownArrow, KeyModifiers::NONE) => {
+            (KeyCode::DownArrow, KeyModifiers::NONE) | (KeyCode::Char('n'), KeyModifiers::CTRL) => {
                 self.move_down();
             }
             (KeyCode::Char(c), KeyModifiers::NONE) | (KeyCode::Char(c), KeyModifiers::SHIFT) => {


### PR DESCRIPTION
Add `ctrl-p`/`ctrl-n` key bindings to move up and down in the command palette.