### PR TITLE
build(pty): don't use `std::os::fd::RawFd` symbol directly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3684,7 +3684,7 @@ dependencies = [
 
 [[package]]
 name = "portable-pty"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "bitflags",

--- a/pty/Cargo.toml
+++ b/pty/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "portable-pty"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["Wez Furlong"]
 edition = "2018"
 repository = "https://github.com/wez/wezterm"

--- a/pty/src/lib.rs
+++ b/pty/src/lib.rs
@@ -111,7 +111,7 @@ pub trait MasterPty {
     /// associated with the stream. This is to enable applications that
     /// "know things" to query similar information for themselves.
     #[cfg(unix)]
-    fn as_raw_fd(&self) -> Option<std::os::fd::RawFd>;
+    fn as_raw_fd(&self) -> Option<unix::RawFd>;
 
     /// If applicable to the type of the tty, return the termios
     /// associated with the stream

--- a/pty/src/serial.rs
+++ b/pty/src/serial.rs
@@ -242,7 +242,7 @@ impl MasterPty for Master {
     }
 
     #[cfg(unix)]
-    fn as_raw_fd(&self) -> Option<std::os::fd::RawFd> {
+    fn as_raw_fd(&self) -> Option<crate::unix::RawFd> {
         None
     }
 }

--- a/pty/src/unix.rs
+++ b/pty/src/unix.rs
@@ -6,9 +6,11 @@ use filedescriptor::FileDescriptor;
 use libc::{self, winsize};
 use std::cell::RefCell;
 use std::io::{Read, Write};
-use std::os::unix::io::{AsRawFd, FromRawFd, RawFd};
+use std::os::unix::io::{AsRawFd, FromRawFd};
 use std::os::unix::process::CommandExt;
 use std::{io, mem, ptr};
+
+pub use std::os::unix::io::RawFd;
 
 #[derive(Default)]
 pub struct UnixPtySystem {}
@@ -323,7 +325,7 @@ impl MasterPty for UnixMasterPty {
         Ok(Box::new(UnixMasterWriter { fd }))
     }
 
-    fn as_raw_fd(&self) -> Option<std::os::fd::RawFd> {
+    fn as_raw_fd(&self) -> Option<RawFd> {
         Some(self.fd.0.as_raw_fd())
     }
 


### PR DESCRIPTION
For whatever reason, `portable-pty` doesn't build until Rust v1.66 due to a failure to import `std::os::fd::RawFd`. According to `cargo-msrv`:

```
$ cargo msrv --linear
Fetching index
Determining the Minimum Supported Rust Version (MSRV) for toolchain aarch64-apple-darwin
Using check command cargo check
 ⠲ Checking 1.68.0                ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░
 ⠴ Checking 1.68.0                ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░
Check for toolchain '1.68.0-aarch64-apple-darwin' succeeded
Check for toolchain '1.67.1-aarch64-apple-darwin' succeeded
Check for toolchain '1.66.1-aarch64-apple-darwin' succeeded

Check for toolchain '1.65.0-aarch64-apple-darwin' failed with:
┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│ Compiling libc v0.2.139                                                                                                               │
│    Compiling autocfg v1.1.0                                                                                                           │
│     Checking cfg-if v1.0.0                                                                                                            │
│    Compiling proc-macro2 v1.0.51                                                                                                      │
│    Compiling quote v1.0.23                                                                                                            │
│    Compiling syn v1.0.109                                                                                                             │
│    Compiling unicode-ident v1.0.8                                                                                                     │
│    Compiling version_check v0.9.4                                                                                                     │
│    Compiling pkg-config v0.3.26                                                                                                       │
│    Compiling memchr v2.5.0                                                                                                            │
│     Checking bitflags v1.3.2                                                                                                          │
│     Checking once_cell v1.17.1                                                                                                        │
│    Compiling log v0.4.17                                                                                                              │
│    Compiling num-traits v0.2.15                                                                                                       │
│    Compiling futures-core v0.3.26                                                                                                     │
│    Compiling crossbeam-utils v0.8.15                                                                                                  │
│    Compiling serde_derive v1.0.152                                                                                                    │
│    Compiling thiserror v1.0.39                                                                                                        │
│    Compiling serde v1.0.152                                                                                                           │
│    Compiling jobserver v0.1.26                                                                                                        │
│     Checking pin-project-lite v0.2.9                                                                                                  │
│    Compiling cc v1.0.79                                                                                                               │
│     Checking getrandom v0.2.8                                                                                                         │
│     Checking scopeguard v1.1.0                                                                                                        │
│    Compiling ahash v0.7.6                                                                                                             │
│     Checking futures-sink v0.3.26                                                                                                     │
│     Checking futures-io v0.3.26                                                                                                       │
│    Compiling slab v0.4.8                                                                                                              │
│     Checking lazy_static v1.4.0                                                                                                       │
│    Compiling lock_api v0.4.9                                                                                                          │
│     Checking smallvec v1.10.0                                                                                                         │
│     Checking num_cpus v1.15.0                                                                                                         │
│    Compiling num-integer v0.1.45                                                                                                      │
│    Compiling siphasher v0.3.10                                                                                                        │
│    Compiling rand_core v0.6.4                                                                                                         │
│     Checking fastrand v1.9.0                                                                                                          │
│    Compiling rand v0.8.5                                                                                                              │
│    Compiling phf_shared v0.11.1                                                                                                       │
│    Compiling memoffset v0.8.0                                                                                                         │
│     Checking adler v1.0.2                                                                                                             │
│     Checking pin-utils v0.1.0                                                                                                         │
│    Compiling indexmap v1.9.2                                                                                                          │
│    Compiling futures-channel v0.3.26                                                                                                  │
│    Compiling libz-sys v1.1.8                                                                                                          │
│    Compiling anyhow v1.0.69                                                                                                           │
│     Checking hashbrown v0.12.3                                                                                                        │
│    Compiling phf_generator v0.11.1                                                                                                    │
│    Compiling futures-task v0.3.26                                                                                                     │
│     Checking miniz_oxide v0.6.2                                                                                                       │
│     Checking socket2 v0.4.9                                                                                                           │
│    Compiling crossbeam-epoch v0.9.14                                                                                                  │
│    Compiling futures-util v0.3.26                                                                                                     │
│    Compiling crc32fast v1.3.2                                                                                                         │
│     Checking strsim v0.10.0                                                                                                           │
│     Checking crossbeam-channel v0.5.7                                                                                                 │
│     Checking fnv v1.0.7                                                                                                               │
│    Compiling typenum v1.16.0                                                                                                          │
│    Compiling memoffset v0.6.5                                                                                                         │
│     Checking event-listener v2.5.3                                                                                                    │
│     Checking byteorder v1.4.3                                                                                                         │
│     Checking concurrent-queue v2.1.0                                                                                                  │
│     Checking parking v2.0.0                                                                                                           │
│    Compiling rayon-core v1.11.0                                                                                                       │
│     Checking waker-fn v1.1.0                                                                                                          │
│     Checking async-lock v2.7.0                                                                                                        │
│     Checking futures-lite v1.12.0                                                                                                     │
│     Checking signal-hook-registry v1.4.1                                                                                              │
│     Checking crossbeam-deque v0.8.3                                                                                                   │
│    Compiling generic-array v0.14.6                                                                                                    │
│     Checking flate2 v1.0.25                                                                                                           │
│     Checking spin v0.9.5                                                                                                              │
│     Checking nanorand v0.7.0                                                                                                          │
│     Checking aho-corasick v0.7.20                                                                                                     │
│    Compiling polling v2.5.2                                                                                                           │
│     Checking regex-syntax v0.6.28                                                                                                     │
│    Compiling ucd-trie v0.1.5                                                                                                          │
│     Checking either v1.8.1                                                                                                            │
│    Compiling phf_codegen v0.11.1                                                                                                      │
│    Compiling lua-src v544.0.1                                                                                                         │
│    Compiling luajit-src v210.4.5+resty2cf5186                                                                                         │
│    Compiling nom v5.1.2                                                                                                               │
│    Compiling num-rational v0.4.1                                                                                                      │
│     Checking rayon v1.7.0                                                                                                             │
│    Compiling async-io v1.12.0                                                                                                         │
│     Checking weezl v0.1.7                                                                                                             │
│     Checking regex-automata v0.1.10                                                                                                   │
│     Checking async-task v4.3.0                                                                                                        │
│     Checking simd-adler32 v0.3.4                                                                                                      │
│    Compiling core-foundation-sys v0.8.3                                                                                               │
│     Checking base64 v0.21.0                                                                                                           │
│     Checking tinyvec_macros v0.1.1                                                                                                    │
│     Checking rustc-hash v1.1.0                                                                                                        │
│     Checking lab v0.11.0                                                                                                              │
│    Compiling tinyvec v1.6.0                                                                                                           │
│     Checking zune-inflate v0.2.50                                                                                                     │
│    Compiling mlua v0.8.8                                                                                                              │
│     Checking regex v1.7.1                                                                                                             │
│    Compiling terminfo v0.7.5                                                                                                          │
│     Checking png v0.17.7                                                                                                              │
│     Checking threadpool v1.8.1                                                                                                        │
│     Checking dirs-sys v0.3.7                                                                                                          │
│     Checking percent-encoding v2.2.0                                                                                                  │
│     Checking half v2.2.1                                                                                                              │
│     Checking lebe v0.5.2                                                                                                              │
│     Checking color_quant v1.1.0                                                                                                       │
│     Checking bit_field v0.10.2                                                                                                        │
│     Checking form_urlencoded v1.1.0                                                                                                   │
│     Checking gif v0.11.4                                                                                                              │
│     Checking unicode-normalization v0.1.22                                                                                            │
│     Checking dirs v4.0.0                                                                                                              │
│     Checking jpeg-decoder v0.3.0                                                                                                      │
│     Checking block-buffer v0.9.0                                                                                                      │
│     Checking digest v0.9.0                                                                                                            │
│     Checking async-channel v1.8.0                                                                                                     │
│     Checking phf_shared v0.10.0                                                                                                       │
│    Compiling libgit2-sys v0.14.2+1.5.1                                                                                                │
│     Checking cpufeatures v0.2.5                                                                                                       │
│     Checking unicode-bidi v0.3.10                                                                                                     │
│     Checking utf8parse v0.2.0                                                                                                         │
│     Checking opaque-debug v0.3.0                                                                                                      │
│    Compiling thiserror-impl v1.0.39                                                                                                   │
│    Compiling futures-macro v0.3.26                                                                                                    │
│    Compiling wezterm-dynamic-derive v0.1.0 (/Users/waleed/Workspace/wezterm/wezterm-dynamic/derive)                                   │
│    Compiling bytemuck_derive v1.4.0                                                                                                   │
│    Compiling phf_macros v0.11.1                                                                                                       │
│    Compiling pin-project-internal v1.0.12                                                                                             │
│     Checking tiff v0.8.1                                                                                                              │
│    Compiling signal-hook v0.3.15                                                                                                      │
│     Checking deltae v0.3.0                                                                                                            │
│     Checking scoped_threadpool v0.1.9                                                                                                 │
│     Checking atomic-waker v1.1.0                                                                                                      │
│     Checking blocking v1.3.0                                                                                                          │
│     Checking bytemuck v1.13.1                                                                                                         │
│     Checking phf v0.11.1                                                                                                              │
│    Compiling idna v0.3.0                                                                                                              │
│     Checking csscolorparser v0.6.2                                                                                                    │
│     Checking pin-project v1.0.12                                                                                                      │
│     Checking filedescriptor v0.8.2 (/Users/waleed/Workspace/wezterm/filedescriptor)                                                   │
│    Compiling pest v2.5.6                                                                                                              │
│     Checking flume v0.10.14                                                                                                           │
│     Checking sha2 v0.9.9                                                                                                              │
│     Checking exr v1.5.3                                                                                                               │
│     Checking vtparse v0.6.2 (/Users/waleed/Workspace/wezterm/vtparse)                                                                 │
│    Compiling num-derive v0.3.3                                                                                                        │
│     Checking phf v0.10.1                                                                                                              │
│     Checking nix v0.24.3                                                                                                              │
│     Checking signal-hook v0.1.17                                                                                                      │
│     Checking termios v0.3.3                                                                                                           │
│     Checking serial-core v0.4.0                                                                                                       │
│     Checking ioctl-rs v0.1.6                                                                                                          │
│     Checking termios v0.2.2                                                                                                           │
│    Compiling async-net v1.7.0                                                                                                         │
│     Checking semver-parser v0.10.2                                                                                                    │
│    Compiling async-process v1.6.0                                                                                                     │
│    Compiling pest_meta v2.5.6                                                                                                         │
│    Compiling async-fs v1.6.0                                                                                                          │
│     Checking semver v0.11.0                                                                                                           │
│     Checking memmem v0.1.1                                                                                                            │
│     Checking unicode-segmentation v1.10.1                                                                                             │
│     Checking finl_unicode v1.2.0                                                                                                      │
│     Checking fixedbitset v0.4.2                                                                                                       │
│     Checking hex v0.4.3                                                                                                               │
│     Checking same-file v1.0.6                                                                                                         │
│     Checking walkdir v2.3.2                                                                                                           │
│     Checking serial-unix v0.4.0                                                                                                       │
│    Compiling pest_generator v2.5.6                                                                                                    │
│     Checking url v2.3.1                                                                                                               │
│     Checking image v0.24.5                                                                                                            │
│     Checking async-executor v1.5.0                                                                                                    │
│     Checking bstr v0.2.17                                                                                                             │
│    Compiling miniz_oxide v0.4.4                                                                                                       │
│     Checking serial v0.4.0                                                                                                            │
│     Checking nix v0.25.1                                                                                                              │
│     Checking euclid v0.22.7                                                                                                           │
│     Checking dirs-sys-next v0.1.2                                                                                                     │
│     Checking filetime v0.2.20                                                                                                         │
│     Checking winnow v0.3.4                                                                                                            │
│     Checking downcast-rs v1.2.0                                                                                                       │
│     Checking shell-words v1.1.0                                                                                                       │
│     Checking dirs-next v2.0.0                                                                                                         │
│     Checking smol v1.3.0                                                                                                              │
│     Checking lru v0.7.8                                                                                                               │
│     Checking fsevent-sys v4.1.0                                                                                                       │
│     Checking match_cfg v0.1.0                                                                                                         │
│    Compiling pest_derive v2.5.6                                                                                                       │
│     Checking promise v0.2.0 (/Users/waleed/Workspace/wezterm/promise)                                                                 │
│     Checking hostname v0.3.1                                                                                                          │
│     Checking notify v5.1.0                                                                                                            │
│     Checking colorgrad v0.6.2                                                                                                         │
│    Compiling enum-display-derive v0.1.1                                                                                               │
│    Compiling wezterm-config-derive v0.1.0 (/Users/waleed/Workspace/wezterm/config/derive)                                             │
│     Checking umask v0.1.0 (/Users/waleed/Workspace/wezterm/umask)                                                                     │
│     Checking shlex v1.1.0                                                                                                             │
│    Compiling openssl-src v300.0.12+3.0.8                                                                                              │
│     Checking foreign-types-shared v0.1.1                                                                                              │
│     Checking itoa v1.0.6                                                                                                              │
│     Checking foreign-types v0.3.2                                                                                                     │
│    Compiling io-lifetimes v1.0.5                                                                                                      │
│    Compiling rustix v0.36.9                                                                                                           │
│     Checking errno v0.2.8                                                                                                             │
│    Compiling openssl-sys v0.9.71                                                                                                      │
│     Checking ordered-float v3.4.0                                                                                                     │
│     Checking toml_datetime v0.6.1                                                                                                     │
│     Checking serde_spanned v0.6.1                                                                                                     │
│    Compiling objc_exception v0.1.2                                                                                                    │
│     Checking wezterm-dynamic v0.1.0 (/Users/waleed/Workspace/wezterm/wezterm-dynamic)                                                 │
│     Checking toml_edit v0.19.4                                                                                                        │
│     Checking portable-pty v0.8.0 (/Users/waleed/Workspace/wezterm/pty)                                                                │
│ error[E0412]: cannot find type `RawFd` in `std::os::fd`                                                                               │
│    --> pty/src/unix.rs:326:48                                                                                                         │
│     |                                                                                                                                 │
│ 326 |     fn as_raw_fd(&self) -> Option<std::os::fd::RawFd> {                                                                         │
│     |                                                ^^^^^ not found in `std::os::fd`                                                 │
│     |                                                                                                                                 │
│ help: consider importing this type alias                                                                                              │
│     |                                                                                                                                 │
│ 3   | use std::os::unix::prelude::RawFd;                                                                                              │
│     |                                                                                                                                 │
│ help: if you import `RawFd`, refer to it directly                                                                                     │
│     |                                                                                                                                 │
│ 326 -     fn as_raw_fd(&self) -> Option<std::os::fd::RawFd> {                                                                         │
│ 326 +     fn as_raw_fd(&self) -> Option<RawFd> {                                                                                      │
│     |                                                                                                                                 │
│                                                                                                                                       │
│ error[E0412]: cannot find type `RawFd` in `std::os::fd`                                                                               │
│    --> pty/src/serial.rs:245:48                                                                                                       │
│     |                                                                                                                                 │
│ 245 |     fn as_raw_fd(&self) -> Option<std::os::fd::RawFd> {                                                                         │
│     |                                                ^^^^^ not found in `std::os::fd`                                                 │
│     |                                                                                                                                 │
│ help: consider importing this type alias                                                                                              │
│     |                                                                                                                                 │
│ 8   | use std::os::unix::prelude::RawFd;                                                                                              │
│     |                                                                                                                                 │
│ help: if you import `RawFd`, refer to it directly                                                                                     │
│     |                                                                                                                                 │
│ 245 -     fn as_raw_fd(&self) -> Option<std::os::fd::RawFd> {                                                                         │
│ 245 +     fn as_raw_fd(&self) -> Option<RawFd> {                                                                                      │
│     |                                                                                                                                 │
│                                                                                                                                       │
│ error[E0412]: cannot find type `RawFd` in `std::os::fd`                                                                               │
│    --> pty/src/lib.rs:114:48                                                                                                          │
│     |                                                                                                                                 │
│ 114 |     fn as_raw_fd(&self) -> Option<std::os::fd::RawFd>;                                                                          │
│     |                                                ^^^^^ not found in `std::os::fd`                                                 │
│     |                                                                                                                                 │
│ help: consider importing this type alias                                                                                              │
│     |                                                                                                                                 │
│ 40  | use std::os::unix::prelude::RawFd;                                                                                              │
│     |                                                                                                                                 │
│ help: if you import `RawFd`, refer to it directly                                                                                     │
│     |                                                                                                                                 │
│ 114 -     fn as_raw_fd(&self) -> Option<std::os::fd::RawFd>;                                                                          │
│ 114 +     fn as_raw_fd(&self) -> Option<RawFd>;                                                                                       │
│     |                                                                                                                                 │
│                                                                                                                                       │
│ error[E0603]: module `fd` is private                                                                                                  │
│    --> pty/src/unix.rs:326:44                                                                                                         │
│     |                                                                                                                                 │
│ 326 |     fn as_raw_fd(&self) -> Option<std::os::fd::RawFd> {                                                                         │
│     |                                            ^^ private module                                                                    │
│     |                                                                                                                                 │
│ note: the module `fd` is defined here                                                                                                 │
│                                                                                                                                       │
│ error[E0603]: module `fd` is private                                                                                                  │
│    --> pty/src/serial.rs:245:44                                                                                                       │
│     |                                                                                                                                 │
│ 245 |     fn as_raw_fd(&self) -> Option<std::os::fd::RawFd> {                                                                         │
│     |                                            ^^ private module                                                                    │
│     |                                                                                                                                 │
│ note: the module `fd` is defined here                                                                                                 │
│                                                                                                                                       │
│ error[E0603]: module `fd` is private                                                                                                  │
│    --> pty/src/lib.rs:114:44                                                                                                          │
│     |                                                                                                                                 │
│ 114 |     fn as_raw_fd(&self) -> Option<std::os::fd::RawFd>;                                                                          │
│     |                                            ^^ private module                                                                    │
│     |                                                                                                                                 │
│ note: the module `fd` is defined here                                                                                                 │
│                                                                                                                                       │
│     Checking wezterm-color-types v0.2.0 (/Users/waleed/Workspace/wezterm/color-types)                                                 │
│     Checking wezterm-bidi v0.2.2 (/Users/waleed/Workspace/wezterm/bidi)                                                               │
│ Some errors have detailed explanations: E0412, E0603.                                                                                 │
│ For more information about an error, try `rustc --explain E0412`.                                                                     │
│ error: could not compile `portable-pty` due to 6 previous errors                                                                      │
│ warning: build failed, waiting for other jobs to finish...                                                                            │
└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
   Finished The MSRV is: 1.66.1   ██████████████████████████████████████████████████████████████████████████████████████████████ 00:05:30
```

However, the issue is simple to work around: just don't use the symbol `std::os::fd::RawFd` directly. This commit:

1) changes the interface to use a new exported symbol `RawFd` from the `crate::unix` module;
2) imports `std::os::unix::io::RawFd` instead of `std::os::fd::RawFd` as the symbol exported from `crate::unix`.

