### PR TITLE
Convert admonition blocks to markdown equivalent

### DIFF
--- a/docs/config/lua/config/window_decorations.md
+++ b/docs/config/lua/config/window_decorations.md
@@ -28,17 +28,15 @@ When the resizable border is disabled you will need to use features of your
 desktop environment to resize the window.  Windows users may wish to consider
 [AltSnap](https://github.com/RamonUnch/AltSnap).
 
-```admonish warning
-Think twice before removing `RESIZE` from the set of decorations as it causes
-problems with resizing and minimizing the window. You usually want to keep
-`RESIZE` enabled.
-```
+!!! warning
+    Think twice before removing `RESIZE` from the set of decorations as it causes
+    problems with resizing and minimizing the window. You usually want to keep
+    `RESIZE` enabled.
 
 If you just want to remove the title bar, set `window_decorations = "RESIZE"`
 as you will run into problems if you remove `RESIZE` from the set of
 decorations.
 
-```admonish
-You probably always want `RESIZE` to be listed in your `window_decorations`.
-```
+!!! info
+    You probably always want `RESIZE` to be listed in your `window_decorations`.
 


### PR DESCRIPTION
Note: the second block had no type specified. I picked `tip` for this one.

<img width="1552" alt="Screenshot 2023-03-19 at 14 58 41" src="https://user-images.githubusercontent.com/1554116/226181155-d4676b81-19f0-4ec1-a85f-64bd991bdec5.png">
