### PR TITLE
fix(clippy): Remove closures where possible

### DIFF
--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -1341,7 +1341,7 @@ impl Config {
         }
 
         if wsl_env.is_some() || cfg!(windows) || crate::version::running_under_wsl() {
-            let mut wsl_env = wsl_env.unwrap_or_else(String::new);
+            let mut wsl_env = wsl_env.unwrap_or_default();
             if !wsl_env.is_empty() {
                 wsl_env.push(':');
             }

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -90,7 +90,7 @@ fn toml_to_dynamic(value: &toml::Value) -> Value {
         toml::Value::Datetime(d) => d.to_string().to_dynamic(),
         toml::Value::Array(a) => a
             .iter()
-            .map(|element| toml_to_dynamic(&element))
+            .map(toml_to_dynamic)
             .collect::<Vec<_>>()
             .to_dynamic(),
         // Allow `colors.indexed` to be passed through with actual integer keys
@@ -166,7 +166,7 @@ impl LuaConfigState {
 
     /// Take a reference on the latest generation of the lua context
     fn get_lua(&self) -> Option<Rc<mlua::Lua>> {
-        self.lua.as_ref().map(|lua| Rc::clone(lua))
+        self.lua.as_ref().map(Rc::clone)
     }
 }
 

--- a/config/src/lua.rs
+++ b/config/src/lua.rs
@@ -133,14 +133,14 @@ impl ConfigHelper {
                         for i in 1.. {
                             if let Some(debug) = lua.inspect_stack(i) {
                                 let names = debug.names();
-                                let name = names.name.map(|b| String::from_utf8_lossy(b));
-                                let name_what = names.name_what.map(|b| String::from_utf8_lossy(b));
+                                let name = names.name.map(String::from_utf8_lossy);
+                                let name_what = names.name_what.map(String::from_utf8_lossy);
 
                                 let dbg_source = debug.source();
                                 let source = dbg_source
                                     .source
                                     .and_then(|b| String::from_utf8(b.to_vec()).ok())
-                                    .unwrap_or_else(String::new);
+                                    .unwrap_or_default();
                                 let func_name = match (name, name_what) {
                                     (Some(name), Some(name_what)) => format!("{name_what} {name}"),
                                     (Some(name), None) => format!("{name}"),
@@ -412,7 +412,7 @@ fn shell_quote_arg<'lua>(_: &'lua Lua, arg: String) -> mlua::Result<String> {
 /// Errors may occur while retrieving the hostname from the system,
 /// or if the hostname isn't a UTF-8 string.
 fn hostname<'lua>(_: &'lua Lua, _: ()) -> mlua::Result<String> {
-    let hostname = hostname::get().map_err(|e| mlua::Error::external(e))?;
+    let hostname = hostname::get().map_err(mlua::Error::external)?;
     match hostname.to_str() {
         Some(hostname) => Ok(hostname.to_owned()),
         None => Err(mlua::Error::external(anyhow!("hostname isn't UTF-8"))),
@@ -567,9 +567,7 @@ fn font<'lua>(
             freetype_load_target: attrs.freetype_load_target,
             freetype_render_target: attrs.freetype_render_target,
             freetype_load_flags: match attrs.freetype_load_flags {
-                Some(flags) => {
-                    Some(TryFrom::try_from(flags).map_err(|e| mlua::Error::external(e))?)
-                }
+                Some(flags) => Some(TryFrom::try_from(flags).map_err(mlua::Error::external)?),
                 None => None,
             },
             scale: attrs.scale,
@@ -618,9 +616,7 @@ fn font_with_fallback<'lua>(
                 freetype_load_target: attrs.freetype_load_target,
                 freetype_render_target: attrs.freetype_render_target,
                 freetype_load_flags: match attrs.freetype_load_flags {
-                    Some(flags) => {
-                        Some(TryFrom::try_from(flags).map_err(|e| mlua::Error::external(e))?)
-                    }
+                    Some(flags) => Some(TryFrom::try_from(flags).map_err(mlua::Error::external)?),
                     None => None,
                 },
                 scale: attrs.scale,
@@ -840,7 +836,7 @@ fn utf16_to_utf8<'lua>(_: &'lua Lua, text: mlua::String) -> mlua::Result<String>
     let wide: &[u16] =
         unsafe { std::slice::from_raw_parts(bytes.as_ptr() as *const u16, bytes.len() / 2) };
 
-    String::from_utf16(wide).map_err(|e| mlua::Error::external(e))
+    String::from_utf16(wide).map_err(mlua::Error::external)
 }
 
 pub fn add_to_config_reload_watch_list<'lua>(

--- a/lua-api-crates/battery/src/lib.rs
+++ b/lua-api-crates/battery/src/lib.rs
@@ -23,10 +23,10 @@ impl_lua_conversion_dynamic!(BatteryInfo);
 
 fn battery_info<'lua>(_: &'lua Lua, _: ()) -> mlua::Result<Vec<BatteryInfo>> {
     use starship_battery::{Manager, State};
-    let manager = Manager::new().map_err(|e| mlua::Error::external(e))?;
+    let manager = Manager::new().map_err(mlua::Error::external)?;
     let mut result = vec![];
-    for b in manager.batteries().map_err(|e| mlua::Error::external(e))? {
-        let bat = b.map_err(|e| mlua::Error::external(e))?;
+    for b in manager.batteries().map_err(mlua::Error::external)? {
+        let bat = b.map_err(mlua::Error::external)?;
         result.push(BatteryInfo {
             state_of_charge: bat.state_of_charge().value,
             vendor: opt_string(bat.vendor()),

--- a/lua-api-crates/color-funcs/src/lib.rs
+++ b/lua-api-crates/color-funcs/src/lib.rs
@@ -191,7 +191,7 @@ fn gradient_colors<'lua>(
     _lua: &'lua Lua,
     (gradient, num_colors): (Gradient, usize),
 ) -> mlua::Result<Vec<ColorWrap>> {
-    let g = gradient.build().map_err(|e| mlua::Error::external(e))?;
+    let g = gradient.build().map_err(mlua::Error::external)?;
     Ok(g.colors(num_colors)
         .into_iter()
         .map(|c| {

--- a/lua-api-crates/filesystem/src/lib.rs
+++ b/lua-api-crates/filesystem/src/lib.rs
@@ -13,10 +13,10 @@ pub fn register(lua: &Lua) -> anyhow::Result<()> {
 async fn read_dir<'lua>(_: &'lua Lua, path: String) -> mlua::Result<Vec<String>> {
     let mut dir = smol::fs::read_dir(path)
         .await
-        .map_err(|e| mlua::Error::external(e))?;
+        .map_err(mlua::Error::external)?;
     let mut entries = vec![];
     while let Some(entry) = dir.next().await {
-        let entry = entry.map_err(|e| mlua::Error::external(e))?;
+        let entry = entry.map_err(mlua::Error::external)?;
         if let Some(utf8) = entry.path().to_str() {
             entries.push(utf8.to_string());
         } else {
@@ -36,7 +36,7 @@ async fn glob<'lua>(
     let entries = smol::unblock(move || {
         let mut entries = vec![];
         let glob = filenamegen::Glob::new(&pattern)?;
-        for path in glob.walk(path.as_ref().map(|s| s.as_str()).unwrap_or(".")) {
+        for path in glob.walk(path.as_deref().unwrap_or(".")) {
             if let Some(utf8) = path.to_str() {
                 entries.push(utf8.to_string());
             } else {
@@ -49,6 +49,6 @@ async fn glob<'lua>(
         Ok(entries)
     })
     .await
-    .map_err(|e| mlua::Error::external(e))?;
+    .map_err(mlua::Error::external)?;
     Ok(entries)
 }

--- a/lua-api-crates/mux/src/lib.rs
+++ b/lua-api-crates/mux/src/lib.rs
@@ -104,7 +104,7 @@ pub fn register(lua: &Lua) -> anyhow::Result<()> {
             Ok(mux
                 .iter_windows()
                 .into_iter()
-                .map(|id| MuxWindow(id))
+                .map(MuxWindow)
                 .collect::<Vec<MuxWindow>>())
         })?,
     )?;

--- a/lua-api-crates/spawn-funcs/src/lib.rs
+++ b/lua-api-crates/spawn-funcs/src/lib.rs
@@ -45,7 +45,7 @@ async fn run_child_process<'lua>(
         cmd.creation_flags(winapi::um::winbase::CREATE_NO_WINDOW);
     }
 
-    let output = cmd.output().await.map_err(|e| mlua::Error::external(e))?;
+    let output = cmd.output().await.map_err(mlua::Error::external)?;
 
     Ok((
         output.status.success(),
@@ -69,7 +69,7 @@ async fn background_child_process<'lua>(_: &'lua Lua, args: Vec<String>) -> mlua
 
     cmd.stdin(smol::process::Stdio::null())
         .spawn()
-        .map_err(|e| mlua::Error::external(e))?;
+        .map_err(mlua::Error::external)?;
 
     Ok(())
 }

--- a/lua-api-crates/termwiz-funcs/src/lib.rs
+++ b/lua-api-crates/termwiz-funcs/src/lib.rs
@@ -145,7 +145,7 @@ pub fn format_as_escapes(items: Vec<FormatItem>) -> anyhow::Result<String> {
 }
 
 fn format<'lua>(_: &'lua Lua, items: Vec<FormatItem>) -> mlua::Result<String> {
-    format_as_escapes(items).map_err(|e| mlua::Error::external(e))
+    format_as_escapes(items).map_err(mlua::Error::external)
 }
 
 pub fn pad_right(mut result: String, width: usize) -> String {

--- a/procinfo/src/linux.rs
+++ b/procinfo/src/linux.rs
@@ -82,7 +82,7 @@ impl LocalProcessInfo {
         }
 
         fn cwd_for_pid(pid: pid_t) -> PathBuf {
-            LocalProcessInfo::current_working_dir(pid as u32).unwrap_or_else(|| PathBuf::new())
+            LocalProcessInfo::current_working_dir(pid as u32).unwrap_or_else(PathBuf::new)
         }
 
         fn parse_cmdline(pid: pid_t) -> Vec<String> {

--- a/promise/src/spawn.rs
+++ b/promise/src/spawn.rs
@@ -115,11 +115,7 @@ where
 }
 
 fn get_scoped() -> Option<Arc<Executor<'static>>> {
-    SCOPED_EXECUTOR
-        .lock()
-        .unwrap()
-        .as_ref()
-        .map(|e| Arc::clone(&e))
+    SCOPED_EXECUTOR.lock().unwrap().as_ref().map(Arc::clone)
 }
 
 /// Spawn a future into the main thread; it will be polled in the

--- a/tabout/src/lib.rs
+++ b/tabout/src/lib.rs
@@ -94,7 +94,7 @@ pub fn tabulate_output<S: std::string::ToString, W: std::io::Write>(
 
     for row in &display_rows {
         for (idx, col) in row.iter().enumerate() {
-            let max_width = col_widths.get(idx).cloned().unwrap_or_else(|| col.len());
+            let max_width = col_widths.get(idx).cloned().unwrap_or(col.len());
             let alignment = columns
                 .get(idx)
                 .map(|c| c.alignment)
@@ -200,7 +200,7 @@ pub fn tabulate_for_terminal(
 
     for row in rows {
         for (idx, col) in row.iter().enumerate() {
-            let max_width = col_widths.get(idx).cloned().unwrap_or_else(|| col.len());
+            let max_width = col_widths.get(idx).cloned().unwrap_or(col.len());
             let alignment = columns
                 .get(idx)
                 .map(|c| c.alignment)

--- a/term/src/screen.rs
+++ b/term/src/screen.rs
@@ -890,7 +890,7 @@ impl Screen {
             .iter()
             .skip(phys_range.start)
             .take(phys_range.end - phys_range.start)
-            .map(|line| line.clone())
+            .cloned()
             .collect()
     }
 

--- a/wezterm-client/src/client.rs
+++ b/wezterm-client/src/client.rs
@@ -901,8 +901,7 @@ impl Reconnectable {
                 .connect(
                     tls_client
                         .expected_cn
-                        .as_ref()
-                        .map(String::as_str)
+                        .as_deref()
                         .unwrap_or(remote_host_name),
                     stream,
                 )

--- a/wezterm-client/src/domain.rs
+++ b/wezterm-client/src/domain.rs
@@ -332,7 +332,7 @@ impl ClientDomain {
     }
 
     fn inner(&self) -> Option<Arc<ClientInner>> {
-        self.inner.lock().unwrap().as_ref().map(|i| Arc::clone(i))
+        self.inner.lock().unwrap().as_ref().map(Arc::clone)
     }
 
     pub fn connect_automatically(&self) -> bool {

--- a/wezterm-dynamic/src/fromdynamic.rs
+++ b/wezterm-dynamic/src/fromdynamic.rs
@@ -184,7 +184,7 @@ impl FromDynamic for char {
         match value {
             Value::String(s) => {
                 let mut iter = s.chars();
-                let c = iter.next().ok_or_else(|| Error::CharFromWrongSizedString)?;
+                let c = iter.next().ok_or(Error::CharFromWrongSizedString)?;
                 if iter.next().is_some() {
                     Err(Error::CharFromWrongSizedString)
                 } else {

--- a/wezterm-dynamic/src/object.rs
+++ b/wezterm-dynamic/src/object.rs
@@ -99,7 +99,7 @@ impl PartialOrd for Object {
 
 impl Drop for Object {
     fn drop(&mut self) {
-        for (_, child) in std::mem::replace(&mut self.inner, BTreeMap::new()) {
+        for (_, child) in std::mem::take(&mut self.inner) {
             crate::drop::safely(child);
         }
     }

--- a/wezterm-font/src/db.rs
+++ b/wezterm-font/src/db.rs
@@ -22,7 +22,7 @@ impl FontDatabase {
         for parsed in font_info {
             self.by_full_name
                 .entry(parsed.names().full_name.clone())
-                .or_insert_with(|| vec![])
+                .or_insert_with(Vec::new)
                 .push(parsed);
         }
     }
@@ -138,7 +138,7 @@ impl FontDatabase {
         }
 
         if let Some(idx) = ParsedFont::best_matching_index(font_attr, &candidates, pixel_size) {
-            return candidates.get(idx).map(|&p| p);
+            return candidates.get(idx).copied();
         }
 
         None

--- a/wezterm-font/src/ftwrap.rs
+++ b/wezterm-font/src/ftwrap.rs
@@ -279,7 +279,7 @@ impl Face {
 
             names
                 .entry(sfnt_name.name_id as u32)
-                .or_insert_with(|| vec![])
+                .or_insert_with(Vec::new)
                 .push(NameRecord {
                     platform_id: sfnt_name.platform_id,
                     encoding_id: sfnt_name.encoding_id,

--- a/wezterm-font/src/lib.rs
+++ b/wezterm-font/src/lib.rs
@@ -471,7 +471,7 @@ pub struct FontConfiguration {
 impl FontConfigInner {
     /// Create a new empty configuration
     pub fn new(config: Option<ConfigHandle>, dpi: usize) -> anyhow::Result<Self> {
-        let config = config.unwrap_or_else(|| configuration());
+        let config = config.unwrap_or_else(configuration);
         let locator = new_locator(config.font_locator);
         Ok(Self {
             fonts: RefCell::new(HashMap::new()),
@@ -590,11 +590,7 @@ impl FontConfigInner {
 
         let font_size = pref_size.unwrap_or(sys_size);
 
-        let text_style = config
-            .window_frame
-            .font
-            .as_ref()
-            .unwrap_or_else(|| &sys_font);
+        let text_style = config.window_frame.font.as_ref().unwrap_or(&sys_font);
 
         let dpi = *self.dpi.borrow() as u32;
         let pixel_size = (font_size * dpi as f64 / 72.0) as u16;
@@ -701,12 +697,12 @@ impl FontConfigInner {
         let preferred_attributes = attributes
             .iter()
             .filter(|a| !a.is_fallback)
-            .map(|a| a.clone())
+            .cloned()
             .collect::<Vec<_>>();
         let fallback_attributes = attributes
             .iter()
             .filter(|a| a.is_fallback)
-            .map(|a| a.clone())
+            .cloned()
             .collect::<Vec<_>>();
         let mut loaded = HashSet::new();
         let mut handles = vec![];

--- a/wezterm-font/src/shaper/harfbuzz.rs
+++ b/wezterm-font/src/shaper/harfbuzz.rs
@@ -405,7 +405,7 @@ impl HarfbuzzShaper {
                     map.entry(start).or_insert_with(|| Item { start, cell_idx });
                 }
 
-                let mut cluster_starts: Vec<Item> = map.into_iter().map(|(_, item)| item).collect();
+                let mut cluster_starts: Vec<Item> = map.into_values().collect();
                 cluster_starts.sort();
 
                 // If we have multiple entries with the same starting cell index,

--- a/wezterm-mux-server/src/main.rs
+++ b/wezterm-mux-server/src/main.rs
@@ -215,9 +215,7 @@ async fn async_run(cmd: Option<CommandBuilder>) -> anyhow::Result<()> {
     let domain = mux.default_domain();
 
     {
-        if let Err(err) =
-            config::with_lua_config_on_main_thread(move |lua| trigger_mux_startup(lua)).await
-        {
+        if let Err(err) = config::with_lua_config_on_main_thread(trigger_mux_startup).await {
             log::error!("while processing mux-startup event: {:#}", err);
         }
     }

--- a/wezterm-ssh/tests/sshd.rs
+++ b/wezterm-ssh/tests/sshd.rs
@@ -24,7 +24,7 @@ fn allocate_port() -> u16 {
     listener.local_addr().unwrap().port()
 }
 
-const USERNAME: Lazy<String> = Lazy::new(|| whoami::username());
+const USERNAME: Lazy<String> = Lazy::new(whoami::username);
 
 pub struct SshKeygen;
 

--- a/wezterm/src/main.rs
+++ b/wezterm/src/main.rs
@@ -482,8 +482,8 @@ impl ImgCatCommand {
             ITermFileData {
                 name: None,
                 size: Some(data.len()),
-                width: self.width.unwrap_or_else(Default::default),
-                height: self.height.unwrap_or_else(Default::default),
+                width: self.width.unwrap_or_default(),
+                height: self.height.unwrap_or_default(),
                 preserve_aspect_ratio: !self.no_preserve_aspect_ratio,
                 inline: true,
                 do_not_move_cursor: false,

--- a/window/src/os/wayland/frame.rs
+++ b/window/src/os/wayland/frame.rs
@@ -425,7 +425,7 @@ struct ShapedGlyph {
 impl ConceptFrame {
     fn reshape_title(&mut self) -> Option<()> {
         let font_config = self.config.font_config.as_ref()?;
-        let title = self.title.as_ref().map(|s| s.as_str()).unwrap_or("");
+        let title = self.title.as_deref().unwrap_or("");
         if title.is_empty() {
             self.title.take();
             self.shaped_title.take();

--- a/window/src/os/x11/cursor.rs
+++ b/window/src/os/x11/cursor.rs
@@ -308,10 +308,8 @@ impl CursorInfo {
             }
         }
 
-        let theme = self.theme.as_ref().map(|s| s.as_str()).unwrap_or("default");
-        if self.pict_format_id.is_none() {
-            return None;
-        }
+        let theme = self.theme.as_deref().unwrap_or("default");
+        self.pict_format_id?;
 
         let names: &[&str] = match cursor.unwrap_or(MouseCursor::Arrow) {
             MouseCursor::Arrow => &["top_left_arrow", "left_ptr"],

--- a/window/src/os/x11/keyboard.rs
+++ b/window/src/os/x11/keyboard.rs
@@ -102,7 +102,7 @@ impl Compose {
             }
             ComposeStatus::Composed => {
                 let res = self.state.keysym();
-                let composed = self.state.utf8().unwrap_or_else(String::new);
+                let composed = self.state.utf8().unwrap_or_default();
                 self.state.reset();
                 FeedResult::Composed(composed, res.unwrap_or(xsym))
             }


### PR DESCRIPTION
- Removes closures and function calls for types that implement default:

  ```rust
  // Change
  let _my_str = get_str().unwrap_or(String::new);
  // To
  let _my_str = get_str().unwrap_or_default();
  ```

- Uses the `.cloned()/.copied()` methods where possible
- Use function pointer instead of simple closure

May improve performace as closures generate more code, and this might unlock some inlining opportunities.