### PR TITLE
Update shell-integration.md

### DIFF
--- a/docs/shell-integration.md
+++ b/docs/shell-integration.md
@@ -134,6 +134,7 @@ $prompt = ""
 function Invoke-Starship-PreCommand {
     $current_location = $executionContext.SessionState.Path.CurrentLocation
     if ($current_location.Provider.Name -eq "FileSystem") {
+        $ansi_escape = [char]27
         $provider_path = $current_location.ProviderPath -replace "\\", "/"
         $prompt = "$ansi_escape]7;file://${env:COMPUTERNAME}/${provider_path}$ansi_escape\"
     }


### PR DESCRIPTION
Add missing line to powershell starship OSC 7 integration. The variable for $ansi_escape was missing.

I have tested this on windows 11 and proved that it works with this addition.