### PR TITLE
Filter figterm from stateful check

### DIFF
--- a/mux/src/localpane.rs
+++ b/mux/src/localpane.rs
@@ -509,6 +509,10 @@ impl Pane for LocalPane {
             });
 
             fn default_stateful_check(proc_list: &LocalProcessInfo) -> bool {
+                // Fig uses `figterm` a pseudo terminal for a lot of functionality, it runs between
+                // the shell and terminal. Unfortunately it is typically named `<shell> (figterm)`,
+                // which prevents the statuful check from passing. This strips the suffix from the
+                // process name to allow the check to pass.
                 let names = proc_list
                     .flatten_to_exe_names()
                     .into_iter()

--- a/mux/src/localpane.rs
+++ b/mux/src/localpane.rs
@@ -509,7 +509,14 @@ impl Pane for LocalPane {
             });
 
             fn default_stateful_check(proc_list: &LocalProcessInfo) -> bool {
-                let names = proc_list.flatten_to_exe_names();
+                let names = proc_list
+                    .flatten_to_exe_names()
+                    .into_iter()
+                    .map(|s| match s.strip_suffix(" (figterm)") {
+                        Some(s) => s.into(),
+                        None => s,
+                    })
+                    .collect::<HashSet<_>>();
 
                 let skip = configuration()
                     .skip_close_confirmation_for_processes_named


### PR DESCRIPTION
Fig uses figterm a pseudo terminal for a lot of functionality, it runs between the shell and terminal. Unfortunately it is typically named `<shell> (figterm)`, which prevents the statuful check from passing.

Not sure if this is the best implementation, I personally would prefer to add `figterm` to the `default_stateless_process_list` but as a regex searching for `(figterm)` in the process name. This would be a bigger change but also up for doing. 

Also for some more context this is also done similarly in VSCode where they filter `(figterm)` out from the process name, but they do it at the process API level, I didn't want to change the `procinfo` impl however. 

https://github.com/microsoft/vscode/blob/728ee42999e6f07c32539f3dd4b09be1e89c8556/src/vs/platform/terminal/node/terminalProcess.ts#L408
