### PR TITLE
Escape Sequence fix wrong name for RGBA ID `6`

### DIFF
--- a/docs/escape-sequences.md
+++ b/docs/escape-sequences.md
@@ -280,7 +280,7 @@ CSI 38 : 2 : R : G : B m
 
 *Since: 20220807-113146-c2fee766*
 
-This is a wezterm extension: wezterm considers colorspace ID `6` as RGBA,
+This is a wezterm extension: wezterm considers color mode `6` as RGBA,
 allowing you to specify the alpha channel in addition to the RGB channels.
 
 ```
@@ -308,7 +308,7 @@ CSI 48 : 2 : R : G : B m
 
 *Since: 20220807-113146-c2fee766*
 
-This is a wezterm extension: wezterm considers colorspace ID `6` as RGBA,
+This is a wezterm extension: wezterm considers color mode `6` as RGBA,
 allowing you to specify the alpha channel in addition to the RGB channels.
 
 ```
@@ -336,7 +336,7 @@ CSI 58 : 2 : R : G : B m
 
 *Since: 20220807-113146-c2fee766*
 
-This is a wezterm extension: wezterm considers colorspace ID `6` as RGBA,
+This is a wezterm extension: wezterm considers color mode `6` as RGBA,
 allowing you to specify the alpha channel in addition to the RGB channels.
 
 ```


### PR DESCRIPTION
I have been looking over the wezterm documentation and found that the following paragraph is wrongly worded:

> This is a wezterm extension: wezterm considers colorspace ID `6` as RGBA, allowing you to specify the alpha channel in addition to the RGB channels.

This is wrong and directly contradicts the paragraph from before: 

> For the sake of compatibility with some other terminal emulators this additional form is also supported where the colorspace ID argument is not specified:

According to ISO 8613-6 13.1.8 the first parameter has no name, and the second parameter (if the first parameter is 2, 3, 4) is the colorspace id. I chose "color mode" as a more fitting name, as it is unused in the spec and there is no explicit official name.

> If the first parameter element has the value 2, 3, or 4, the second parameter element specifies a colour space identifier referring to a colour space definition in the document profile.