### PR TITLE
Update wezterm-linuxbrew.rb.template

### DIFF
--- a/ci/wezterm-linuxbrew.rb.template
+++ b/ci/wezterm-linuxbrew.rb.template
@@ -5,9 +5,9 @@
 class Wezterm < Formula
   desc "A GPU-accelerated cross-platform terminal emulator and multiplexer written by @wez and implemented in Rust"
   homepage "https://wezfurlong.org/wezterm/"
-  url "https://github.com/wez/wezterm/releases/download/@TAG@/WezTerm-@TAG@-Ubuntu18.04.AppImage"
+  url "https://github.com/wez/wezterm/releases/download/@TAG@/WezTerm-@TAG@-Ubuntu22.04.AppImage"
   sha256 "@SHA256@"
-  head "https://github.com/wez/wezterm/releases/download/nightly/WezTerm-nightly-Ubuntu18.04.AppImage"
+  head "https://github.com/wez/wezterm/releases/download/nightly/WezTerm-nightly-Ubuntu22.04.AppImage"
 
   def install
     Dir.glob("*.AppImage").each do |img|


### PR DESCRIPTION
Hello, I encountered some issues when upgrading to latest version with Homebrew because AppImage for Ubuntu 18.04 doesn't exist anymore (https://github.com/wez/wezterm/releases). 

I believe this would be the required change is that correct? Or should 20.04 be used? 22.04 is LTS as well.