### PR TITLE
fix(clippy): Derive Default where possible

### DIFF
--- a/config/src/background.rs
+++ b/config/src/background.rs
@@ -290,31 +290,21 @@ impl Default for BackgroundOrigin {
     }
 }
 
-#[derive(Debug, Copy, Clone, FromDynamic, ToDynamic, PartialEq)]
+#[derive(Debug, Copy, Clone, FromDynamic, ToDynamic, PartialEq, Default)]
 pub enum Interpolation {
+    #[default]
     Linear,
     Basis,
     CatmullRom,
 }
 
-impl Default for Interpolation {
-    fn default() -> Self {
-        Interpolation::Linear
-    }
-}
-
-#[derive(Debug, Copy, Clone, FromDynamic, ToDynamic, PartialEq)]
+#[derive(Debug, Copy, Clone, FromDynamic, ToDynamic, PartialEq, Default)]
 pub enum BlendMode {
+    #[default]
     Rgb,
     LinearRgb,
     Hsv,
     Oklab,
-}
-
-impl Default for BlendMode {
-    fn default() -> Self {
-        BlendMode::Rgb
-    }
 }
 
 #[derive(Debug, Copy, Clone, FromDynamic, ToDynamic, PartialEq)]

--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -1572,20 +1572,15 @@ fn default_inactive_pane_hsb() -> HsbTransform {
     }
 }
 
-#[derive(FromDynamic, ToDynamic, Clone, Copy, Debug)]
+#[derive(FromDynamic, ToDynamic, Clone, Copy, Debug, Default)]
 pub enum DefaultCursorStyle {
     BlinkingBlock,
+    #[default]
     SteadyBlock,
     BlinkingUnderline,
     SteadyUnderline,
     BlinkingBar,
     SteadyBar,
-}
-
-impl Default for DefaultCursorStyle {
-    fn default() -> Self {
-        DefaultCursorStyle::SteadyBlock
-    }
 }
 
 impl DefaultCursorStyle {
@@ -1648,18 +1643,13 @@ pub enum NewlineCanon {
     CarriageReturnAndLineFeed,
 }
 
-#[derive(FromDynamic, ToDynamic, Clone, Copy, Debug)]
+#[derive(FromDynamic, ToDynamic, Clone, Copy, Debug, Default)]
 pub enum WindowCloseConfirmation {
+    #[default]
     AlwaysPrompt,
     NeverPrompt,
     // TODO: something smart where we see whether the
     // running programs are stateful
-}
-
-impl Default for WindowCloseConfirmation {
-    fn default() -> Self {
-        WindowCloseConfirmation::AlwaysPrompt
-    }
 }
 
 struct PathPossibility {
@@ -1682,20 +1672,15 @@ impl PathPossibility {
 }
 
 /// Behavior when the program spawned by wezterm terminates
-#[derive(Debug, FromDynamic, ToDynamic, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, FromDynamic, ToDynamic, Clone, Copy, PartialEq, Eq, Default)]
 pub enum ExitBehavior {
     /// Close the associated pane
+    #[default]
     Close,
     /// Close the associated pane if the process was successful
     CloseOnCleanExit,
     /// Hold the pane until it is explicitly closed
     Hold,
-}
-
-impl Default for ExitBehavior {
-    fn default() -> Self {
-        ExitBehavior::Close
-    }
 }
 
 #[derive(Debug, FromDynamic, ToDynamic, Clone, Copy, PartialEq, Eq)]
@@ -1762,11 +1747,12 @@ fn default_line_to_ele_shape_cache_size() -> usize {
     1024
 }
 
-#[derive(Debug, ToDynamic, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, ToDynamic, Clone, Copy, PartialEq, Eq, Default)]
 pub enum BoldBrightening {
     /// Bold doesn't influence palette selection
     No,
     /// Bold Shifts palette from 0-7 to 8-15 and preserves bold font
+    #[default]
     BrightAndBold,
     /// Bold Shifts palette from 0-7 to 8-15 and removes bold intensity
     BrightOnly,
@@ -1795,24 +1781,13 @@ impl FromDynamic for BoldBrightening {
     }
 }
 
-impl Default for BoldBrightening {
-    fn default() -> Self {
-        BoldBrightening::BrightAndBold
-    }
-}
-
-#[derive(Debug, FromDynamic, ToDynamic, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, FromDynamic, ToDynamic, Clone, Copy, PartialEq, Eq, Default)]
 pub enum ImePreeditRendering {
     /// IME preedit is rendered by WezTerm itself
+    #[default]
     Builtin,
     /// IME preedit is rendered by system
     System,
-}
-
-impl Default for ImePreeditRendering {
-    fn default() -> Self {
-        ImePreeditRendering::Builtin
-    }
 }
 
 fn validate_row_or_col(value: &u16) -> Result<(), String> {

--- a/config/src/font.rs
+++ b/config/src/font.rs
@@ -662,27 +662,17 @@ impl Default for FontLocatorSelection {
     }
 }
 
-#[derive(Debug, Clone, Copy, FromDynamic, ToDynamic)]
+#[derive(Debug, Clone, Copy, FromDynamic, ToDynamic, Default)]
 pub enum FontRasterizerSelection {
+    #[default]
     FreeType,
 }
 
-impl Default for FontRasterizerSelection {
-    fn default() -> Self {
-        FontRasterizerSelection::FreeType
-    }
-}
-
-#[derive(Debug, Clone, Copy, FromDynamic, ToDynamic)]
+#[derive(Debug, Clone, Copy, FromDynamic, ToDynamic, Default)]
 pub enum FontShaperSelection {
     Allsorts,
+    #[default]
     Harfbuzz,
-}
-
-impl Default for FontShaperSelection {
-    fn default() -> Self {
-        FontShaperSelection::Harfbuzz
-    }
 }
 
 #[cfg(test)]

--- a/config/src/frontend.rs
+++ b/config/src/frontend.rs
@@ -1,17 +1,12 @@
 use luahelper::impl_lua_conversion_dynamic;
 use wezterm_dynamic::{FromDynamic, ToDynamic};
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, FromDynamic, ToDynamic)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, FromDynamic, ToDynamic, Default)]
 pub enum FrontEndSelection {
+    #[default]
     OpenGL,
     WebGpu,
     Software,
-}
-
-impl Default for FrontEndSelection {
-    fn default() -> Self {
-        FrontEndSelection::OpenGL
-    }
 }
 
 /// Corresponds to <https://docs.rs/wgpu/latest/wgpu/struct.AdapterInfo.html>

