### PR TITLE
mux: Don't add excessively long lines to the logical lines

### DIFF
--- a/mux/src/pane.rs
+++ b/mux/src/pane.rs
@@ -508,9 +508,9 @@ pub fn impl_get_logical_lines_via_get_lines<P: Pane + ?Sized>(
                 });
             }
             Some(prior) => {
-                if prior.logical.last_cell_was_wrapped()
-                    && prior.logical.len() <= MAX_LOGICAL_LINE_LEN
-                {
+                if prior.logical.len() > MAX_LOGICAL_LINE_LEN {
+                    break;
+                } else if prior.logical.last_cell_was_wrapped() {
                     let seqno = prior.logical.current_seqno().max(line.current_seqno());
                     prior.logical.set_last_cell_was_wrapped(false, seqno);
                     prior.logical.append_line(line.clone(), seqno);


### PR DESCRIPTION
The behavior of impl_get_logical_lines_via_get_lines() was inconsistent when all physical lines appeared to be one wrapped logical line.

The combined logical line would be appended to the result if and only if it exceeded MAX_LOGICAL_LINE_LEN (1024) characters.

Having an extra logical line in the result would lead to an extra newline being added to the text copied to clipboard.

Fixes #3177.