### PR TITLE
Fix missing longopt in cargo command

### DIFF
--- a/install/source.markdown
+++ b/install/source.markdown
@@ -49,7 +49,7 @@ If your distribution has X11 but not Wayland, then you can build WezTerm without
 Wayland support by changing the `build` invocation:
 
 ```bash
-cargo build --release --no-default-features vendored-fonts
+cargo build --release --no-default-features --features vendored-fonts
 ```
 
 Building without X11 is not supported.


### PR DESCRIPTION
Cargo requires the `--feature` longopt in order to enable `vendored-fonts` and other feature options, otherwise the following error will occur:

```
error: Found argument 'vendored-fonts' which wasn't expected, or isn't valid in this context

Usage: cargo build [OPTIONS]

For more information try '--help'
```