### PR TITLE
Ci toolchain: Do not use actions-rs/toolchain

### DIFF
--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -21,14 +21,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: "Install Rust"
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@nightly
         with:
-          profile: "minimal"
-          toolchain: "nightly"
-          override: true
           components: rustfmt
-        env:
-          ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
       - name: Build
         run: |
           source $HOME/.cargo/env

--- a/.github/workflows/gen_alpine3.15.yml
+++ b/.github/workflows/gen_alpine3.15.yml
@@ -56,12 +56,7 @@ jobs:
         with:
           submodules: "recursive"
       - name: "Install Rust"
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: "minimal"
-          toolchain: "stable"
-          override: true
-          components: "rustfmt"
+        uses: dtolnay/rust-toolchain@stable
         env:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
       - name: "Cache cargo"

--- a/.github/workflows/gen_alpine3.15.yml
+++ b/.github/workflows/gen_alpine3.15.yml
@@ -57,8 +57,6 @@ jobs:
           submodules: "recursive"
       - name: "Install Rust"
         uses: dtolnay/rust-toolchain@stable
-        env:
-          ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
       - name: "Cache cargo"
         uses: actions/cache@v3
         with:

--- a/.github/workflows/gen_alpine3.15_continuous.yml
+++ b/.github/workflows/gen_alpine3.15_continuous.yml
@@ -60,8 +60,6 @@ jobs:
           submodules: "recursive"
       - name: "Install Rust"
         uses: dtolnay/rust-toolchain@stable
-        env:
-          ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
       - name: "Cache cargo"
         uses: actions/cache@v3
         with:

--- a/.github/workflows/gen_alpine3.15_continuous.yml
+++ b/.github/workflows/gen_alpine3.15_continuous.yml
@@ -59,12 +59,7 @@ jobs:
         with:
           submodules: "recursive"
       - name: "Install Rust"
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: "minimal"
-          toolchain: "stable"
-          override: true
-          components: "rustfmt"
+        uses: dtolnay/rust-toolchain@stable
         env:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
       - name: "Cache cargo"

--- a/.github/workflows/gen_alpine3.15_tag.yml
+++ b/.github/workflows/gen_alpine3.15_tag.yml
@@ -39,12 +39,7 @@ jobs:
         with:
           submodules: "recursive"
       - name: "Install Rust"
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: "minimal"
-          toolchain: "stable"
-          override: true
-          components: "rustfmt"
+        uses: dtolnay/rust-toolchain@stable
         env:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
       - name: "Cache cargo"

--- a/.github/workflows/gen_alpine3.15_tag.yml
+++ b/.github/workflows/gen_alpine3.15_tag.yml
@@ -40,8 +40,6 @@ jobs:
           submodules: "recursive"
       - name: "Install Rust"
         uses: dtolnay/rust-toolchain@stable
-        env:
-          ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
       - name: "Cache cargo"
         uses: actions/cache@v3
         with:

--- a/.github/workflows/gen_centos7.yml
+++ b/.github/workflows/gen_centos7.yml
@@ -74,6 +74,8 @@ jobs:
             curl --proto '=https' --tlsv1.2 --retry 10 -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain none -y
             echo "${CARGO_HOME:-$HOME/.cargo}/bin" >> $GITHUB_PATH
           fi
+      - name: "Setup Toolchain"
+        run: |
           rustup toolchain install stable --profile minimal --no-self-update
           rustup default stable
       - name: "Cache cargo"

--- a/.github/workflows/gen_centos7.yml
+++ b/.github/workflows/gen_centos7.yml
@@ -67,15 +67,18 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: "recursive"
-      - name: "Install Rust"
+      - name: "Install Rustup"
+        shell: bash
         run: |
-          : install rustup if needed
+
           if ! command -v rustup &>/dev/null; then
             curl --proto '=https' --tlsv1.2 --retry 10 -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain none -y
             echo "${CARGO_HOME:-$HOME/.cargo}/bin" >> $GITHUB_PATH
           fi
       - name: "Setup Toolchain"
+        shell: bash
         run: |
+
           rustup toolchain install stable --profile minimal --no-self-update
           rustup default stable
       - name: "Cache cargo"

--- a/.github/workflows/gen_centos7.yml
+++ b/.github/workflows/gen_centos7.yml
@@ -69,8 +69,6 @@ jobs:
           submodules: "recursive"
       - name: "Install Rust"
         uses: dtolnay/rust-toolchain@stable
-        env:
-          ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
       - name: "Cache cargo"
         uses: actions/cache@v3
         with:

--- a/.github/workflows/gen_centos7.yml
+++ b/.github/workflows/gen_centos7.yml
@@ -68,12 +68,7 @@ jobs:
         with:
           submodules: "recursive"
       - name: "Install Rust"
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: "minimal"
-          toolchain: "stable"
-          override: true
-          components: "rustfmt"
+        uses: dtolnay/rust-toolchain@stable
         env:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
       - name: "Cache cargo"

--- a/.github/workflows/gen_centos7.yml
+++ b/.github/workflows/gen_centos7.yml
@@ -68,7 +68,14 @@ jobs:
         with:
           submodules: "recursive"
       - name: "Install Rust"
-        uses: dtolnay/rust-toolchain@stable
+        run: |
+          : install rustup if needed
+          if ! command -v rustup &>/dev/null; then
+            curl --proto '=https' --tlsv1.2 --retry 10 -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain none -y
+            echo "${CARGO_HOME:-$HOME/.cargo}/bin" >> $GITHUB_PATH
+          fi
+          rustup toolchain install stable --profile minimal --no-self-update
+          rustup default stable
       - name: "Cache cargo"
         uses: actions/cache@v3
         with:

--- a/.github/workflows/gen_centos7_continuous.yml
+++ b/.github/workflows/gen_centos7_continuous.yml
@@ -72,7 +72,14 @@ jobs:
         with:
           submodules: "recursive"
       - name: "Install Rust"
-        uses: dtolnay/rust-toolchain@stable
+        run: |
+          : install rustup if needed
+          if ! command -v rustup &>/dev/null; then
+            curl --proto '=https' --tlsv1.2 --retry 10 -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain none -y
+            echo "${CARGO_HOME:-$HOME/.cargo}/bin" >> $GITHUB_PATH
+          fi
+          rustup toolchain install stable --profile minimal --no-self-update
+          rustup default stable
       - name: "Cache cargo"
         uses: actions/cache@v3
         with:

