### PR TITLE
Improve XDG configuration search paths

### DIFF
--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -23,7 +23,7 @@ use crate::wsl::WslDomain;
 use crate::{
     default_config_with_overrides_applied, default_one_point_oh, default_one_point_oh_f64,
     default_true, GpuInfo, KeyMapPreference, LoadedConfig, MouseEventTriggerMods, RgbaColor,
-    WebGpuPowerPreference, CONFIG_DIR, CONFIG_FILE_OVERRIDE, CONFIG_OVERRIDES, CONFIG_SKIP,
+    WebGpuPowerPreference, CONFIG_DIRS, CONFIG_FILE_OVERRIDE, CONFIG_OVERRIDES, CONFIG_SKIP,
     HOME_DIR,
 };
 use anyhow::Context;
@@ -777,10 +777,11 @@ impl Config {
         // multiple.  In addition, it spawns a lot of subprocesses,
         // so we do this bit "by-hand"
 
-        let mut paths = vec![
-            PathPossibility::optional(CONFIG_DIR.join("wezterm.lua")),
-            PathPossibility::optional(HOME_DIR.join(".wezterm.lua")),
-        ];
+        let mut paths = vec![PathPossibility::optional(HOME_DIR.join(".wezterm.lua"))];
+        for dir in CONFIG_DIRS.iter() {
+            paths.push(PathPossibility::optional(dir.join("wezterm.lua")))
+        }
+
         if cfg!(windows) {
             // On Windows, a common use case is to maintain a thumb drive
             // with a set of portable tools that don't need to be installed
@@ -1175,7 +1176,9 @@ impl Config {
 
     fn compute_color_scheme_dirs(&self) -> Vec<PathBuf> {
         let mut paths = self.color_scheme_dirs.clone();
-        paths.push(CONFIG_DIR.join("colors"));
+        for dir in CONFIG_DIRS.iter() {
+            paths.push(dir.join("colors"));
+        }
         if cfg!(windows) {
             // See commentary re: portable tools above!
             if let Ok(exe_name) = std::env::current_exe() {

--- a/config/src/lua.rs
+++ b/config/src/lua.rs
@@ -247,7 +247,9 @@ pub fn make_lua_context(config_file: &Path) -> anyhow::Result<Lua> {
         }
 
         prefix_path(&mut path_array, &crate::HOME_DIR.join(".wezterm"));
-        prefix_path(&mut path_array, &crate::CONFIG_DIR);
+        for dir in crate::CONFIG_DIRS.iter() {
+            prefix_path(&mut path_array, dir);
+        }
         path_array.insert(
             2,
             format!("{}/plugins/?/plugin/init.lua", crate::RUNTIME_DIR.display()),

--- a/env-bootstrap/src/lib.rs
+++ b/env-bootstrap/src/lib.rs
@@ -73,7 +73,12 @@ pub fn fixup_appimage() {
             clean_wezterm_config_env();
         }
 
-        if config::CONFIG_DIR.starts_with(append_extra_file_name_suffix(&appimage, ".config")) {
+        if std::env::var("XDG_CONFIG_HOME")
+            .map(|d| {
+                PathBuf::from(d).starts_with(append_extra_file_name_suffix(&appimage, ".config"))
+            })
+            .unwrap_or_default()
+        {
             std::env::remove_var("XDG_CONFIG_HOME");
             clean_wezterm_config_env();
         }


### PR DESCRIPTION
In addition to XDG_CONFIG_HOME, use XDG_CONFIG_DIRS (https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html) to append paths for searching for configuration files.