### PR TITLE
fix: rewrite `.` when fetching path in lua `plugin` crate

### DIFF
--- a/lua-api-crates/plugin/src/lib.rs
+++ b/lua-api-crates/plugin/src/lib.rs
@@ -26,7 +26,10 @@ fn compute_repo_dir(url: &str) -> String {
             ':' => {
                 dir.push_str("sCs");
             }
-            '.' | '-' | '_' => dir.push(c),
+            '.' => {
+                dir.push_str("sDs");
+            }
+            '-' | '_' => dir.push(c),
             c if c.is_alphanumeric() => dir.push(c),
             c => dir.push_str(&format!("u{}", c as u32)),
         }
@@ -244,8 +247,8 @@ mod test {
         for (input, expect) in &[
             ("foo", "foo"),
             (
-                "github.com/wez/wezterm-plugins",
-                "github.comsZswezsZswezterm-plugins",
+                "githubsDscom/wez/wezterm-plugins",
+                "githubsDscomsZswezsZswezterm-plugins",
             ),
             ("localhost:8080/repo", "localhostsCs8080sZsrepo"),
         ] {


### PR DESCRIPTION
Closes #3194 by rewriting `.` -> `sDs`, similar to `/` ->` sZs` & `:` -> `sCs`.

I've tried it locally by importing my plugin (minimal config in #3194), and it cloned & loaded it successfully:
```
06:42:50.389 INFO plugin > Cloned https://github.com/nekowinston/wezterm-bar into "/Users/winston/.local/share/wezterm/plugins/httpssCssZssZsgithubsDscomsZsnekowinstonsZswezterm-bar"
```