--- a/.github/workflows/gen_centos7_continuous.yml
+++ b/.github/workflows/gen_centos7_continuous.yml
@@ -73,8 +73,6 @@ jobs:
           submodules: "recursive"
       - name: "Install Rust"
         uses: dtolnay/rust-toolchain@stable
-        env:
-          ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
       - name: "Cache cargo"
         uses: actions/cache@v3
         with:

--- a/.github/workflows/gen_centos7_continuous.yml
+++ b/.github/workflows/gen_centos7_continuous.yml
@@ -78,6 +78,8 @@ jobs:
             curl --proto '=https' --tlsv1.2 --retry 10 -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain none -y
             echo "${CARGO_HOME:-$HOME/.cargo}/bin" >> $GITHUB_PATH
           fi
+      - name: "Setup Toolchain"
+        run: |
           rustup toolchain install stable --profile minimal --no-self-update
           rustup default stable
       - name: "Cache cargo"

--- a/.github/workflows/gen_centos7_continuous.yml
+++ b/.github/workflows/gen_centos7_continuous.yml
@@ -71,15 +71,18 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: "recursive"
-      - name: "Install Rust"
+      - name: "Install Rustup"
+        shell: bash
         run: |
-          : install rustup if needed
+
           if ! command -v rustup &>/dev/null; then
             curl --proto '=https' --tlsv1.2 --retry 10 -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain none -y
             echo "${CARGO_HOME:-$HOME/.cargo}/bin" >> $GITHUB_PATH
           fi
       - name: "Setup Toolchain"
+        shell: bash
         run: |
+
           rustup toolchain install stable --profile minimal --no-self-update
           rustup default stable
       - name: "Cache cargo"

--- a/.github/workflows/gen_centos7_continuous.yml
+++ b/.github/workflows/gen_centos7_continuous.yml
@@ -72,12 +72,7 @@ jobs:
         with:
           submodules: "recursive"
       - name: "Install Rust"
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: "minimal"
-          toolchain: "stable"
-          override: true
-          components: "rustfmt"
+        uses: dtolnay/rust-toolchain@stable
         env:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
       - name: "Cache cargo"

--- a/.github/workflows/gen_centos7_tag.yml
+++ b/.github/workflows/gen_centos7_tag.yml
@@ -57,6 +57,8 @@ jobs:
             curl --proto '=https' --tlsv1.2 --retry 10 -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain none -y
             echo "${CARGO_HOME:-$HOME/.cargo}/bin" >> $GITHUB_PATH
           fi
+      - name: "Setup Toolchain"
+        run: |
           rustup toolchain install stable --profile minimal --no-self-update
           rustup default stable
       - name: "Cache cargo"

--- a/.github/workflows/gen_centos7_tag.yml
+++ b/.github/workflows/gen_centos7_tag.yml
@@ -50,15 +50,18 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: "recursive"
-      - name: "Install Rust"
+      - name: "Install Rustup"
+        shell: bash
         run: |
-          : install rustup if needed
+
           if ! command -v rustup &>/dev/null; then
             curl --proto '=https' --tlsv1.2 --retry 10 -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain none -y
             echo "${CARGO_HOME:-$HOME/.cargo}/bin" >> $GITHUB_PATH
           fi
       - name: "Setup Toolchain"
+        shell: bash
         run: |
+
           rustup toolchain install stable --profile minimal --no-self-update
           rustup default stable
       - name: "Cache cargo"

--- a/.github/workflows/gen_centos7_tag.yml
+++ b/.github/workflows/gen_centos7_tag.yml
@@ -51,12 +51,7 @@ jobs:
         with:
           submodules: "recursive"
       - name: "Install Rust"
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: "minimal"
-          toolchain: "stable"
-          override: true
-          components: "rustfmt"
+        uses: dtolnay/rust-toolchain@stable
         env:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
       - name: "Cache cargo"

--- a/.github/workflows/gen_centos7_tag.yml
+++ b/.github/workflows/gen_centos7_tag.yml
@@ -51,7 +51,14 @@ jobs:
         with:
           submodules: "recursive"
       - name: "Install Rust"
-        uses: dtolnay/rust-toolchain@stable
+        run: |
+          : install rustup if needed
+          if ! command -v rustup &>/dev/null; then
+            curl --proto '=https' --tlsv1.2 --retry 10 -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain none -y
+            echo "${CARGO_HOME:-$HOME/.cargo}/bin" >> $GITHUB_PATH
+          fi
+          rustup toolchain install stable --profile minimal --no-self-update
+          rustup default stable
       - name: "Cache cargo"
         uses: actions/cache@v3
         with:

--- a/.github/workflows/gen_centos7_tag.yml
+++ b/.github/workflows/gen_centos7_tag.yml
@@ -52,8 +52,6 @@ jobs:
           submodules: "recursive"
       - name: "Install Rust"
         uses: dtolnay/rust-toolchain@stable
-        env:
-          ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
       - name: "Cache cargo"
         uses: actions/cache@v3
         with:

--- a/.github/workflows/gen_centos8.yml
+++ b/.github/workflows/gen_centos8.yml
@@ -55,8 +55,6 @@ jobs:
           submodules: "recursive"
       - name: "Install Rust"
         uses: dtolnay/rust-toolchain@stable
-        env:
-          ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
       - name: "Cache cargo"
         uses: actions/cache@v3
         with:

--- a/.github/workflows/gen_centos8.yml
+++ b/.github/workflows/gen_centos8.yml
@@ -54,12 +54,7 @@ jobs:
         with:
           submodules: "recursive"
       - name: "Install Rust"
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: "minimal"
-          toolchain: "stable"
-          override: true
-          components: "rustfmt"
+        uses: dtolnay/rust-toolchain@stable
         env:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
       - name: "Cache cargo"

--- a/.github/workflows/gen_centos8_continuous.yml
+++ b/.github/workflows/gen_centos8_continuous.yml
@@ -59,8 +59,6 @@ jobs:
           submodules: "recursive"
       - name: "Install Rust"
         uses: dtolnay/rust-toolchain@stable
-        env:
-          ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
       - name: "Cache cargo"
         uses: actions/cache@v3
         with:

