### PR TITLE
fix(clippy): Implement From instead of Into

### DIFF
--- a/codec/src/lib.rs
+++ b/codec/src/lib.rs
@@ -689,9 +689,9 @@ impl InputSerial {
     }
 }
 
-impl Into<InputSerial> for std::time::SystemTime {
-    fn into(self) -> InputSerial {
-        let duration = self
+impl From<std::time::SystemTime> for InputSerial {
+    fn from(val: std::time::SystemTime) -> Self {
+        let duration = val
             .duration_since(std::time::SystemTime::UNIX_EPOCH)
             .expect("SystemTime before unix epoch?");
         let millis: u64 = duration

--- a/color-types/src/lib.rs
+++ b/color-types/src/lib.rs
@@ -753,9 +753,9 @@ impl From<[f32; 4]> for LinearRgba {
     }
 }
 
-impl Into<[f32; 4]> for LinearRgba {
-    fn into(self) -> [f32; 4] {
-        [self.0, self.1, self.2, self.3]
+impl From<LinearRgba> for [f32; 4] {
+    fn from(val: LinearRgba) -> Self {
+        [val.0, val.1, val.2, val.3]
     }
 }
 

--- a/config/src/color.rs
+++ b/config/src/color.rs
@@ -63,21 +63,21 @@ impl std::ops::Deref for RgbaColor {
     }
 }
 
-impl Into<String> for &RgbaColor {
-    fn into(self) -> String {
-        self.color.to_string()
+impl From<&RgbaColor> for String {
+    fn from(val: &RgbaColor) -> Self {
+        val.color.to_string()
     }
 }
 
-impl Into<String> for RgbaColor {
-    fn into(self) -> String {
-        self.color.to_string()
+impl From<RgbaColor> for String {
+    fn from(val: RgbaColor) -> Self {
+        val.color.to_string()
     }
 }
 
-impl Into<SrgbaTuple> for RgbaColor {
-    fn into(self) -> SrgbaTuple {
-        self.color
+impl From<RgbaColor> for SrgbaTuple {
+    fn from(val: RgbaColor) -> Self {
+        val.color
     }
 }
 
@@ -104,22 +104,24 @@ impl From<AnsiColor> for ColorSpec {
     }
 }
 
-impl Into<ColorAttribute> for ColorSpec {
-    fn into(self) -> ColorAttribute {
-        match self {
-            Self::AnsiColor(c) => ColorAttribute::PaletteIndex(c.into()),
-            Self::Color(RgbaColor { color }) => ColorAttribute::TrueColorWithDefaultFallback(color),
-            Self::Default => ColorAttribute::Default,
+impl From<ColorSpec> for ColorAttribute {
+    fn from(val: ColorSpec) -> Self {
+        match val {
+            ColorSpec::AnsiColor(c) => ColorAttribute::PaletteIndex(c.into()),
+            ColorSpec::Color(RgbaColor { color }) => {
+                ColorAttribute::TrueColorWithDefaultFallback(color)
+            }
+            ColorSpec::Default => ColorAttribute::Default,
         }
     }
 }
 
-impl Into<TWColorSpec> for ColorSpec {
-    fn into(self) -> TWColorSpec {
-        match self {
-            Self::AnsiColor(c) => c.into(),
-            Self::Color(RgbaColor { color }) => TWColorSpec::TrueColor(color),
-            Self::Default => TWColorSpec::Default,
+impl From<ColorSpec> for TWColorSpec {
+    fn from(val: ColorSpec) -> Self {
+        match val {
+            ColorSpec::AnsiColor(c) => c.into(),
+            ColorSpec::Color(RgbaColor { color }) => TWColorSpec::TrueColor(color),
+            ColorSpec::Default => TWColorSpec::Default,
         }
     }
 }

--- a/config/src/font.rs
+++ b/config/src/font.rs
@@ -267,15 +267,15 @@ bitflags! {
     }
 }
 
-impl Into<String> for FreeTypeLoadFlags {
-    fn into(self) -> String {
-        self.to_string()
+impl From<FreeTypeLoadFlags> for String {
+    fn from(val: FreeTypeLoadFlags) -> Self {
+        val.to_string()
     }
 }
 
-impl Into<String> for &FreeTypeLoadFlags {
-    fn into(self) -> String {
-        self.to_string()
+impl From<&FreeTypeLoadFlags> for String {
+    fn from(val: &FreeTypeLoadFlags) -> Self {
+        val.to_string()
     }
 }
 

--- a/config/src/keyassignment.rs
+++ b/config/src/keyassignment.rs
@@ -33,15 +33,15 @@ bitflags::bitflags! {
     }
 }
 
-impl Into<String> for LauncherFlags {
-    fn into(self) -> String {
-        self.to_string()
+impl From<LauncherFlags> for String {
+    fn from(val: LauncherFlags) -> Self {
+        val.to_string()
     }
 }
 
-impl Into<String> for &LauncherFlags {
-    fn into(self) -> String {
-        self.to_string()
+impl From<&LauncherFlags> for String {
+    fn from(val: &LauncherFlags) -> Self {
+        val.to_string()
     }
 }
 

--- a/config/src/keys.rs
+++ b/config/src/keys.rs
@@ -62,20 +62,20 @@ impl DeferredKeyCode {
     }
 }
 
-impl Into<String> for &DeferredKeyCode {
-    fn into(self) -> String {
-        match self {
+impl From<&DeferredKeyCode> for String {
+    fn from(val: &DeferredKeyCode) -> Self {
+        match val {
             DeferredKeyCode::KeyCode(key) => key.to_string(),
             DeferredKeyCode::Either { original, .. } => original.to_string(),
         }
     }
 }
 
-impl Into<String> for DeferredKeyCode {
-    fn into(self) -> String {
-        match self {
+impl From<DeferredKeyCode> for String {
+    fn from(val: DeferredKeyCode) -> Self {
+        match val {
             DeferredKeyCode::KeyCode(key) => key.to_string(),
-            DeferredKeyCode::Either { original, .. } => original.to_string(),
+            DeferredKeyCode::Either { original, .. } => original,
         }
     }
 }

--- a/config/src/units.rs
+++ b/config/src/units.rs
@@ -16,18 +16,18 @@ impl FromDynamic for OptPixelUnit {
     }
 }
 
-impl Into<Option<Dimension>> for OptPixelUnit {
-    fn into(self) -> Option<Dimension> {
-        self.0
+impl From<OptPixelUnit> for Option<Dimension> {
+    fn from(val: OptPixelUnit) -> Self {
+        val.0
     }
 }
 
 #[derive(Debug, Copy, Clone)]
 pub struct PixelUnit(Dimension);
 
-impl Into<Dimension> for PixelUnit {
-    fn into(self) -> Dimension {
-        self.0
+impl From<PixelUnit> for Dimension {
+    fn from(val: PixelUnit) -> Self {
+        val.0
     }
 }
 

--- a/lua-api-crates/color-funcs/src/schemes/iterm2.rs
+++ b/lua-api-crates/color-funcs/src/schemes/iterm2.rs
@@ -13,14 +13,14 @@ struct Color {
     blue: f32,
 }
 
-impl Into<RgbaColor> for Color {
-    fn into(self) -> RgbaColor {
+impl From<Color> for RgbaColor {
+    fn from(val: Color) -> Self {
         // For compatibility with `iterm2xrdb`, we round these
         // values off :-/
         fn compat(v: f32) -> f32 {
             (v * 255.).round() / 255.
         }
-        SrgbaTuple(compat(self.red), compat(self.green), compat(self.blue), 1.0).into()
+        SrgbaTuple(compat(val.red), compat(val.green), compat(val.blue), 1.0).into()
     }
 }
 

--- a/lua-api-crates/termwiz-funcs/src/lib.rs
+++ b/lua-api-crates/termwiz-funcs/src/lib.rs
@@ -81,9 +81,9 @@ impl FormatColor {
     }
 }
 
-impl Into<ColorSpec> for FormatColor {
-    fn into(self) -> ColorSpec {
-        match self {
+impl From<FormatColor> for ColorSpec {
+    fn from(val: FormatColor) -> Self {
+        match val {
             FormatColor::AnsiColor(c) => c.into(),
             FormatColor::Color(s) => {
                 let rgba = SrgbaTuple::from_str(&s).unwrap_or_else(|()| (0xff, 0xff, 0xff).into());
@@ -104,14 +104,14 @@ pub enum FormatItem {
 }
 impl_lua_conversion_dynamic!(FormatItem);
 
-impl Into<Change> for FormatItem {
-    fn into(self) -> Change {
-        match self {
-            Self::Attribute(change) => change.into(),
-            Self::Text(t) => t.into(),
-            Self::Foreground(c) => AttributeChange::Foreground(c.to_attr()).into(),
-            Self::Background(c) => AttributeChange::Background(c.to_attr()).into(),
-            Self::ResetAttributes => Change::AllAttributes(CellAttributes::default()),
+impl From<FormatItem> for Change {
+    fn from(val: FormatItem) -> Self {
+        match val {
+            FormatItem::Attribute(change) => change.into(),
+            FormatItem::Text(t) => t.into(),
+            FormatItem::Foreground(c) => AttributeChange::Foreground(c.to_attr()).into(),
+            FormatItem::Background(c) => AttributeChange::Background(c.to_attr()).into(),
+            FormatItem::ResetAttributes => Change::AllAttributes(CellAttributes::default()),
         }
     }
 }

--- a/wezterm-input-types/src/lib.rs
+++ b/wezterm-input-types/src/lib.rs
@@ -500,9 +500,9 @@ impl TryFrom<String> for Modifiers {
     }
 }
 
-impl Into<String> for &Modifiers {
-    fn into(self) -> String {
-        self.to_string()
+impl From<&Modifiers> for String {
+    fn from(val: &Modifiers) -> Self {
+        val.to_string()
     }
 }
 

--- a/window/src/bitmaps/mod.rs
+++ b/window/src/bitmaps/mod.rs
@@ -325,9 +325,9 @@ impl std::fmt::Debug for Image {
     }
 }
 
-impl Into<Vec<u8>> for Image {
-    fn into(self) -> Vec<u8> {
-        self.data
+impl From<Image> for Vec<u8> {
+    fn from(val: Image) -> Self {
+        val.data
     }
 }
 


### PR DESCRIPTION
Implementing `From` is prefered as this also implements the `Into` trait, may not be desireable for code size/compilation time reasons.

Exerpt from the [Rust documentation](https://doc.rust-lang.org/std/convert/trait.From.html)

> One should always prefer implementing From over [Into](https://doc.rust-lang.org/std/convert/trait.Into.html) because implementing From automatically provides one with an implementation of [Into](https://doc.rust-lang.org/std/convert/trait.Into.html) thanks to the blanket implementation in the standard library.
> 
> Only implement [Into](https://doc.rust-lang.org/std/convert/trait.Into.html) when targeting a version prior to Rust 1.41 and converting to a type outside the current crate. From was not able to do these types of conversions in earlier versions because of Rust’s orphaning rules. See [Into](https://doc.rust-lang.org/std/convert/trait.Into.html) for more details.