### PR TITLE
Added Tokyo Night to Colorscheme Sync

### DIFF
--- a/sync-color-schemes/src/main.rs
+++ b/sync-color-schemes/src/main.rs
@@ -394,6 +394,13 @@ async fn main() -> anyhow::Result<()> {
         &mut schemeses,
     )
     .await?;
+    sync_toml(
+        "https://github.com/folke/tokyonight.nvim",
+        "main",
+        "",
+        &mut schemeses,
+    )
+    .await?;
     accumulate(
         &mut schemeses,
         iterm2::sync_iterm2().await.context("sync iterm2")?,


### PR DESCRIPTION
I added the metadata table to Tokyo Night's wezterm extra so it could be used in the sync-color-schemes module.
https://github.com/folke/tokyonight.nvim/pull/327