--- a/.github/workflows/gen_centos8_continuous.yml
+++ b/.github/workflows/gen_centos8_continuous.yml
@@ -58,12 +58,7 @@ jobs:
         with:
           submodules: "recursive"
       - name: "Install Rust"
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: "minimal"
-          toolchain: "stable"
-          override: true
-          components: "rustfmt"
+        uses: dtolnay/rust-toolchain@stable
         env:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
       - name: "Cache cargo"

--- a/.github/workflows/gen_centos8_tag.yml
+++ b/.github/workflows/gen_centos8_tag.yml
@@ -38,8 +38,6 @@ jobs:
           submodules: "recursive"
       - name: "Install Rust"
         uses: dtolnay/rust-toolchain@stable
-        env:
-          ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
       - name: "Cache cargo"
         uses: actions/cache@v3
         with:

--- a/.github/workflows/gen_centos8_tag.yml
+++ b/.github/workflows/gen_centos8_tag.yml
@@ -37,12 +37,7 @@ jobs:
         with:
           submodules: "recursive"
       - name: "Install Rust"
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: "minimal"
-          toolchain: "stable"
-          override: true
-          components: "rustfmt"
+        uses: dtolnay/rust-toolchain@stable
         env:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
       - name: "Cache cargo"

--- a/.github/workflows/gen_centos9.yml
+++ b/.github/workflows/gen_centos9.yml
@@ -55,8 +55,6 @@ jobs:
           submodules: "recursive"
       - name: "Install Rust"
         uses: dtolnay/rust-toolchain@stable
-        env:
-          ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
       - name: "Cache cargo"
         uses: actions/cache@v3
         with:

--- a/.github/workflows/gen_centos9.yml
+++ b/.github/workflows/gen_centos9.yml
@@ -54,12 +54,7 @@ jobs:
         with:
           submodules: "recursive"
       - name: "Install Rust"
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: "minimal"
-          toolchain: "stable"
-          override: true
-          components: "rustfmt"
+        uses: dtolnay/rust-toolchain@stable
         env:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
       - name: "Cache cargo"

--- a/.github/workflows/gen_centos9_continuous.yml
+++ b/.github/workflows/gen_centos9_continuous.yml
@@ -59,8 +59,6 @@ jobs:
           submodules: "recursive"
       - name: "Install Rust"
         uses: dtolnay/rust-toolchain@stable
-        env:
-          ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
       - name: "Cache cargo"
         uses: actions/cache@v3
         with:

--- a/.github/workflows/gen_centos9_continuous.yml
+++ b/.github/workflows/gen_centos9_continuous.yml
@@ -58,12 +58,7 @@ jobs:
         with:
           submodules: "recursive"
       - name: "Install Rust"
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: "minimal"
-          toolchain: "stable"
-          override: true
-          components: "rustfmt"
+        uses: dtolnay/rust-toolchain@stable
         env:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
       - name: "Cache cargo"

--- a/.github/workflows/gen_centos9_tag.yml
+++ b/.github/workflows/gen_centos9_tag.yml
@@ -38,8 +38,6 @@ jobs:
           submodules: "recursive"
       - name: "Install Rust"
         uses: dtolnay/rust-toolchain@stable
-        env:
-          ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
       - name: "Cache cargo"
         uses: actions/cache@v3
         with:

--- a/.github/workflows/gen_centos9_tag.yml
+++ b/.github/workflows/gen_centos9_tag.yml
@@ -37,12 +37,7 @@ jobs:
         with:
           submodules: "recursive"
       - name: "Install Rust"
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: "minimal"
-          toolchain: "stable"
-          override: true
-          components: "rustfmt"
+        uses: dtolnay/rust-toolchain@stable
         env:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
       - name: "Cache cargo"

--- a/.github/workflows/gen_debian10.3.yml
+++ b/.github/workflows/gen_debian10.3.yml
@@ -57,12 +57,7 @@ jobs:
         with:
           submodules: "recursive"
       - name: "Install Rust"
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: "minimal"
-          toolchain: "stable"
-          override: true
-          components: "rustfmt"
+        uses: dtolnay/rust-toolchain@stable
         env:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
       - name: "Cache cargo"

--- a/.github/workflows/gen_debian10.3.yml
+++ b/.github/workflows/gen_debian10.3.yml
@@ -58,8 +58,6 @@ jobs:
           submodules: "recursive"
       - name: "Install Rust"
         uses: dtolnay/rust-toolchain@stable
-        env:
-          ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
       - name: "Cache cargo"
         uses: actions/cache@v3
         with:

--- a/.github/workflows/gen_debian10.3_continuous.yml
+++ b/.github/workflows/gen_debian10.3_continuous.yml
@@ -62,8 +62,6 @@ jobs:
           submodules: "recursive"
       - name: "Install Rust"
         uses: dtolnay/rust-toolchain@stable
-        env:
-          ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
       - name: "Cache cargo"
         uses: actions/cache@v3
         with:

--- a/.github/workflows/gen_debian10.3_continuous.yml
+++ b/.github/workflows/gen_debian10.3_continuous.yml
@@ -61,12 +61,7 @@ jobs:
         with:
           submodules: "recursive"
       - name: "Install Rust"
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: "minimal"
-          toolchain: "stable"
-          override: true
-          components: "rustfmt"
+        uses: dtolnay/rust-toolchain@stable
         env:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
       - name: "Cache cargo"

--- a/.github/workflows/gen_debian10.3_tag.yml
+++ b/.github/workflows/gen_debian10.3_tag.yml
@@ -41,8 +41,6 @@ jobs:
           submodules: "recursive"
       - name: "Install Rust"
         uses: dtolnay/rust-toolchain@stable
-        env:
-          ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
       - name: "Cache cargo"
         uses: actions/cache@v3
         with:

--- a/.github/workflows/gen_debian10.3_tag.yml
+++ b/.github/workflows/gen_debian10.3_tag.yml
@@ -40,12 +40,7 @@ jobs:
         with:
           submodules: "recursive"
       - name: "Install Rust"
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: "minimal"
-          toolchain: "stable"
-          override: true
-          components: "rustfmt"
+        uses: dtolnay/rust-toolchain@stable
         env:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
       - name: "Cache cargo"