--- a/wezterm-dynamic/src/fromdynamic.rs
+++ b/wezterm-dynamic/src/fromdynamic.rs
@@ -7,20 +7,15 @@ use std::hash::Hash;
 
 /// Specify how FromDynamic will treat unknown fields
 /// when converting from Value to a given target type
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Default)]
 pub enum UnknownFieldAction {
     /// Don't check, don't warn, don't raise an error
     Ignore,
     /// Emit a log::warn log
+    #[default]
     Warn,
     /// Return an Error
     Deny,
-}
-
-impl Default for UnknownFieldAction {
-    fn default() -> UnknownFieldAction {
-        UnknownFieldAction::Warn
-    }
 }
 
 /// Specify various options for FromDynamic::from_dynamic

--- a/window/src/os/wayland/frame.rs
+++ b/window/src/os/wayland/frame.rs
@@ -40,7 +40,7 @@ const BORDER_SIZE: u32 = 12;
 const HEADER_SIZE: u32 = 30;
 
 /// Configuration for ConceptFrame
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct ConceptConfig {
     pub font_config: Option<Rc<FontConfiguration>>,
     pub config: Option<ConfigHandle>,
@@ -53,16 +53,6 @@ impl ConceptConfig {
             .as_ref()
             .map(|c| &c.window_frame)
             .unwrap_or(&self.default_frame)
-    }
-}
-
-impl Default for ConceptConfig {
-    fn default() -> ConceptConfig {
-        ConceptConfig {
-            font_config: None,
-            default_frame: WindowFrameConfig::default(),
-            config: None,
-        }
     }
 }
 


### PR DESCRIPTION
Apply clippy fixes that derive `Default` instead of manually implementing it.