### PR TITLE
fix(clippy): Remove unnecessary clone/to_string calls

### DIFF
--- a/config/src/color.rs
+++ b/config/src/color.rs
@@ -201,7 +201,7 @@ impl Palette {
             indexed: {
                 let mut map = self.indexed.clone();
                 for (k, v) in &other.indexed {
-                    map.insert(k.clone(), v.clone());
+                    map.insert(*k, *v);
                 }
                 map
             },

--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -1719,7 +1719,7 @@ impl DroppedFileQuoting {
             Self::None => s.to_string(),
             Self::SpacesOnly => s.replace(" ", "\\ "),
             // https://docs.rs/shlex/latest/shlex/fn.quote.html
-            Self::Posix => shlex::quote(s).into_owned().to_string(),
+            Self::Posix => shlex::quote(s).into_owned(),
             Self::Windows => {
                 let chars_need_quoting = [' ', '\t', '\n', '\x0b', '\"'];
                 if s.chars().any(|c| chars_need_quoting.contains(&c)) {

--- a/config/src/lua.rs
+++ b/config/src/lua.rs
@@ -397,7 +397,7 @@ fn shell_join_args<'lua>(_: &'lua Lua, args: Vec<String>) -> mlua::Result<String
 }
 
 fn shell_quote_arg<'lua>(_: &'lua Lua, arg: String) -> mlua::Result<String> {
-    Ok(shlex::quote(&arg).into_owned().to_string())
+    Ok(shlex::quote(&arg).into_owned())
 }
 
 /// Returns the system hostname.

--- a/lua-api-crates/color-funcs/src/schemes/base16.rs
+++ b/lua-api-crates/color-funcs/src/schemes/base16.rs
@@ -81,7 +81,7 @@ impl Base16Scheme {
             },
             metadata: ColorSchemeMetaData {
                 name: Some(scheme.scheme),
-                author: Some(scheme.author.clone()),
+                author: Some(scheme.author),
                 origin_url: None,
                 wezterm_version: None,
                 aliases: vec![],

--- a/lua-api-crates/json/src/lib.rs
+++ b/lua-api-crates/json/src/lib.rs
@@ -150,7 +150,7 @@ fn lua_value_to_json_value(value: LuaValue, visited: &mut HashSet<usize>) -> mlu
                         mlua::Error::FromLuaConversionError {
                             from: lua_type,
                             to: "value",
-                            message: Some(format!("while processing {key:?}: {}", e.to_string())),
+                            message: Some(format!("while processing {key:?}: {e}")),
                         }
                     })?;
                     obj.insert(key, value);