--- a/.github/workflows/gen_debian11.yml
+++ b/.github/workflows/gen_debian11.yml
@@ -57,12 +57,7 @@ jobs:
         with:
           submodules: "recursive"
       - name: "Install Rust"
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: "minimal"
-          toolchain: "stable"
-          override: true
-          components: "rustfmt"
+        uses: dtolnay/rust-toolchain@stable
         env:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
       - name: "Cache cargo"

--- a/.github/workflows/gen_debian11.yml
+++ b/.github/workflows/gen_debian11.yml
@@ -58,8 +58,6 @@ jobs:
           submodules: "recursive"
       - name: "Install Rust"
         uses: dtolnay/rust-toolchain@stable
-        env:
-          ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
       - name: "Cache cargo"
         uses: actions/cache@v3
         with:

--- a/.github/workflows/gen_debian11_continuous.yml
+++ b/.github/workflows/gen_debian11_continuous.yml
@@ -62,8 +62,6 @@ jobs:
           submodules: "recursive"
       - name: "Install Rust"
         uses: dtolnay/rust-toolchain@stable
-        env:
-          ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
       - name: "Cache cargo"
         uses: actions/cache@v3
         with:

--- a/.github/workflows/gen_debian11_continuous.yml
+++ b/.github/workflows/gen_debian11_continuous.yml
@@ -61,12 +61,7 @@ jobs:
         with:
           submodules: "recursive"
       - name: "Install Rust"
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: "minimal"
-          toolchain: "stable"
-          override: true
-          components: "rustfmt"
+        uses: dtolnay/rust-toolchain@stable
         env:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
       - name: "Cache cargo"

--- a/.github/workflows/gen_debian11_tag.yml
+++ b/.github/workflows/gen_debian11_tag.yml
@@ -41,8 +41,6 @@ jobs:
           submodules: "recursive"
       - name: "Install Rust"
         uses: dtolnay/rust-toolchain@stable
-        env:
-          ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
       - name: "Cache cargo"
         uses: actions/cache@v3
         with:

--- a/.github/workflows/gen_debian11_tag.yml
+++ b/.github/workflows/gen_debian11_tag.yml
@@ -40,12 +40,7 @@ jobs:
         with:
           submodules: "recursive"
       - name: "Install Rust"
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: "minimal"
-          toolchain: "stable"
-          override: true
-          components: "rustfmt"
+        uses: dtolnay/rust-toolchain@stable
         env:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
       - name: "Cache cargo"

--- a/.github/workflows/gen_fedora35.yml
+++ b/.github/workflows/gen_fedora35.yml
@@ -51,12 +51,7 @@ jobs:
         with:
           submodules: "recursive"
       - name: "Install Rust"
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: "minimal"
-          toolchain: "stable"
-          override: true
-          components: "rustfmt"
+        uses: dtolnay/rust-toolchain@stable
         env:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
       - name: "Cache cargo"

--- a/.github/workflows/gen_fedora35.yml
+++ b/.github/workflows/gen_fedora35.yml
@@ -52,8 +52,6 @@ jobs:
           submodules: "recursive"
       - name: "Install Rust"
         uses: dtolnay/rust-toolchain@stable
-        env:
-          ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
       - name: "Cache cargo"
         uses: actions/cache@v3
         with:

--- a/.github/workflows/gen_fedora35_continuous.yml
+++ b/.github/workflows/gen_fedora35_continuous.yml
@@ -56,8 +56,6 @@ jobs:
           submodules: "recursive"
       - name: "Install Rust"
         uses: dtolnay/rust-toolchain@stable
-        env:
-          ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
       - name: "Cache cargo"
         uses: actions/cache@v3
         with:

--- a/.github/workflows/gen_fedora35_continuous.yml
+++ b/.github/workflows/gen_fedora35_continuous.yml
@@ -55,12 +55,7 @@ jobs:
         with:
           submodules: "recursive"
       - name: "Install Rust"
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: "minimal"
-          toolchain: "stable"
-          override: true
-          components: "rustfmt"
+        uses: dtolnay/rust-toolchain@stable
         env:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
       - name: "Cache cargo"

--- a/.github/workflows/gen_fedora35_tag.yml
+++ b/.github/workflows/gen_fedora35_tag.yml
@@ -34,12 +34,7 @@ jobs:
         with:
           submodules: "recursive"
       - name: "Install Rust"
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: "minimal"
-          toolchain: "stable"
-          override: true
-          components: "rustfmt"
+        uses: dtolnay/rust-toolchain@stable
         env:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
       - name: "Cache cargo"

--- a/.github/workflows/gen_fedora35_tag.yml
+++ b/.github/workflows/gen_fedora35_tag.yml
@@ -35,8 +35,6 @@ jobs:
           submodules: "recursive"
       - name: "Install Rust"
         uses: dtolnay/rust-toolchain@stable
-        env:
-          ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
       - name: "Cache cargo"
         uses: actions/cache@v3
         with:

--- a/.github/workflows/gen_fedora36.yml
+++ b/.github/workflows/gen_fedora36.yml
@@ -51,12 +51,7 @@ jobs:
         with:
           submodules: "recursive"
       - name: "Install Rust"
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: "minimal"
-          toolchain: "stable"
-          override: true
-          components: "rustfmt"
+        uses: dtolnay/rust-toolchain@stable
         env:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
       - name: "Cache cargo"

--- a/.github/workflows/gen_fedora36.yml
+++ b/.github/workflows/gen_fedora36.yml
@@ -52,8 +52,6 @@ jobs:
           submodules: "recursive"
       - name: "Install Rust"
         uses: dtolnay/rust-toolchain@stable
-        env:
-          ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
       - name: "Cache cargo"
         uses: actions/cache@v3
         with:

--- a/.github/workflows/gen_fedora36_continuous.yml
+++ b/.github/workflows/gen_fedora36_continuous.yml
@@ -56,8 +56,6 @@ jobs:
           submodules: "recursive"
       - name: "Install Rust"
         uses: dtolnay/rust-toolchain@stable
-        env:
-          ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
       - name: "Cache cargo"
         uses: actions/cache@v3
         with:

--- a/.github/workflows/gen_fedora36_continuous.yml
+++ b/.github/workflows/gen_fedora36_continuous.yml
@@ -55,12 +55,7 @@ jobs:
         with:
           submodules: "recursive"
       - name: "Install Rust"
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: "minimal"
-          toolchain: "stable"
-          override: true
-          components: "rustfmt"
+        uses: dtolnay/rust-toolchain@stable
         env:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
       - name: "Cache cargo"

