### PR TITLE
Add config for scrolling between tabs

### DIFF
--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -402,8 +402,8 @@ pub struct Config {
     #[dynamic(default)]
     pub tab_bar_at_bottom: bool,
 
-    #[dynamic(default)]
-    pub scroll_tabs: bool,
+    #[dynamic(default = "default_true")]
+    pub mouse_wheel_scrolls_tabs: bool,
 
     /// If true, tab bar titles are prefixed with the tab index
     #[dynamic(default = "default_true")]

--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -401,6 +401,9 @@ pub struct Config {
 
     #[dynamic(default)]
     pub tab_bar_at_bottom: bool,
+    
+    #[dynamic(default)]
+    pub scroll_tabs: bool,
 
     /// If true, tab bar titles are prefixed with the tab index
     #[dynamic(default = "default_true")]

--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -401,7 +401,7 @@ pub struct Config {
 
     #[dynamic(default)]
     pub tab_bar_at_bottom: bool,
-    
+
     #[dynamic(default)]
     pub scroll_tabs: bool,
 

--- a/docs/config/lua/config/mouse_wheel_scrolls_tabs.md
+++ b/docs/config/lua/config/mouse_wheel_scrolls_tabs.md
@@ -1,6 +1,6 @@
 # `mouse_wheel_scrolls_tabs`
 
-*Since: nightly builds only*
+{{since('nightly')}}
 
 If `true`, the vertical mouse wheel will switch between tabs when the mouse 
 cursor is over the tab bar. 
@@ -8,7 +8,5 @@ cursor is over the tab bar.
 The default is `true`. Set to `false` to disable this behavior.
 
 ```lua
-return {
-  mouse_wheel_scrolls_tabs = true,
-}
+config.mouse_wheel_scrolls_tabs = true
 ```

--- a/docs/config/lua/config/mouse_wheel_scrolls_tabs.md
+++ b/docs/config/lua/config/mouse_wheel_scrolls_tabs.md
@@ -1,4 +1,4 @@
-# `scroll_tabs`
+# `mouse_wheel_scrolls_tabs`
 
 *Since: nightly builds only*
 
@@ -9,6 +9,6 @@ The default is `true`. Set to `false` to disable this behavior.
 
 ```lua
 return {
-  scroll_tabs = true,
+  mouse_wheel_scrolls_tabs = true,
 }
 ```

--- a/docs/config/lua/config/scroll_tabs.md
+++ b/docs/config/lua/config/scroll_tabs.md
@@ -1,0 +1,14 @@
+# `scroll_tabs`
+
+*Since: nightly builds only*
+
+If `true`, the vertical mouse wheel will switch between tabs when the mouse 
+cursor is over the tab bar. 
+
+The default is `true`. Set to `false` to disable this behavior.
+
+```lua
+return {
+  scroll_tabs = true,
+}
+```

--- a/wezterm-gui/src/termwindow/mouseevent.rs
+++ b/wezterm-gui/src/termwindow/mouseevent.rs
@@ -446,7 +446,7 @@ impl super::TermWindow {
                 TabBarItem::Tab { .. } | TabBarItem::NewTabButton { .. } => {}
             },
             WMEK::VertWheel(n) => {
-                if self.config.scroll_tabs {
+                if self.config.mouse_wheel_scrolls_tabs {
                     self.activate_tab_relative(if n < 1 { 1 } else { -1 }, true)
                         .ok();
                 }

--- a/wezterm-gui/src/termwindow/mouseevent.rs
+++ b/wezterm-gui/src/termwindow/mouseevent.rs
@@ -446,8 +446,10 @@ impl super::TermWindow {
                 TabBarItem::Tab { .. } | TabBarItem::NewTabButton { .. } => {}
             },
             WMEK::VertWheel(n) => {
-                self.activate_tab_relative(if n < 1 { 1 } else { -1 }, true)
-                    .ok();
+                if self.config.scroll_tabs {
+                    self.activate_tab_relative(if n < 1 { 1 } else { -1 }, true)
+                        .ok();
+                }
             }
             _ => {}
         }


### PR DESCRIPTION
Adds a boolean config option ~~`scroll_tabs`~~ `mouse_wheel_scrolls_tabs`, defaulting to true, controlling whether using the mouse wheel on the tab bar will switch between tabs. 

Closes https://github.com/wez/wezterm/issues/2938