### PR TITLE
fix(clippy): Don't use single character strings

### DIFF
--- a/bidi/generate/src/main.rs
+++ b/bidi/generate/src/main.rs
@@ -19,7 +19,7 @@ fn gen_class() -> anyhow::Result<()> {
     impl Entry {
         fn parse(line: &str) -> anyhow::Result<Option<Self>> {
             let line = line.trim();
-            if line.starts_with("#") || line.is_empty() {
+            if line.starts_with('#') || line.is_empty() {
                 return Ok(None);
             }
             let fields: Vec<&str> = line.split(';').collect();
@@ -152,7 +152,7 @@ fn gen_brackets() -> anyhow::Result<()> {
     impl Entry {
         fn parse(line: &str) -> anyhow::Result<Option<Self>> {
             let line = line.trim();
-            if line.starts_with("#") || line.is_empty() {
+            if line.starts_with('#') || line.is_empty() {
                 return Ok(None);
             }
             let fields: Vec<&str> = line.split(';').collect();

--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -1721,7 +1721,7 @@ impl DroppedFileQuoting {
     pub fn escape(self, s: &str) -> String {
         match self {
             Self::None => s.to_string(),
-            Self::SpacesOnly => s.replace(" ", "\\ "),
+            Self::SpacesOnly => s.replace(' ', "\\ "),
             // https://docs.rs/shlex/latest/shlex/fn.quote.html
             Self::Posix => shlex::quote(s).into_owned(),
             Self::Windows => {

--- a/config/src/lua.rs
+++ b/config/src/lua.rs
@@ -239,7 +239,7 @@ pub fn make_lua_context(config_file: &Path) -> anyhow::Result<Lua> {
 
         let package: Table = globals.get("package")?;
         let package_path: String = package.get("path")?;
-        let mut path_array: Vec<String> = package_path.split(";").map(|s| s.to_owned()).collect();
+        let mut path_array: Vec<String> = package_path.split(';').map(|s| s.to_owned()).collect();
 
         fn prefix_path(array: &mut Vec<String>, path: &Path) {
             array.insert(0, format!("{}/?.lua", path.display()));

--- a/config/src/units.rs
+++ b/config/src/units.rs
@@ -204,7 +204,7 @@ impl GuiPosition {
     fn parse_dim(s: &str) -> anyhow::Result<Dimension> {
         if let Some(v) = s.strip_suffix("px") {
             Ok(Dimension::Pixels(v.parse()?))
-        } else if let Some(v) = s.strip_suffix("%") {
+        } else if let Some(v) = s.strip_suffix('%') {
             Ok(Dimension::Percent(v.parse::<f32>()? / 100.))
         } else {
             Ok(Dimension::Pixels(s.parse()?))

--- a/config/src/wsl.rs
+++ b/config/src/wsl.rs
@@ -141,7 +141,7 @@ fn parse_wsl_distro_list(output: &str) -> Vec<WslDistro> {
             continue;
         }
 
-        let is_default = line.starts_with("*");
+        let is_default = line.starts_with('*');
 
         let mut fields = HashMap::new();
         for (label, (start_idx, end_idx)) in field_map.iter() {

--- a/lua-api-crates/color-funcs/src/schemes/iterm2.rs
+++ b/lua-api-crates/color-funcs/src/schemes/iterm2.rs
@@ -83,7 +83,7 @@ impl ITerm2 {
 
         // Look for metadata encoded in comments(!)
         for line in s.lines() {
-            let fields = line.splitn(2, ":").collect::<Vec<_>>();
+            let fields = line.splitn(2, ':').collect::<Vec<_>>();
             if fields.len() == 2 {
                 let k = fields[0].trim().to_ascii_lowercase();
                 let v = fields[1].trim();

--- a/sync-color-schemes/src/main.rs
+++ b/sync-color-schemes/src/main.rs
@@ -62,7 +62,7 @@ pub async fn fetch_url(url: &str) -> anyhow::Result<Vec<u8>> {
     let mut ttl = Duration::from_secs(86400);
     if let Some(value) = response.headers().get(reqwest::header::CACHE_CONTROL) {
         if let Ok(value) = value.to_str() {
-            let fields = value.splitn(2, "=").collect::<Vec<_>>();
+            let fields = value.splitn(2, '=').collect::<Vec<_>>();
             if fields.len() == 2 && fields[0] == "max-age" {
                 if let Ok(secs) = fields[1].parse::<u64>() {
                     ttl = Duration::from_secs(secs);

--- a/wezterm-client/src/pane/renderable.rs
+++ b/wezterm-client/src/pane/renderable.rs
@@ -270,7 +270,7 @@ impl RenderableInner {
         }
 
         let text = textwrap::fill(text, self.dimensions.cols);
-        let lines: Vec<&str> = text.split("\n").collect();
+        let lines: Vec<&str> = text.split('\n').collect();
 
         for (idx, paste_line) in lines.iter().enumerate() {
             let row = self.cursor_position.y + idx as StableRowIndex;

--- a/wezterm-font/src/parser.rs
+++ b/wezterm-font/src/parser.rs
@@ -349,7 +349,7 @@ impl ParsedFont {
                 }
                 code.push_str("},\n")
             }
-            code.push_str("\n");
+            code.push('\n');
         }
         code.push_str("})");
         code

--- a/wezterm-input-types/src/lib.rs
+++ b/wezterm-input-types/src/lib.rs
@@ -415,7 +415,7 @@ impl TryFrom<&str> for KeyCode {
 
         // Don't consider "F" to be an invalid F key!
         if s.len() > 1 {
-            if let Some(n) = s.strip_prefix("F") {
+            if let Some(n) = s.strip_prefix('F') {
                 let n: u8 = n
                     .parse()
                     .map_err(|err| format!("parsing F<NUMBER>: {:#}", err))?;

--- a/wezterm-ssh/tests/sshd.rs
+++ b/wezterm-ssh/tests/sshd.rs
@@ -63,11 +63,11 @@ impl SshAgent {
         let stdout = String::from_utf8(output.stdout)
             .map_err(|x| io::Error::new(io::ErrorKind::InvalidData, x))?;
         Ok(stdout
-            .split(";")
+            .split(';')
             .map(str::trim)
-            .filter(|s| s.contains("="))
+            .filter(|s| s.contains('='))
             .map(|s| {
-                let mut tokens = s.split("=");
+                let mut tokens = s.split('=');
                 let key = tokens.next().unwrap().trim().to_string();
                 let rest = tokens
                     .map(str::trim)


### PR DESCRIPTION
Should improve performance as it passes a 16-bit codepoint instead of a 64-bit - 128-bit string slice, but it doesn't?

I see ~4% worse performance on my machine (Arch Linux, Intel i5 8th gen Processor).

Can I rely on the benchmarks?