--- a/lua-api-crates/mux/src/tab.rs
+++ b/lua-api-crates/mux/src/tab.rs
@@ -39,7 +39,7 @@ impl UserData for MuxTab {
         methods.add_method("get_title", |_, this, _: ()| {
             let mux = get_mux()?;
             let tab = this.resolve(&mux)?;
-            Ok(tab.get_title().to_string())
+            Ok(tab.get_title())
         });
         methods.add_method("set_title", |_, this, title: String| {
             let mux = get_mux()?;

--- a/lua-api-crates/plugin/src/lib.rs
+++ b/lua-api-crates/plugin/src/lib.rs
@@ -101,7 +101,7 @@ impl RepoSpec {
         let mut merge_info = None;
         repo.fetchhead_foreach(|refname, _remote_url, target_oid, was_merge| {
             if was_merge {
-                merge_info.replace((refname.to_string(), target_oid.clone()));
+                merge_info.replace((refname.to_string(), *target_oid));
                 return true;
             }
             false

--- a/lua-api-crates/share-data/src/lib.rs
+++ b/lua-api-crates/share-data/src/lib.rs
@@ -222,7 +222,7 @@ fn lua_value_to_gvalue_impl(value: LuaValue, visited: &mut HashSet<usize>) -> ml
                         mlua::Error::FromLuaConversionError {
                             from: lua_type,
                             to: "value",
-                            message: Some(format!("while processing {key:?}: {}", e.to_string())),
+                            message: Some(format!("while processing {key:?}: {e}")),
                         }
                     })?;
                     obj.insert(key, value);

--- a/luahelper/src/enumctor.rs
+++ b/luahelper/src/enumctor.rs
@@ -183,8 +183,7 @@ where
                 }
                 _ => {
                     // Must be a valid variant, but requires arguments
-                    let variant_ctor =
-                        lua.create_userdata(EnumVariant::<T>::new(field.to_string()))?;
+                    let variant_ctor = lua.create_userdata(EnumVariant::<T>::new(field))?;
                     Ok(Value::UserData(variant_ctor))
                 }
             }

--- a/luahelper/src/lib.rs
+++ b/luahelper/src/lib.rs
@@ -229,7 +229,7 @@ fn lua_value_to_dynamic_impl(
                         mlua::Error::FromLuaConversionError {
                             from: lua_type,
                             to: "value",
-                            message: Some(format!("while processing {key:?}: {}", e.to_string())),
+                            message: Some(format!("while processing {key:?}: {e}")),
                         }
                     })?;
                     obj.insert(key, value);

--- a/sync-color-schemes/src/sexy.rs
+++ b/sync-color-schemes/src/sexy.rs
@@ -16,7 +16,7 @@ where
     apply_nightly_version(&mut scheme.metadata);
 
     Ok(Scheme {
-        name: name.clone(),
+        name,
         file_name: None,
         data: scheme,
     })

--- a/term/src/terminalstate/mod.rs
+++ b/term/src/terminalstate/mod.rs
@@ -2017,7 +2017,7 @@ impl TerminalState {
         {
             let bidi_mode = self.get_bidi_mode();
             let screen = self.screen_mut();
-            for y in row_range.clone() {
+            for y in row_range {
                 screen.clear_line(y, col_range.clone(), &pen, seqno, bidi_mode);
                 let line_idx = screen.phys_row(y);
                 screen.line_mut(line_idx).set_single_width(seqno);
@@ -2098,7 +2098,7 @@ impl TerminalState {
                 };
 
                 self.screen_mut()
-                    .clear_line(cy, range.clone(), &pen, seqno, bidi_mode);
+                    .clear_line(cy, range, &pen, seqno, bidi_mode);
             }
             Edit::InsertCharacter(n) => {
                 // https://vt100.net/docs/vt510-rm/ICH.html

--- a/term/src/terminalstate/mouse.rs
+++ b/term/src/terminalstate/mouse.rs
@@ -260,7 +260,7 @@ impl TerminalState {
                 }
                 _ => {}
             }
-            self.last_mouse_move.replace(event.clone());
+            self.last_mouse_move.replace(event);
 
             let (button, _button) = self.mouse_report_button_number(&event);
             let button = 32 + button;

--- a/term/src/terminalstate/performer.rs
+++ b/term/src/terminalstate/performer.rs
@@ -703,7 +703,7 @@ impl<'a> Performer<'a> {
                 if title.is_empty() {
                     self.icon_title = None;
                 } else {
-                    self.icon_title = Some(title.clone());
+                    self.icon_title = Some(title);
                 }
                 let title = self.icon_title.clone();
                 if let Some(handler) = self.alert_handler.as_mut() {
@@ -715,7 +715,7 @@ impl<'a> Performer<'a> {
                 self.title = title.clone();
                 if let Some(handler) = self.alert_handler.as_mut() {
                     handler.alert(Alert::WindowTitleChanged(title.clone()));
-                    handler.alert(Alert::IconTitleChanged(Some(title.clone())));
+                    handler.alert(Alert::IconTitleChanged(Some(title)));
                 }
             }
 
@@ -723,7 +723,7 @@ impl<'a> Performer<'a> {
             | OperatingSystemCommand::SetWindowTitle(title) => {
                 self.title = title.clone();
                 if let Some(handler) = self.alert_handler.as_mut() {
-                    handler.alert(Alert::WindowTitleChanged(title.clone()));
+                    handler.alert(Alert::WindowTitleChanged(title));
                 }
             }
             OperatingSystemCommand::SetHyperlink(link) => {

--- a/umask/src/lib.rs
+++ b/umask/src/lib.rs
@@ -40,7 +40,7 @@ impl UmaskSaver {
     /// used in a program.
     #[cfg(unix)]
     pub fn saved_umask() -> Option<mode_t> {
-        SAVED_UMASK.lock().unwrap().clone()
+        *SAVED_UMASK.lock().unwrap()
     }
 }
 

--- a/wezterm-font/src/ftwrap.rs
+++ b/wezterm-font/src/ftwrap.rs
@@ -205,7 +205,7 @@ impl Face {
         if res != 0 {
             None
         } else {
-            Some(String::from_utf8_lossy(&buf).into_owned().to_string())
+            Some(String::from_utf8_lossy(&buf).into_owned())
         }
     }
 
@@ -612,7 +612,7 @@ impl Face {
     }
 
     pub fn set_transform(&mut self, matrix: Option<FT_Matrix>) {
-        let mut matrix = matrix.clone();
+        let mut matrix = matrix;
         unsafe {
             FT_Set_Transform(
                 self.face,

--- a/wezterm-font/src/parser.rs
+++ b/wezterm-font/src/parser.rs
@@ -70,7 +70,7 @@ impl Clone for ParsedFont {
             synthesize_dim: self.synthesize_dim,
             assume_emoji_presentation: self.assume_emoji_presentation,
             handle: self.handle.clone(),
-            cap_height: self.cap_height.clone(),
+            cap_height: self.cap_height,
             coverage: Mutex::new(self.coverage.lock().unwrap().clone()),
             pixel_sizes: self.pixel_sizes.clone(),
             harfbuzz_features: self.harfbuzz_features.clone(),

--- a/wezterm-font/src/shaper/harfbuzz.rs
+++ b/wezterm-font/src/shaper/harfbuzz.rs
@@ -701,7 +701,7 @@ impl FontShaper for HarfbuzzShaper {
             dpi,
         };
         if let Some(metrics) = self.metrics.borrow().get(&key) {
-            return Ok(metrics.clone());
+            return Ok(*metrics);
         }
 
         let scale = self.handles[font_idx].scale.unwrap_or(1.);
@@ -737,7 +737,7 @@ impl FontShaper for HarfbuzzShaper {
             metrics.force_y_adjust = diff;
         }
 
-        self.metrics.borrow_mut().insert(key, metrics.clone());
+        self.metrics.borrow_mut().insert(key, metrics);
 
         log::trace!(
             "metrics_for_idx={}, size={}, dpi={} -> {:?}",

--- a/wezterm-input-types/src/lib.rs
+++ b/wezterm-input-types/src/lib.rs
@@ -441,7 +441,7 @@ impl ToString for KeyCode {
         match self {
             Self::RawCode(n) => format!("raw:{}", n),
             Self::Char(c) => format!("mapped:{}", c),
-            Self::Physical(phys) => format!("{}", phys.to_string()),
+            Self::Physical(phys) => phys.to_string(),
             Self::Composed(s) => s.to_string(),
             Self::Numpad(n) => format!("Numpad{}", n),
             Self::Function(n) => format!("F{}", n),
@@ -965,7 +965,7 @@ impl PhysKeyCode {
     fn make_inv_map() -> HashMap<Self, String> {
         let mut map = HashMap::new();
         for (k, v) in PHYSKEYCODE_MAP.iter() {
-            map.insert(v.clone(), k.clone());
+            map.insert(*v, k.clone());
         }
         map
     }

--- a/wezterm/src/asciicast.rs
+++ b/wezterm/src/asciicast.rs
@@ -71,10 +71,10 @@ impl Header {
             config::wezterm_target_triple().to_string(),
         );
         if let Ok(shell) = std::env::var("SHELL") {
-            env.insert("SHELL".to_string(), shell.to_string());
+            env.insert("SHELL".to_string(), shell);
         }
         if let Ok(lang) = std::env::var("LANG") {
-            env.insert("LANG".to_string(), lang.to_string());
+            env.insert("LANG".to_string(), lang);
         }
 
         let palette: ColorPalette = config.resolved_palette.clone().into();
@@ -412,7 +412,7 @@ impl RecordCommand {
         }
 
         {
-            let tx = tx.clone();
+            let tx = tx;
             std::thread::spawn(move || -> anyhow::Result<()> {
                 let status = child.wait()?;
                 tx.send(Message::Terminated(status))?;
@@ -517,7 +517,7 @@ impl PlayCommand {
 
         {
             let mut stdin = tty.reader()?;
-            let tx = tx.clone();
+            let tx = tx;
             std::thread::spawn(move || -> anyhow::Result<()> {
                 let mut buf = [0u8; 8192];
                 loop {

--- a/window/src/connection.rs
+++ b/window/src/connection.rs
@@ -91,7 +91,7 @@ pub trait ConnectionOps {
                     GeometryOrigin::MainScreen => screens.main.rect,
                     GeometryOrigin::ActiveScreen => screens.active.rect,
                     GeometryOrigin::Named(name) => match screens.by_name.get(&name) {
-                        Some(info) => info.rect.clone(),
+                        Some(info) => info.rect,
                         None => {
                             log::error!(
                             "Requested display {} was not found; available displays are: {:?}. \

--- a/window/src/os/x11/keyboard.rs
+++ b/window/src/os/x11/keyboard.rs
@@ -294,7 +294,7 @@ impl Keyboard {
                 log::trace!("process_key_event: raw key was handled; not processing further");
 
                 if want_repeat {
-                    return Some(WindowKeyEvent::RawKeyEvent(raw_key_event.clone()));
+                    return Some(WindowKeyEvent::RawKeyEvent(raw_key_event));
                 }
                 return None;
             }


### PR DESCRIPTION
# Purpose

Implement clippy fixes that relate to allocations, by removing calls to `clone`, `to_string` and `format!` when unnecessary.

Sometimes `clone` is removed in favor of copy (`*my_var`), which does not reduce allocations (as clone would not have allocated anyways), but it makes it clear that no allocation is performed.

## Concerns

A lot of calls to `to_string` are passed directly to `format!`, ie. `format!("{}", e.to_string())`, is this intended?

## Tests

All tests pass locally (Linux).