### PR TITLE
new config option: resolve_new_window_geometry_bounds_from_screens

### DIFF
--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -653,6 +653,9 @@ pub struct Config {
     #[dynamic(default = "default_true")]
     pub adjust_window_size_when_changing_font_size: bool,
 
+    #[dynamic(default = "default_true")]
+    pub resolve_new_window_geometry_bounds_from_screens: bool,
+
     #[dynamic(default)]
     pub use_resize_increments: bool,
 

--- a/docs/config/lua/config/resolve_new_window_geometry_bounds_from_screens.md
+++ b/docs/config/lua/config/resolve_new_window_geometry_bounds_from_screens.md
@@ -1,0 +1,8 @@
+# `resolve_new_window_geometry_bounds_from_screens = true`
+
+*Since 20230320-172200-12345678*
+
+Control whether window geometry bounds are calculated from screens. The default is true.
+
+If are experience slow window launches only when using multiple monitors on X11 then you
+may wish to set this to `false`.

--- a/window/src/connection.rs
+++ b/window/src/connection.rs
@@ -82,29 +82,32 @@ pub trait ConnectionOps {
     }
 
     fn resolve_geometry(&self, geometry: RequestedWindowGeometry) -> ResolvedGeometry {
-        let bounds = match self.screens() {
-            Ok(screens) => {
-                log::trace!("{screens:?}");
+        let bounds = match config::configuration().resolve_new_window_geometry_bounds_from_screens {
+            true => match self.screens() {
+                Ok(screens) => {
+                    log::trace!("{screens:?}");
 
-                match geometry.origin {
-                    GeometryOrigin::ScreenCoordinateSystem => screens.virtual_rect,
-                    GeometryOrigin::MainScreen => screens.main.rect,
-                    GeometryOrigin::ActiveScreen => screens.active.rect,
-                    GeometryOrigin::Named(name) => match screens.by_name.get(&name) {
-                        Some(info) => info.rect,
-                        None => {
-                            log::error!(
+                    match geometry.origin {
+                        GeometryOrigin::ScreenCoordinateSystem => screens.virtual_rect,
+                        GeometryOrigin::MainScreen => screens.main.rect,
+                        GeometryOrigin::ActiveScreen => screens.active.rect,
+                        GeometryOrigin::Named(name) => match screens.by_name.get(&name) {
+                            Some(info) => info.rect,
+                            None => {
+                                log::error!(
                             "Requested display {} was not found; available displays are: {:?}. \
                              Using primary display instead",
                             name,
                             screens.by_name,
                         );
-                            screens.main.rect
-                        }
-                    },
+                                screens.main.rect
+                            }
+                        },
+                    }
                 }
-            }
-            Err(_) => euclid::rect(0, 0, 65535, 65535),
+                Err(_) => euclid::rect(0, 0, 65535, 65535),
+            },
+            false => euclid::rect(0, 0, 65535, 65535),
         };
 
         let dpi = self.default_dpi();


### PR DESCRIPTION
addresses #3300

adds a new config option: `resolve_new_window_geometry_bounds_from_screens`

The default is true to maintain existing behavior. When set to false, the `bounds` variable within `resolve_geometry` is set to `euclid::rect(0, 0, 65535, 65535)`, which is consistent with the behavior that happens when the result of `screens()` is an `Err`.

With this set to false, new windows open instantly on X11 even while connected to three external displays. The tradeoff is that the `ResolvedGeometry` fields are based on these fallback values rather than the `ScreenRect` you would get from the default behavior, meaning window positioning will likely behave differently, but this is a non-issue with tiling window managers.