--- a/.github/workflows/gen_fedora36_tag.yml
+++ b/.github/workflows/gen_fedora36_tag.yml
@@ -34,12 +34,7 @@ jobs:
         with:
           submodules: "recursive"
       - name: "Install Rust"
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: "minimal"
-          toolchain: "stable"
-          override: true
-          components: "rustfmt"
+        uses: dtolnay/rust-toolchain@stable
         env:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
       - name: "Cache cargo"

--- a/.github/workflows/gen_fedora36_tag.yml
+++ b/.github/workflows/gen_fedora36_tag.yml
@@ -35,8 +35,6 @@ jobs:
           submodules: "recursive"
       - name: "Install Rust"
         uses: dtolnay/rust-toolchain@stable
-        env:
-          ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
       - name: "Cache cargo"
         uses: actions/cache@v3
         with:

--- a/.github/workflows/gen_fedora37.yml
+++ b/.github/workflows/gen_fedora37.yml
@@ -51,12 +51,7 @@ jobs:
         with:
           submodules: "recursive"
       - name: "Install Rust"
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: "minimal"
-          toolchain: "stable"
-          override: true
-          components: "rustfmt"
+        uses: dtolnay/rust-toolchain@stable
         env:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
       - name: "Cache cargo"

--- a/.github/workflows/gen_fedora37.yml
+++ b/.github/workflows/gen_fedora37.yml
@@ -52,8 +52,6 @@ jobs:
           submodules: "recursive"
       - name: "Install Rust"
         uses: dtolnay/rust-toolchain@stable
-        env:
-          ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
       - name: "Cache cargo"
         uses: actions/cache@v3
         with:

--- a/.github/workflows/gen_fedora37_continuous.yml
+++ b/.github/workflows/gen_fedora37_continuous.yml
@@ -56,8 +56,6 @@ jobs:
           submodules: "recursive"
       - name: "Install Rust"
         uses: dtolnay/rust-toolchain@stable
-        env:
-          ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
       - name: "Cache cargo"
         uses: actions/cache@v3
         with:

--- a/.github/workflows/gen_fedora37_continuous.yml
+++ b/.github/workflows/gen_fedora37_continuous.yml
@@ -55,12 +55,7 @@ jobs:
         with:
           submodules: "recursive"
       - name: "Install Rust"
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: "minimal"
-          toolchain: "stable"
-          override: true
-          components: "rustfmt"
+        uses: dtolnay/rust-toolchain@stable
         env:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
       - name: "Cache cargo"

--- a/.github/workflows/gen_fedora37_tag.yml
+++ b/.github/workflows/gen_fedora37_tag.yml
@@ -34,12 +34,7 @@ jobs:
         with:
           submodules: "recursive"
       - name: "Install Rust"
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: "minimal"
-          toolchain: "stable"
-          override: true
-          components: "rustfmt"
+        uses: dtolnay/rust-toolchain@stable
         env:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
       - name: "Cache cargo"

--- a/.github/workflows/gen_fedora37_tag.yml
+++ b/.github/workflows/gen_fedora37_tag.yml
@@ -35,8 +35,6 @@ jobs:
           submodules: "recursive"
       - name: "Install Rust"
         uses: dtolnay/rust-toolchain@stable
-        env:
-          ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
       - name: "Cache cargo"
         uses: actions/cache@v3
         with:

--- a/.github/workflows/gen_macos.yml
+++ b/.github/workflows/gen_macos.yml
@@ -30,12 +30,7 @@ jobs:
         with:
           submodules: "recursive"
       - name: "Install Rust"
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: "minimal"
-          toolchain: "stable"
-          override: true
-          components: "rustfmt"
+        uses: dtolnay/rust-toolchain@stable
         env:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
       - name: "Install Rust (ARM)"

--- a/.github/workflows/gen_macos.yml
+++ b/.github/workflows/gen_macos.yml
@@ -31,8 +31,6 @@ jobs:
           submodules: "recursive"
       - name: "Install Rust"
         uses: dtolnay/rust-toolchain@stable
-        env:
-          ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
       - name: "Install Rust (ARM)"
         shell: bash
         run: "rustup target add aarch64-apple-darwin"

--- a/.github/workflows/gen_macos_continuous.yml
+++ b/.github/workflows/gen_macos_continuous.yml
@@ -34,8 +34,6 @@ jobs:
           submodules: "recursive"
       - name: "Install Rust"
         uses: dtolnay/rust-toolchain@stable
-        env:
-          ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
       - name: "Install Rust (ARM)"
         shell: bash
         run: "rustup target add aarch64-apple-darwin"

--- a/.github/workflows/gen_macos_continuous.yml
+++ b/.github/workflows/gen_macos_continuous.yml
@@ -33,12 +33,7 @@ jobs:
         with:
           submodules: "recursive"
       - name: "Install Rust"
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: "minimal"
-          toolchain: "stable"
-          override: true
-          components: "rustfmt"
+        uses: dtolnay/rust-toolchain@stable
         env:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
       - name: "Install Rust (ARM)"

--- a/.github/workflows/gen_macos_tag.yml
+++ b/.github/workflows/gen_macos_tag.yml
@@ -18,12 +18,7 @@ jobs:
         with:
           submodules: "recursive"
       - name: "Install Rust"
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: "minimal"
-          toolchain: "stable"
-          override: true
-          components: "rustfmt"
+        uses: dtolnay/rust-toolchain@stable
         env:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
       - name: "Install Rust (ARM)"

--- a/.github/workflows/gen_macos_tag.yml
+++ b/.github/workflows/gen_macos_tag.yml
@@ -19,8 +19,6 @@ jobs:
           submodules: "recursive"
       - name: "Install Rust"
         uses: dtolnay/rust-toolchain@stable
-        env:
-          ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
       - name: "Install Rust (ARM)"
         shell: bash
         run: "rustup target add aarch64-apple-darwin"

--- a/.github/workflows/gen_opensuse_leap.yml
+++ b/.github/workflows/gen_opensuse_leap.yml
@@ -55,8 +55,6 @@ jobs:
           submodules: "recursive"
       - name: "Install Rust"
         uses: dtolnay/rust-toolchain@stable
-        env:
-          ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
       - name: "Cache cargo"
         uses: actions/cache@v3
         with:

--- a/.github/workflows/gen_opensuse_leap.yml
+++ b/.github/workflows/gen_opensuse_leap.yml
@@ -54,12 +54,7 @@ jobs:
         with:
           submodules: "recursive"
       - name: "Install Rust"
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: "minimal"
-          toolchain: "stable"
-          override: true
-          components: "rustfmt"
+        uses: dtolnay/rust-toolchain@stable
         env:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
       - name: "Cache cargo"

--- a/.github/workflows/gen_opensuse_leap_continuous.yml
+++ b/.github/workflows/gen_opensuse_leap_continuous.yml
@@ -59,8 +59,6 @@ jobs:
           submodules: "recursive"
       - name: "Install Rust"
         uses: dtolnay/rust-toolchain@stable
-        env:
-          ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
       - name: "Cache cargo"
         uses: actions/cache@v3
         with:

--- a/.github/workflows/gen_opensuse_leap_continuous.yml
+++ b/.github/workflows/gen_opensuse_leap_continuous.yml
@@ -58,12 +58,7 @@ jobs:
         with:
           submodules: "recursive"
       - name: "Install Rust"
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: "minimal"
-          toolchain: "stable"
-          override: true
-          components: "rustfmt"
+        uses: dtolnay/rust-toolchain@stable
         env:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
       - name: "Cache cargo"

--- a/.github/workflows/gen_opensuse_leap_tag.yml
+++ b/.github/workflows/gen_opensuse_leap_tag.yml
@@ -38,8 +38,6 @@ jobs:
           submodules: "recursive"
       - name: "Install Rust"
         uses: dtolnay/rust-toolchain@stable
-        env:
-          ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
       - name: "Cache cargo"
         uses: actions/cache@v3
         with:

--- a/.github/workflows/gen_opensuse_leap_tag.yml
+++ b/.github/workflows/gen_opensuse_leap_tag.yml
@@ -37,12 +37,7 @@ jobs:
         with:
           submodules: "recursive"
       - name: "Install Rust"
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: "minimal"
-          toolchain: "stable"
-          override: true
-          components: "rustfmt"
+        uses: dtolnay/rust-toolchain@stable
         env:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
       - name: "Cache cargo"

--- a/.github/workflows/gen_opensuse_tumbleweed.yml
+++ b/.github/workflows/gen_opensuse_tumbleweed.yml
@@ -57,12 +57,7 @@ jobs:
         with:
           submodules: "recursive"
       - name: "Install Rust"
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: "minimal"
-          toolchain: "stable"
-          override: true
-          components: "rustfmt"
+        uses: dtolnay/rust-toolchain@stable
         env:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
       - name: "Cache cargo"

--- a/.github/workflows/gen_opensuse_tumbleweed.yml
+++ b/.github/workflows/gen_opensuse_tumbleweed.yml
@@ -58,8 +58,6 @@ jobs:
           submodules: "recursive"
       - name: "Install Rust"
         uses: dtolnay/rust-toolchain@stable
-        env:
-          ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
       - name: "Cache cargo"
         uses: actions/cache@v3
         with:

--- a/.github/workflows/gen_opensuse_tumbleweed_continuous.yml
+++ b/.github/workflows/gen_opensuse_tumbleweed_continuous.yml
@@ -62,8 +62,6 @@ jobs:
           submodules: "recursive"
       - name: "Install Rust"
         uses: dtolnay/rust-toolchain@stable
-        env:
-          ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
       - name: "Cache cargo"
         uses: actions/cache@v3
         with:

--- a/.github/workflows/gen_opensuse_tumbleweed_continuous.yml
+++ b/.github/workflows/gen_opensuse_tumbleweed_continuous.yml
@@ -61,12 +61,7 @@ jobs:
         with:
           submodules: "recursive"
       - name: "Install Rust"
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: "minimal"
-          toolchain: "stable"
-          override: true
-          components: "rustfmt"
+        uses: dtolnay/rust-toolchain@stable
         env:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
       - name: "Cache cargo"

--- a/.github/workflows/gen_opensuse_tumbleweed_tag.yml
+++ b/.github/workflows/gen_opensuse_tumbleweed_tag.yml
@@ -41,8 +41,6 @@ jobs:
           submodules: "recursive"
       - name: "Install Rust"
         uses: dtolnay/rust-toolchain@stable
-        env:
-          ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
       - name: "Cache cargo"
         uses: actions/cache@v3
         with:

--- a/.github/workflows/gen_opensuse_tumbleweed_tag.yml
+++ b/.github/workflows/gen_opensuse_tumbleweed_tag.yml
@@ -40,12 +40,7 @@ jobs:
         with:
           submodules: "recursive"
       - name: "Install Rust"
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: "minimal"
-          toolchain: "stable"
-          override: true
-          components: "rustfmt"
+        uses: dtolnay/rust-toolchain@stable
         env:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
       - name: "Cache cargo"

--- a/.github/workflows/gen_ubuntu20.04.yml
+++ b/.github/workflows/gen_ubuntu20.04.yml
@@ -63,8 +63,6 @@ jobs:
           submodules: "recursive"
       - name: "Install Rust"
         uses: dtolnay/rust-toolchain@stable
-        env:
-          ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
       - name: "Cache cargo"
         uses: actions/cache@v3
         with:

--- a/.github/workflows/gen_ubuntu20.04.yml
+++ b/.github/workflows/gen_ubuntu20.04.yml
@@ -62,12 +62,7 @@ jobs:
         with:
           submodules: "recursive"
       - name: "Install Rust"
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: "minimal"
-          toolchain: "stable"
-          override: true
-          components: "rustfmt"
+        uses: dtolnay/rust-toolchain@stable
         env:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
       - name: "Cache cargo"

--- a/.github/workflows/gen_ubuntu20.04_continuous.yml
+++ b/.github/workflows/gen_ubuntu20.04_continuous.yml
@@ -67,8 +67,6 @@ jobs:
           submodules: "recursive"
       - name: "Install Rust"
         uses: dtolnay/rust-toolchain@stable
-        env:
-          ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
       - name: "Cache cargo"
         uses: actions/cache@v3
         with:

--- a/.github/workflows/gen_ubuntu20.04_continuous.yml
+++ b/.github/workflows/gen_ubuntu20.04_continuous.yml
@@ -66,12 +66,7 @@ jobs:
         with:
           submodules: "recursive"
       - name: "Install Rust"
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: "minimal"
-          toolchain: "stable"
-          override: true
-          components: "rustfmt"
+        uses: dtolnay/rust-toolchain@stable
         env:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
       - name: "Cache cargo"

--- a/.github/workflows/gen_ubuntu20.04_tag.yml
+++ b/.github/workflows/gen_ubuntu20.04_tag.yml
@@ -43,8 +43,6 @@ jobs:
           submodules: "recursive"
       - name: "Install Rust"
         uses: dtolnay/rust-toolchain@stable
-        env:
-          ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
       - name: "Cache cargo"
         uses: actions/cache@v3
         with:

--- a/.github/workflows/gen_ubuntu20.04_tag.yml
+++ b/.github/workflows/gen_ubuntu20.04_tag.yml
@@ -42,12 +42,7 @@ jobs:
         with:
           submodules: "recursive"
       - name: "Install Rust"
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: "minimal"
-          toolchain: "stable"
-          override: true
-          components: "rustfmt"
+        uses: dtolnay/rust-toolchain@stable
         env:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
       - name: "Cache cargo"

--- a/.github/workflows/gen_ubuntu22.04.yml
+++ b/.github/workflows/gen_ubuntu22.04.yml
@@ -57,12 +57,7 @@ jobs:
         with:
           submodules: "recursive"
       - name: "Install Rust"
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: "minimal"
-          toolchain: "stable"
-          override: true
-          components: "rustfmt"
+        uses: dtolnay/rust-toolchain@stable
         env:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
       - name: "Cache cargo"

--- a/.github/workflows/gen_ubuntu22.04.yml
+++ b/.github/workflows/gen_ubuntu22.04.yml
@@ -58,8 +58,6 @@ jobs:
           submodules: "recursive"
       - name: "Install Rust"
         uses: dtolnay/rust-toolchain@stable
-        env:
-          ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
       - name: "Cache cargo"
         uses: actions/cache@v3
         with:

--- a/.github/workflows/gen_ubuntu22.04_continuous.yml
+++ b/.github/workflows/gen_ubuntu22.04_continuous.yml
@@ -62,8 +62,6 @@ jobs:
           submodules: "recursive"
       - name: "Install Rust"
         uses: dtolnay/rust-toolchain@stable
-        env:
-          ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
       - name: "Cache cargo"
         uses: actions/cache@v3
         with:

--- a/.github/workflows/gen_ubuntu22.04_continuous.yml
+++ b/.github/workflows/gen_ubuntu22.04_continuous.yml
@@ -61,12 +61,7 @@ jobs:
         with:
           submodules: "recursive"
       - name: "Install Rust"
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: "minimal"
-          toolchain: "stable"
-          override: true
-          components: "rustfmt"
+        uses: dtolnay/rust-toolchain@stable
         env:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
       - name: "Cache cargo"

--- a/.github/workflows/gen_ubuntu22.04_tag.yml
+++ b/.github/workflows/gen_ubuntu22.04_tag.yml
@@ -41,8 +41,6 @@ jobs:
           submodules: "recursive"
       - name: "Install Rust"
         uses: dtolnay/rust-toolchain@stable
-        env:
-          ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
       - name: "Cache cargo"
         uses: actions/cache@v3
         with:

--- a/.github/workflows/gen_ubuntu22.04_tag.yml
+++ b/.github/workflows/gen_ubuntu22.04_tag.yml
@@ -40,12 +40,7 @@ jobs:
         with:
           submodules: "recursive"
       - name: "Install Rust"
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: "minimal"
-          toolchain: "stable"
-          override: true
-          components: "rustfmt"
+        uses: dtolnay/rust-toolchain@stable
         env:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
       - name: "Cache cargo"

--- a/.github/workflows/gen_windows.yml
+++ b/.github/workflows/gen_windows.yml
@@ -29,8 +29,6 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           target: "x86_64-pc-windows-msvc"
-        env:
-          ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
       - name: "Cache cargo"
         uses: actions/cache@v3
         with:

--- a/.github/workflows/gen_windows.yml
+++ b/.github/workflows/gen_windows.yml
@@ -26,12 +26,8 @@ jobs:
         with:
           submodules: "recursive"
       - name: "Install Rust"
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-          profile: "minimal"
-          toolchain: "stable"
-          override: true
-          components: "rustfmt"
           target: "x86_64-pc-windows-msvc"
         env:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"

--- a/.github/workflows/gen_windows_continuous.yml
+++ b/.github/workflows/gen_windows_continuous.yml
@@ -33,8 +33,6 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           target: "x86_64-pc-windows-msvc"
-        env:
-          ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
       - name: "Cache cargo"
         uses: actions/cache@v3
         with:

--- a/.github/workflows/gen_windows_continuous.yml
+++ b/.github/workflows/gen_windows_continuous.yml
@@ -30,12 +30,8 @@ jobs:
         with:
           submodules: "recursive"
       - name: "Install Rust"
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-          profile: "minimal"
-          toolchain: "stable"
-          override: true
-          components: "rustfmt"
           target: "x86_64-pc-windows-msvc"
         env:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"

--- a/.github/workflows/gen_windows_tag.yml
+++ b/.github/workflows/gen_windows_tag.yml
@@ -19,8 +19,6 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           target: "x86_64-pc-windows-msvc"
-        env:
-          ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
       - name: "Cache cargo"
         uses: actions/cache@v3
         with:

--- a/.github/workflows/gen_windows_tag.yml
+++ b/.github/workflows/gen_windows_tag.yml
@@ -16,12 +16,8 @@ jobs:
         with:
           submodules: "recursive"
       - name: "Install Rust"
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-          profile: "minimal"
-          toolchain: "stable"
-          override: true
-          components: "rustfmt"
           target: "x86_64-pc-windows-msvc"
         env:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -32,15 +32,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: "Install Rust"
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: "minimal"
-          toolchain: "stable"
-          default: true
-          override: true
-          components: "rustfmt"
-        env:
-          ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
+        uses: dtolnay/rust-toolchain@stable
       - name: Install gelatyx
         uses: baptiste0928/cargo-install@v1
         with:

--- a/.github/workflows/termwiz.yml
+++ b/.github/workflows/termwiz.yml
@@ -31,13 +31,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: "Install Rust"
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: "minimal"
-          toolchain: "stable"
-          override: true
-        env:
-          ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
+        uses: dtolnay/rust-toolchain@stable
       - name: Build
         run: |
           source $HOME/.cargo/env
@@ -50,13 +44,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: "Install Rust"
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: "minimal"
-          toolchain: "nightly"
-          override: true
-        env:
-          ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
+        uses: dtolnay/rust-toolchain@nightly
       - name: "Cache cargo"
         uses: actions/cache@v3
         with:

--- a/.github/workflows/verify-pages.yml
+++ b/.github/workflows/verify-pages.yml
@@ -20,13 +20,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: "Install Rust"
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: "minimal"
-          toolchain: "stable"
-          override: true
-        env:
-          ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
+        uses: dtolnay/rust-toolchain@stable
       - name: Install gelatyx
         uses: baptiste0928/cargo-install@v1
         with:

--- a/.github/workflows/wezterm_ssh.yml
+++ b/.github/workflows/wezterm_ssh.yml
@@ -29,13 +29,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: "Install Rust"
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: "minimal"
-          toolchain: "stable"
-          override: true
-        env:
-          ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
+        uses: dtolnay/rust-toolchain@stable
       - name: Build
         run: |
           source $HOME/.cargo/env
@@ -47,13 +41,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: "Install Rust"
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: "minimal"
-          toolchain: "stable"
-          override: true
-        env:
-          ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
+        uses: dtolnay/rust-toolchain@stable
       - name: Build
         run: |
           source $HOME/.cargo/env

--- a/ci/generate-workflows.py
+++ b/ci/generate-workflows.py
@@ -325,21 +325,16 @@ ln -s /usr/local/git/bin/git /usr/local/bin/git""",
 
         return steps
 
-    def install_rust(self, cache=True):
+    def install_rust(self, cache=True, toolchain="stable"):
         salt = "2"
         key_prefix = f"{self.name}-{self.rust_target}-{salt}-${{{{ runner.os }}}}-${{{{ hashFiles('**/Cargo.lock') }}}}"
-        params = {
-            "profile": "minimal",
-            "toolchain": "stable",
-            "override": True,
-            "components": "rustfmt",
-        }
+        params = dict()
         if self.rust_target:
             params["target"] = self.rust_target
         steps = [
             ActionStep(
                 name="Install Rust",
-                action="actions-rs/toolchain@v1",
+                action=f"dtolnay/rust-toolchain@{toolchain}",
                 params=params,
                 env={"ACTIONS_ALLOW_UNSECURE_COMMANDS": "true"},
             ),

--- a/ci/generate-workflows.py
+++ b/ci/generate-workflows.py
@@ -338,6 +338,25 @@ ln -s /usr/local/git/bin/git /usr/local/bin/git""",
                 params=params,
             ),
         ]
+        if "centos7" in self.name:
+            steps = [
+                RunStep(
+                    name="Install Rustup",
+                    run = """
+if ! command -v rustup &>/dev/null; then
+  curl --proto '=https' --tlsv1.2 --retry 10 -fsSL "https://sh.rustup.rs" | sh -s -- --default-toolchain none -y
+  echo "${CARGO_HOME:-$HOME/.cargo}/bin" >> $GITHUB_PATH
+fi
+"""
+                ),
+                RunStep(
+                    name="Setup Toolchain",
+                    run =f"""
+rustup toolchain install {toolchain} --profile minimal --no-self-update
+rustup default {toolchain}
+"""
+                ),
+            ]
         if "macos" in self.name:
             steps += [
                 RunStep(

--- a/ci/generate-workflows.py
+++ b/ci/generate-workflows.py
@@ -331,15 +331,10 @@ ln -s /usr/local/git/bin/git /usr/local/bin/git""",
         params = dict()
         if self.rust_target:
             params["target"] = self.rust_target
-        steps = [
-            ActionStep(
-                name="Install Rust",
-                action=f"dtolnay/rust-toolchain@{toolchain}",
-                params=params,
-            ),
-        ]
+        steps = []
+        # Manually setup rust toolchain in CentOS7 curl is too old for the action
         if "centos7" in self.name:
-            steps = [
+            steps += [
                 RunStep(
                     name="Install Rustup",
                     run = """
@@ -355,6 +350,14 @@ fi
 rustup toolchain install {toolchain} --profile minimal --no-self-update
 rustup default {toolchain}
 """
+                ),
+            ]
+        else:
+            steps += [
+                ActionStep(
+                    name="Install Rust",
+                    action=f"dtolnay/rust-toolchain@{toolchain}",
+                    params=params,
                 ),
             ]
         if "macos" in self.name:

--- a/ci/generate-workflows.py
+++ b/ci/generate-workflows.py
@@ -336,7 +336,6 @@ ln -s /usr/local/git/bin/git /usr/local/bin/git""",
                 name="Install Rust",
                 action=f"dtolnay/rust-toolchain@{toolchain}",
                 params=params,
-                env={"ACTIONS_ALLOW_UNSECURE_COMMANDS": "true"},
             ),
         ]
         if "macos" in self.name:


### PR DESCRIPTION
[actions-rs/toolchain](https://github.com/actions-rs/toolchain) is **unsupported**:

- Has not recieved updates since November 2020 (~2.5 years)
- It uses Node.js 12 and GitHub will stop supporting it Summer this year(?) see this [article](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/).

[dtolnay/rust-toolchain](https://github.com/dtolnay/rust-toolchain) is actively supported and its mostly a 1-1 replacement, the differences are:

- Uses the minimal profile always, so no need to specify it.
- There is no need to override the toolchain.

I also removed some things:

- None of the generated actions use `rustfmt` so I removed the component
- The toolchain is always stable, so I specified it in the action itself instead of in the action parameters.

### Follow up questions

I am in the process of planning a follow up PR to run less CI workflows if one fails and I have some questions about it:

1. Is this of any interest to you? I don't want you to review something you are not interested in.
2. Is it okay not to run `_continous` workflows if the non continous one fails?
3. Is it okay to run one Linux workflow first (I am thinking Ubuntu22.04), and skip all other Linux workflows if it fails? It would still run the MacOS/Windows workflows.
4. Is it okay to run `cargo check` instead of `cargo build` in the non `_tag`/`_continous` workflows? Should be much faster than a full compile/optimize run.