Doing so fixes the build in earlier versions of Rust:

```
$ cargo +1.63.0 check -p portable-pty --all-targets
    Checking portable-pty v0.8.0 (/Users/waleed/Workspace/wezterm/pty)
error[E0412]: cannot find type `RawFd` in `std::os::fd`
   --> pty/src/unix.rs:326:48
    |
326 |     fn as_raw_fd(&self) -> Option<std::os::fd::RawFd> {
    |                                                ^^^^^ not found in `std::os::fd`
    |
help: consider importing this type alias
    |
3   | use std::os::unix::prelude::RawFd;
    |
help: if you import `RawFd`, refer to it directly
    |
326 -     fn as_raw_fd(&self) -> Option<std::os::fd::RawFd> {
326 +     fn as_raw_fd(&self) -> Option<RawFd> {
    |

error[E0412]: cannot find type `RawFd` in `std::os::fd`
   --> pty/src/serial.rs:245:48
    |
245 |     fn as_raw_fd(&self) -> Option<std::os::fd::RawFd> {
    |                                                ^^^^^ not found in `std::os::fd`
    |
help: consider importing this type alias
    |
8   | use std::os::unix::prelude::RawFd;
    |
help: if you import `RawFd`, refer to it directly
    |
245 -     fn as_raw_fd(&self) -> Option<std::os::fd::RawFd> {
245 +     fn as_raw_fd(&self) -> Option<RawFd> {
    |

error[E0412]: cannot find type `RawFd` in `std::os::fd`
   --> pty/src/lib.rs:114:48
    |
114 |     fn as_raw_fd(&self) -> Option<std::os::fd::RawFd>;
    |                                                ^^^^^ not found in `std::os::fd`
    |
help: consider importing this type alias
    |
40  | use std::os::unix::prelude::RawFd;
    |
help: if you import `RawFd`, refer to it directly
    |
114 -     fn as_raw_fd(&self) -> Option<std::os::fd::RawFd>;
114 +     fn as_raw_fd(&self) -> Option<RawFd>;
    |

error[E0603]: module `fd` is private
   --> pty/src/unix.rs:326:44
    |
326 |     fn as_raw_fd(&self) -> Option<std::os::fd::RawFd> {
    |                                            ^^ private module
    |
note: the module `fd` is defined here

error[E0603]: module `fd` is private
   --> pty/src/serial.rs:245:44
    |
245 |     fn as_raw_fd(&self) -> Option<std::os::fd::RawFd> {
    |                                            ^^ private module
    |
note: the module `fd` is defined here

error[E0603]: module `fd` is private
   --> pty/src/lib.rs:114:44
    |
114 |     fn as_raw_fd(&self) -> Option<std::os::fd::RawFd>;
    |                                            ^^ private module
    |
note: the module `fd` is defined here

Some errors have detailed explanations: E0412, E0603.
For more information about an error, try `rustc --explain E0412`.
error: could not compile `portable-pty` due to 6 previous errors
warning: build failed, waiting for other jobs to finish...
error: could not compile `portable-pty` due to 6 previous errors

$ cargo +1.63.0 check -p portable-pty --all-targets
    Finished dev [unoptimized + debuginfo] target(s) in 0.17s
```
