### PR TITLE
Fix transparent title bar on macOS with `window_decorations = "RESIZE|MACOS_FORCE_DISABLE_SHADOW"`

### DIFF
--- a/window/src/os/macos/window.rs
+++ b/window/src/os/macos/window.rs
@@ -1230,7 +1230,8 @@ fn apply_decorations_to_window(window: &StrongPtr, decorations: WindowDecoration
 
 fn decoration_to_mask(decorations: WindowDecorations) -> NSWindowStyleMask {
     let decorations = decorations.difference(
-        WindowDecorations::MACOS_FORCE_DISABLE_SHADOW | WindowDecorations::MACOS_FORCE_ENABLE_SHADOW
+        WindowDecorations::MACOS_FORCE_DISABLE_SHADOW
+            | WindowDecorations::MACOS_FORCE_ENABLE_SHADOW,
     );
     if decorations == WindowDecorations::TITLE | WindowDecorations::RESIZE {
         NSWindowStyleMask::NSTitledWindowMask

--- a/window/src/os/macos/window.rs
+++ b/window/src/os/macos/window.rs
@@ -1229,6 +1229,9 @@ fn apply_decorations_to_window(window: &StrongPtr, decorations: WindowDecoration
 }
 
 fn decoration_to_mask(decorations: WindowDecorations) -> NSWindowStyleMask {
+    let decorations = decorations.difference(
+        WindowDecorations::MACOS_FORCE_DISABLE_SHADOW | WindowDecorations::MACOS_FORCE_ENABLE_SHADOW
+    );
     if decorations == WindowDecorations::TITLE | WindowDecorations::RESIZE {
         NSWindowStyleMask::NSTitledWindowMask
             | NSWindowStyleMask::NSClosableWindowMask


### PR DESCRIPTION
Close #3313 