### PR TITLE
perf(stats): add toggle to enable stat recording

### DIFF
--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -756,6 +756,9 @@ pub struct Config {
 
     #[dynamic(default)]
     pub quote_dropped_files: DroppedFileQuoting,
+
+    #[dynamic(default)]
+    pub record_statistics: bool,
 }
 impl_lua_conversion_dynamic!(Config);
 

--- a/docs/config/lua/config/record_statistics.md
+++ b/docs/config/lua/config/record_statistics.md
@@ -1,0 +1,6 @@
+# `record_statistics = false`
+
+*Since nightly builds only*
+
+When set to true, wezterm will record performance statistics (available via
+`wezterm.metrics`.)


### PR DESCRIPTION
Add configuration `record_statistics` to control recording of performance statistics.

By default, stats are *not* recorded as ignoring metrics improves performance.

As an example, `cmatrix -u0` on a M2 Pro as measured by htop -d5:

* with stats enabled: 43% CPU
* with stats disabled: 39% CPU

Can be enabled with:

```lua
config.record_statistics = true
```

in `wezterm.lua`