### PR TITLE
ci: Use nextest

### DIFF
--- a/.github/workflows/gen_alpine3.15.yml
+++ b/.github/workflows/gen_alpine3.15.yml
@@ -71,7 +71,7 @@ jobs:
         uses: baptiste0928/cargo-install@v2
         with:
           crate: "cargo-nextest"
-          key: "alpine3.15"
+          cache-key: "alpine3.15"
       - name: "Test (Release mode)"
         shell: bash
         run: "cargo nextest run --all --release --no-fail-fast"

--- a/.github/workflows/gen_alpine3.15.yml
+++ b/.github/workflows/gen_alpine3.15.yml
@@ -71,6 +71,7 @@ jobs:
         uses: baptiste0928/cargo-install@v2
         with:
           crate: "cargo-nextest"
+          key: "alpine3.15"
       - name: "Test (Release mode)"
         shell: bash
         run: "cargo nextest run --all --release --no-fail-fast"

--- a/.github/workflows/gen_alpine3.15.yml
+++ b/.github/workflows/gen_alpine3.15.yml
@@ -67,9 +67,13 @@ jobs:
       - name: "Build (Release mode)"
         shell: bash
         run: "cargo build --all --release"
+      - name: "Install cargo-nextest from Cargo"
+        uses: baptiste0928/cargo-install@v2
+        with:
+          crate: "cargo-nextest"
       - name: "Test (Release mode)"
         shell: bash
-        run: "cargo test --all --release"
+        run: "cargo nextest run --all --release"
       - name: "Package"
         shell: bash
         run: "bash ci/deploy.sh"

--- a/.github/workflows/gen_alpine3.15.yml
+++ b/.github/workflows/gen_alpine3.15.yml
@@ -73,7 +73,7 @@ jobs:
           crate: "cargo-nextest"
       - name: "Test (Release mode)"
         shell: bash
-        run: "cargo nextest run --all --release"
+        run: "cargo nextest run --all --release --no-fail-fast"
       - name: "Package"
         shell: bash
         run: "bash ci/deploy.sh"

--- a/.github/workflows/gen_alpine3.15_continuous.yml
+++ b/.github/workflows/gen_alpine3.15_continuous.yml
@@ -70,9 +70,13 @@ jobs:
       - name: "Build (Release mode)"
         shell: bash
         run: "cargo build --all --release"
+      - name: "Install cargo-nextest from Cargo"
+        uses: baptiste0928/cargo-install@v2
+        with:
+          crate: "cargo-nextest"
       - name: "Test (Release mode)"
         shell: bash
-        run: "cargo test --all --release"
+        run: "cargo nextest run --all --release"
       - name: "Package"
         shell: bash
         run: "bash ci/deploy.sh"

--- a/.github/workflows/gen_alpine3.15_continuous.yml
+++ b/.github/workflows/gen_alpine3.15_continuous.yml
@@ -76,7 +76,7 @@ jobs:
           crate: "cargo-nextest"
       - name: "Test (Release mode)"
         shell: bash
-        run: "cargo nextest run --all --release"
+        run: "cargo nextest run --all --release --no-fail-fast"
       - name: "Package"
         shell: bash
         run: "bash ci/deploy.sh"

--- a/.github/workflows/gen_alpine3.15_continuous.yml
+++ b/.github/workflows/gen_alpine3.15_continuous.yml
@@ -74,7 +74,7 @@ jobs:
         uses: baptiste0928/cargo-install@v2
         with:
           crate: "cargo-nextest"
-          key: "alpine3.15"
+          cache-key: "alpine3.15"
       - name: "Test (Release mode)"
         shell: bash
         run: "cargo nextest run --all --release --no-fail-fast"

--- a/.github/workflows/gen_alpine3.15_continuous.yml
+++ b/.github/workflows/gen_alpine3.15_continuous.yml
@@ -74,6 +74,7 @@ jobs:
         uses: baptiste0928/cargo-install@v2
         with:
           crate: "cargo-nextest"
+          key: "alpine3.15"
       - name: "Test (Release mode)"
         shell: bash
         run: "cargo nextest run --all --release --no-fail-fast"

--- a/.github/workflows/gen_alpine3.15_tag.yml
+++ b/.github/workflows/gen_alpine3.15_tag.yml
@@ -56,7 +56,7 @@ jobs:
           crate: "cargo-nextest"
       - name: "Test (Release mode)"
         shell: bash
-        run: "cargo nextest run --all --release"
+        run: "cargo nextest run --all --release --no-fail-fast"
       - name: "Package"
         shell: bash
         run: "bash ci/deploy.sh"

--- a/.github/workflows/gen_alpine3.15_tag.yml
+++ b/.github/workflows/gen_alpine3.15_tag.yml
@@ -54,6 +54,7 @@ jobs:
         uses: baptiste0928/cargo-install@v2
         with:
           crate: "cargo-nextest"
+          key: "alpine3.15"
       - name: "Test (Release mode)"
         shell: bash
         run: "cargo nextest run --all --release --no-fail-fast"

--- a/.github/workflows/gen_alpine3.15_tag.yml
+++ b/.github/workflows/gen_alpine3.15_tag.yml
@@ -50,9 +50,13 @@ jobs:
       - name: "Build (Release mode)"
         shell: bash
         run: "cargo build --all --release"
+      - name: "Install cargo-nextest from Cargo"
+        uses: baptiste0928/cargo-install@v2
+        with:
+          crate: "cargo-nextest"
       - name: "Test (Release mode)"
         shell: bash
-        run: "cargo test --all --release"
+        run: "cargo nextest run --all --release"
       - name: "Package"
         shell: bash
         run: "bash ci/deploy.sh"

--- a/.github/workflows/gen_alpine3.15_tag.yml
+++ b/.github/workflows/gen_alpine3.15_tag.yml
@@ -54,7 +54,7 @@ jobs:
         uses: baptiste0928/cargo-install@v2
         with:
           crate: "cargo-nextest"
-          key: "alpine3.15"
+          cache-key: "alpine3.15"
       - name: "Test (Release mode)"
         shell: bash
         run: "cargo nextest run --all --release --no-fail-fast"

--- a/.github/workflows/gen_centos7.yml
+++ b/.github/workflows/gen_centos7.yml
@@ -91,9 +91,15 @@ jobs:
       - name: "Build (Release mode)"
         shell: bash
         run: "source /opt/rh/devtoolset-9/enable && cargo build --all --release"
+      - name: "Install cargo-nextest from Cargo"
+        uses: baptiste0928/cargo-install@v2
+        with:
+          crate: "cargo-nextest"
       - name: "Test (Release mode)"
         shell: bash
-        run: "source /opt/rh/devtoolset-9/enable && cargo test --all --release"
+        run: |
+          source /opt/rh/devtoolset-9/enable
+          cargo nextest run --all --release
       - name: "Package"
         shell: bash
         run: "bash ci/deploy.sh"

--- a/.github/workflows/gen_centos7.yml
+++ b/.github/workflows/gen_centos7.yml
@@ -95,6 +95,7 @@ jobs:
         uses: baptiste0928/cargo-install@v2
         with:
           crate: "cargo-nextest"
+          key: "centos7"
       - name: "Test (Release mode)"
         shell: bash
         run: |

--- a/.github/workflows/gen_centos7.yml
+++ b/.github/workflows/gen_centos7.yml
@@ -99,7 +99,7 @@ jobs:
         shell: bash
         run: |
           source /opt/rh/devtoolset-9/enable
-          cargo nextest run --all --release
+          cargo nextest run --all --release --no-fail-fast
       - name: "Package"
         shell: bash
         run: "bash ci/deploy.sh"

--- a/.github/workflows/gen_centos7.yml
+++ b/.github/workflows/gen_centos7.yml
@@ -95,7 +95,7 @@ jobs:
         uses: baptiste0928/cargo-install@v2
         with:
           crate: "cargo-nextest"
-          key: "centos7"
+          cache-key: "centos7"
       - name: "Test (Release mode)"
         shell: bash
         run: |

--- a/.github/workflows/gen_centos7_continuous.yml
+++ b/.github/workflows/gen_centos7_continuous.yml
@@ -99,6 +99,7 @@ jobs:
         uses: baptiste0928/cargo-install@v2
         with:
           crate: "cargo-nextest"
+          key: "centos7"
       - name: "Test (Release mode)"
         shell: bash
         run: |

--- a/.github/workflows/gen_centos7_continuous.yml
+++ b/.github/workflows/gen_centos7_continuous.yml
@@ -103,7 +103,7 @@ jobs:
         shell: bash
         run: |
           source /opt/rh/devtoolset-9/enable
-          cargo nextest run --all --release
+          cargo nextest run --all --release --no-fail-fast
       - name: "Package"
         shell: bash
         run: "bash ci/deploy.sh"

--- a/.github/workflows/gen_centos7_continuous.yml
+++ b/.github/workflows/gen_centos7_continuous.yml
@@ -95,9 +95,15 @@ jobs:
       - name: "Build (Release mode)"
         shell: bash
         run: "source /opt/rh/devtoolset-9/enable && cargo build --all --release"
+      - name: "Install cargo-nextest from Cargo"
+        uses: baptiste0928/cargo-install@v2
+        with:
+          crate: "cargo-nextest"
       - name: "Test (Release mode)"
         shell: bash
-        run: "source /opt/rh/devtoolset-9/enable && cargo test --all --release"
+        run: |
+          source /opt/rh/devtoolset-9/enable
+          cargo nextest run --all --release
       - name: "Package"
         shell: bash
         run: "bash ci/deploy.sh"

--- a/.github/workflows/gen_centos7_continuous.yml
+++ b/.github/workflows/gen_centos7_continuous.yml
@@ -99,7 +99,7 @@ jobs:
         uses: baptiste0928/cargo-install@v2
         with:
           crate: "cargo-nextest"
-          key: "centos7"
+          cache-key: "centos7"
       - name: "Test (Release mode)"
         shell: bash
         run: |

--- a/.github/workflows/gen_centos7_tag.yml
+++ b/.github/workflows/gen_centos7_tag.yml
@@ -74,9 +74,15 @@ jobs:
       - name: "Build (Release mode)"
         shell: bash
         run: "source /opt/rh/devtoolset-9/enable && cargo build --all --release"
+      - name: "Install cargo-nextest from Cargo"
+        uses: baptiste0928/cargo-install@v2
+        with:
+          crate: "cargo-nextest"
       - name: "Test (Release mode)"
         shell: bash
-        run: "source /opt/rh/devtoolset-9/enable && cargo test --all --release"
+        run: |
+          source /opt/rh/devtoolset-9/enable
+          cargo nextest run --all --release
       - name: "Package"
         shell: bash
         run: "bash ci/deploy.sh"

--- a/.github/workflows/gen_centos7_tag.yml
+++ b/.github/workflows/gen_centos7_tag.yml
@@ -78,7 +78,7 @@ jobs:
         uses: baptiste0928/cargo-install@v2
         with:
           crate: "cargo-nextest"
-          key: "centos7"
+          cache-key: "centos7"
       - name: "Test (Release mode)"
         shell: bash
         run: |

--- a/.github/workflows/gen_centos7_tag.yml
+++ b/.github/workflows/gen_centos7_tag.yml
@@ -82,7 +82,7 @@ jobs:
         shell: bash
         run: |
           source /opt/rh/devtoolset-9/enable
-          cargo nextest run --all --release
+          cargo nextest run --all --release --no-fail-fast
       - name: "Package"
         shell: bash
         run: "bash ci/deploy.sh"

--- a/.github/workflows/gen_centos7_tag.yml
+++ b/.github/workflows/gen_centos7_tag.yml
@@ -78,6 +78,7 @@ jobs:
         uses: baptiste0928/cargo-install@v2
         with:
           crate: "cargo-nextest"
+          key: "centos7"
       - name: "Test (Release mode)"
         shell: bash
         run: |

--- a/.github/workflows/gen_centos8.yml
+++ b/.github/workflows/gen_centos8.yml
@@ -69,6 +69,7 @@ jobs:
         uses: baptiste0928/cargo-install@v2
         with:
           crate: "cargo-nextest"
+          key: "centos8"
       - name: "Test (Release mode)"
         shell: bash
         run: "cargo nextest run --all --release --no-fail-fast"

--- a/.github/workflows/gen_centos8.yml
+++ b/.github/workflows/gen_centos8.yml
@@ -69,7 +69,7 @@ jobs:
         uses: baptiste0928/cargo-install@v2
         with:
           crate: "cargo-nextest"
-          key: "centos8"
+          cache-key: "centos8"
       - name: "Test (Release mode)"
         shell: bash
         run: "cargo nextest run --all --release --no-fail-fast"

--- a/.github/workflows/gen_centos8.yml
+++ b/.github/workflows/gen_centos8.yml
@@ -71,7 +71,7 @@ jobs:
           crate: "cargo-nextest"
       - name: "Test (Release mode)"
         shell: bash
-        run: "cargo nextest run --all --release"
+        run: "cargo nextest run --all --release --no-fail-fast"
       - name: "Package"
         shell: bash
         run: "bash ci/deploy.sh"

--- a/.github/workflows/gen_centos8.yml
+++ b/.github/workflows/gen_centos8.yml
@@ -65,9 +65,13 @@ jobs:
       - name: "Build (Release mode)"
         shell: bash
         run: "cargo build --all --release"
+      - name: "Install cargo-nextest from Cargo"
+        uses: baptiste0928/cargo-install@v2
+        with:
+          crate: "cargo-nextest"
       - name: "Test (Release mode)"
         shell: bash
-        run: "cargo test --all --release"
+        run: "cargo nextest run --all --release"
       - name: "Package"
         shell: bash
         run: "bash ci/deploy.sh"

--- a/.github/workflows/gen_centos8_continuous.yml
+++ b/.github/workflows/gen_centos8_continuous.yml
@@ -73,7 +73,7 @@ jobs:
         uses: baptiste0928/cargo-install@v2
         with:
           crate: "cargo-nextest"
-          key: "centos8"
+          cache-key: "centos8"
       - name: "Test (Release mode)"
         shell: bash
         run: "cargo nextest run --all --release --no-fail-fast"

--- a/.github/workflows/gen_centos8_continuous.yml
+++ b/.github/workflows/gen_centos8_continuous.yml
@@ -69,9 +69,13 @@ jobs:
       - name: "Build (Release mode)"
         shell: bash
         run: "cargo build --all --release"
+      - name: "Install cargo-nextest from Cargo"
+        uses: baptiste0928/cargo-install@v2
+        with:
+          crate: "cargo-nextest"
       - name: "Test (Release mode)"
         shell: bash
-        run: "cargo test --all --release"
+        run: "cargo nextest run --all --release"
       - name: "Package"
         shell: bash
         run: "bash ci/deploy.sh"

--- a/.github/workflows/gen_centos8_continuous.yml
+++ b/.github/workflows/gen_centos8_continuous.yml
@@ -73,6 +73,7 @@ jobs:
         uses: baptiste0928/cargo-install@v2
         with:
           crate: "cargo-nextest"
+          key: "centos8"
       - name: "Test (Release mode)"
         shell: bash
         run: "cargo nextest run --all --release --no-fail-fast"

--- a/.github/workflows/gen_centos8_continuous.yml
+++ b/.github/workflows/gen_centos8_continuous.yml
@@ -75,7 +75,7 @@ jobs:
           crate: "cargo-nextest"
       - name: "Test (Release mode)"
         shell: bash
-        run: "cargo nextest run --all --release"
+        run: "cargo nextest run --all --release --no-fail-fast"
       - name: "Package"
         shell: bash
         run: "bash ci/deploy.sh"

--- a/.github/workflows/gen_centos8_tag.yml
+++ b/.github/workflows/gen_centos8_tag.yml
@@ -52,6 +52,7 @@ jobs:
         uses: baptiste0928/cargo-install@v2
         with:
           crate: "cargo-nextest"
+          key: "centos8"
       - name: "Test (Release mode)"
         shell: bash
         run: "cargo nextest run --all --release --no-fail-fast"

--- a/.github/workflows/gen_centos8_tag.yml
+++ b/.github/workflows/gen_centos8_tag.yml
@@ -52,7 +52,7 @@ jobs:
         uses: baptiste0928/cargo-install@v2
         with:
           crate: "cargo-nextest"
-          key: "centos8"
+          cache-key: "centos8"
       - name: "Test (Release mode)"
         shell: bash
         run: "cargo nextest run --all --release --no-fail-fast"

--- a/.github/workflows/gen_centos8_tag.yml
+++ b/.github/workflows/gen_centos8_tag.yml
@@ -48,9 +48,13 @@ jobs:
       - name: "Build (Release mode)"
         shell: bash
         run: "cargo build --all --release"
+      - name: "Install cargo-nextest from Cargo"
+        uses: baptiste0928/cargo-install@v2
+        with:
+          crate: "cargo-nextest"
       - name: "Test (Release mode)"
         shell: bash
-        run: "cargo test --all --release"
+        run: "cargo nextest run --all --release"
       - name: "Package"
         shell: bash
         run: "bash ci/deploy.sh"

--- a/.github/workflows/gen_centos8_tag.yml
+++ b/.github/workflows/gen_centos8_tag.yml
@@ -54,7 +54,7 @@ jobs:
           crate: "cargo-nextest"
       - name: "Test (Release mode)"
         shell: bash
-        run: "cargo nextest run --all --release"
+        run: "cargo nextest run --all --release --no-fail-fast"
       - name: "Package"
         shell: bash
         run: "bash ci/deploy.sh"

--- a/.github/workflows/gen_centos9.yml
+++ b/.github/workflows/gen_centos9.yml
@@ -71,7 +71,7 @@ jobs:
           crate: "cargo-nextest"
       - name: "Test (Release mode)"
         shell: bash
-        run: "cargo nextest run --all --release"
+        run: "cargo nextest run --all --release --no-fail-fast"
       - name: "Package"
         shell: bash
         run: "bash ci/deploy.sh"

--- a/.github/workflows/gen_centos9.yml
+++ b/.github/workflows/gen_centos9.yml
@@ -69,7 +69,7 @@ jobs:
         uses: baptiste0928/cargo-install@v2
         with:
           crate: "cargo-nextest"
-          key: "centos9"
+          cache-key: "centos9"
       - name: "Test (Release mode)"
         shell: bash
         run: "cargo nextest run --all --release --no-fail-fast"

--- a/.github/workflows/gen_centos9.yml
+++ b/.github/workflows/gen_centos9.yml
@@ -65,9 +65,13 @@ jobs:
       - name: "Build (Release mode)"
         shell: bash
         run: "cargo build --all --release"
+      - name: "Install cargo-nextest from Cargo"
+        uses: baptiste0928/cargo-install@v2
+        with:
+          crate: "cargo-nextest"
       - name: "Test (Release mode)"
         shell: bash
-        run: "cargo test --all --release"
+        run: "cargo nextest run --all --release"
       - name: "Package"
         shell: bash
         run: "bash ci/deploy.sh"

--- a/.github/workflows/gen_centos9.yml
+++ b/.github/workflows/gen_centos9.yml
@@ -69,6 +69,7 @@ jobs:
         uses: baptiste0928/cargo-install@v2
         with:
           crate: "cargo-nextest"
+          key: "centos9"
       - name: "Test (Release mode)"
         shell: bash
         run: "cargo nextest run --all --release --no-fail-fast"

--- a/.github/workflows/gen_centos9_continuous.yml
+++ b/.github/workflows/gen_centos9_continuous.yml
@@ -69,9 +69,13 @@ jobs:
       - name: "Build (Release mode)"
         shell: bash
         run: "cargo build --all --release"
+      - name: "Install cargo-nextest from Cargo"
+        uses: baptiste0928/cargo-install@v2
+        with:
+          crate: "cargo-nextest"
       - name: "Test (Release mode)"
         shell: bash
-        run: "cargo test --all --release"
+        run: "cargo nextest run --all --release"
       - name: "Package"
         shell: bash
         run: "bash ci/deploy.sh"

--- a/.github/workflows/gen_centos9_continuous.yml
+++ b/.github/workflows/gen_centos9_continuous.yml
@@ -73,6 +73,7 @@ jobs:
         uses: baptiste0928/cargo-install@v2
         with:
           crate: "cargo-nextest"
+          key: "centos9"
       - name: "Test (Release mode)"
         shell: bash
         run: "cargo nextest run --all --release --no-fail-fast"

--- a/.github/workflows/gen_centos9_continuous.yml
+++ b/.github/workflows/gen_centos9_continuous.yml
@@ -73,7 +73,7 @@ jobs:
         uses: baptiste0928/cargo-install@v2
         with:
           crate: "cargo-nextest"
-          key: "centos9"
+          cache-key: "centos9"
       - name: "Test (Release mode)"
         shell: bash
         run: "cargo nextest run --all --release --no-fail-fast"

--- a/.github/workflows/gen_centos9_continuous.yml
+++ b/.github/workflows/gen_centos9_continuous.yml
@@ -75,7 +75,7 @@ jobs:
           crate: "cargo-nextest"
       - name: "Test (Release mode)"
         shell: bash
-        run: "cargo nextest run --all --release"
+        run: "cargo nextest run --all --release --no-fail-fast"
       - name: "Package"
         shell: bash
         run: "bash ci/deploy.sh"

--- a/.github/workflows/gen_centos9_tag.yml
+++ b/.github/workflows/gen_centos9_tag.yml
@@ -48,9 +48,13 @@ jobs:
       - name: "Build (Release mode)"
         shell: bash
         run: "cargo build --all --release"
+      - name: "Install cargo-nextest from Cargo"
+        uses: baptiste0928/cargo-install@v2
+        with:
+          crate: "cargo-nextest"
       - name: "Test (Release mode)"
         shell: bash
-        run: "cargo test --all --release"
+        run: "cargo nextest run --all --release"
       - name: "Package"
         shell: bash
         run: "bash ci/deploy.sh"

--- a/.github/workflows/gen_centos9_tag.yml
+++ b/.github/workflows/gen_centos9_tag.yml
@@ -54,7 +54,7 @@ jobs:
           crate: "cargo-nextest"
       - name: "Test (Release mode)"
         shell: bash
-        run: "cargo nextest run --all --release"
+        run: "cargo nextest run --all --release --no-fail-fast"
       - name: "Package"
         shell: bash
         run: "bash ci/deploy.sh"

--- a/.github/workflows/gen_centos9_tag.yml
+++ b/.github/workflows/gen_centos9_tag.yml
@@ -52,7 +52,7 @@ jobs:
         uses: baptiste0928/cargo-install@v2
         with:
           crate: "cargo-nextest"
-          key: "centos9"
+          cache-key: "centos9"
       - name: "Test (Release mode)"
         shell: bash
         run: "cargo nextest run --all --release --no-fail-fast"

--- a/.github/workflows/gen_centos9_tag.yml
+++ b/.github/workflows/gen_centos9_tag.yml
@@ -52,6 +52,7 @@ jobs:
         uses: baptiste0928/cargo-install@v2
         with:
           crate: "cargo-nextest"
+          key: "centos9"
       - name: "Test (Release mode)"
         shell: bash
         run: "cargo nextest run --all --release --no-fail-fast"

--- a/.github/workflows/gen_debian10.3.yml
+++ b/.github/workflows/gen_debian10.3.yml
@@ -72,7 +72,7 @@ jobs:
         uses: baptiste0928/cargo-install@v2
         with:
           crate: "cargo-nextest"
-          key: "debian10.3"
+          cache-key: "debian10.3"
       - name: "Test (Release mode)"
         shell: bash
         run: "cargo nextest run --all --release --no-fail-fast"

--- a/.github/workflows/gen_debian10.3.yml
+++ b/.github/workflows/gen_debian10.3.yml
@@ -74,7 +74,7 @@ jobs:
           crate: "cargo-nextest"
       - name: "Test (Release mode)"
         shell: bash
-        run: "cargo nextest run --all --release"
+        run: "cargo nextest run --all --release --no-fail-fast"
       - name: "Package"
         shell: bash
         run: "bash ci/deploy.sh"

--- a/.github/workflows/gen_debian10.3.yml
+++ b/.github/workflows/gen_debian10.3.yml
@@ -72,6 +72,7 @@ jobs:
         uses: baptiste0928/cargo-install@v2
         with:
           crate: "cargo-nextest"
+          key: "debian10.3"
       - name: "Test (Release mode)"
         shell: bash
         run: "cargo nextest run --all --release --no-fail-fast"

--- a/.github/workflows/gen_debian10.3.yml
+++ b/.github/workflows/gen_debian10.3.yml
@@ -68,9 +68,13 @@ jobs:
       - name: "Build (Release mode)"
         shell: bash
         run: "cargo build --all --release"
+      - name: "Install cargo-nextest from Cargo"
+        uses: baptiste0928/cargo-install@v2
+        with:
+          crate: "cargo-nextest"
       - name: "Test (Release mode)"
         shell: bash
-        run: "cargo test --all --release"
+        run: "cargo nextest run --all --release"
       - name: "Package"
         shell: bash
         run: "bash ci/deploy.sh"

--- a/.github/workflows/gen_debian10.3_continuous.yml
+++ b/.github/workflows/gen_debian10.3_continuous.yml
@@ -72,9 +72,13 @@ jobs:
       - name: "Build (Release mode)"
         shell: bash
         run: "cargo build --all --release"
+      - name: "Install cargo-nextest from Cargo"
+        uses: baptiste0928/cargo-install@v2
+        with:
+          crate: "cargo-nextest"
       - name: "Test (Release mode)"
         shell: bash
-        run: "cargo test --all --release"
+        run: "cargo nextest run --all --release"
       - name: "Package"
         shell: bash
         run: "bash ci/deploy.sh"

--- a/.github/workflows/gen_debian10.3_continuous.yml
+++ b/.github/workflows/gen_debian10.3_continuous.yml
@@ -78,7 +78,7 @@ jobs:
           crate: "cargo-nextest"
       - name: "Test (Release mode)"
         shell: bash
-        run: "cargo nextest run --all --release"
+        run: "cargo nextest run --all --release --no-fail-fast"
       - name: "Package"
         shell: bash
         run: "bash ci/deploy.sh"

--- a/.github/workflows/gen_debian10.3_continuous.yml
+++ b/.github/workflows/gen_debian10.3_continuous.yml
@@ -76,7 +76,7 @@ jobs:
         uses: baptiste0928/cargo-install@v2
         with:
           crate: "cargo-nextest"
-          key: "debian10.3"
+          cache-key: "debian10.3"
       - name: "Test (Release mode)"
         shell: bash
         run: "cargo nextest run --all --release --no-fail-fast"

--- a/.github/workflows/gen_debian10.3_continuous.yml
+++ b/.github/workflows/gen_debian10.3_continuous.yml
@@ -76,6 +76,7 @@ jobs:
         uses: baptiste0928/cargo-install@v2
         with:
           crate: "cargo-nextest"
+          key: "debian10.3"
       - name: "Test (Release mode)"
         shell: bash
         run: "cargo nextest run --all --release --no-fail-fast"

--- a/.github/workflows/gen_debian10.3_tag.yml
+++ b/.github/workflows/gen_debian10.3_tag.yml
@@ -57,7 +57,7 @@ jobs:
           crate: "cargo-nextest"
       - name: "Test (Release mode)"
         shell: bash
-        run: "cargo nextest run --all --release"
+        run: "cargo nextest run --all --release --no-fail-fast"
       - name: "Package"
         shell: bash
         run: "bash ci/deploy.sh"

--- a/.github/workflows/gen_debian10.3_tag.yml
+++ b/.github/workflows/gen_debian10.3_tag.yml
@@ -51,9 +51,13 @@ jobs:
       - name: "Build (Release mode)"
         shell: bash
         run: "cargo build --all --release"
+      - name: "Install cargo-nextest from Cargo"
+        uses: baptiste0928/cargo-install@v2
+        with:
+          crate: "cargo-nextest"
       - name: "Test (Release mode)"
         shell: bash
-        run: "cargo test --all --release"
+        run: "cargo nextest run --all --release"
       - name: "Package"
         shell: bash
         run: "bash ci/deploy.sh"

--- a/.github/workflows/gen_debian10.3_tag.yml
+++ b/.github/workflows/gen_debian10.3_tag.yml
@@ -55,7 +55,7 @@ jobs:
         uses: baptiste0928/cargo-install@v2
         with:
           crate: "cargo-nextest"
-          key: "debian10.3"
+          cache-key: "debian10.3"
       - name: "Test (Release mode)"
         shell: bash
         run: "cargo nextest run --all --release --no-fail-fast"

--- a/.github/workflows/gen_debian10.3_tag.yml
+++ b/.github/workflows/gen_debian10.3_tag.yml
@@ -55,6 +55,7 @@ jobs:
         uses: baptiste0928/cargo-install@v2
         with:
           crate: "cargo-nextest"
+          key: "debian10.3"
       - name: "Test (Release mode)"
         shell: bash
         run: "cargo nextest run --all --release --no-fail-fast"

--- a/.github/workflows/gen_debian11.yml
+++ b/.github/workflows/gen_debian11.yml
@@ -72,6 +72,7 @@ jobs:
         uses: baptiste0928/cargo-install@v2
         with:
           crate: "cargo-nextest"
+          key: "debian11"
       - name: "Test (Release mode)"
         shell: bash
         run: "cargo nextest run --all --release --no-fail-fast"

--- a/.github/workflows/gen_debian11.yml
+++ b/.github/workflows/gen_debian11.yml
@@ -72,7 +72,7 @@ jobs:
         uses: baptiste0928/cargo-install@v2
         with:
           crate: "cargo-nextest"
-          key: "debian11"
+          cache-key: "debian11"
       - name: "Test (Release mode)"
         shell: bash
         run: "cargo nextest run --all --release --no-fail-fast"

--- a/.github/workflows/gen_debian11.yml
+++ b/.github/workflows/gen_debian11.yml
@@ -74,7 +74,7 @@ jobs:
           crate: "cargo-nextest"
       - name: "Test (Release mode)"
         shell: bash
-        run: "cargo nextest run --all --release"
+        run: "cargo nextest run --all --release --no-fail-fast"
       - name: "Package"
         shell: bash
         run: "bash ci/deploy.sh"

--- a/.github/workflows/gen_debian11.yml
+++ b/.github/workflows/gen_debian11.yml
@@ -68,9 +68,13 @@ jobs:
       - name: "Build (Release mode)"
         shell: bash
         run: "cargo build --all --release"
+      - name: "Install cargo-nextest from Cargo"
+        uses: baptiste0928/cargo-install@v2
+        with:
+          crate: "cargo-nextest"
       - name: "Test (Release mode)"
         shell: bash
-        run: "cargo test --all --release"
+        run: "cargo nextest run --all --release"
       - name: "Package"
         shell: bash
         run: "bash ci/deploy.sh"

--- a/.github/workflows/gen_debian11_continuous.yml
+++ b/.github/workflows/gen_debian11_continuous.yml
@@ -72,9 +72,13 @@ jobs:
       - name: "Build (Release mode)"
         shell: bash
         run: "cargo build --all --release"
+      - name: "Install cargo-nextest from Cargo"
+        uses: baptiste0928/cargo-install@v2
+        with:
+          crate: "cargo-nextest"
       - name: "Test (Release mode)"
         shell: bash
-        run: "cargo test --all --release"
+        run: "cargo nextest run --all --release"
       - name: "Package"
         shell: bash
         run: "bash ci/deploy.sh"

--- a/.github/workflows/gen_debian11_continuous.yml
+++ b/.github/workflows/gen_debian11_continuous.yml
@@ -78,7 +78,7 @@ jobs:
           crate: "cargo-nextest"
       - name: "Test (Release mode)"
         shell: bash
-        run: "cargo nextest run --all --release"
+        run: "cargo nextest run --all --release --no-fail-fast"
       - name: "Package"
         shell: bash
         run: "bash ci/deploy.sh"

--- a/.github/workflows/gen_debian11_continuous.yml
+++ b/.github/workflows/gen_debian11_continuous.yml
@@ -76,6 +76,7 @@ jobs:
         uses: baptiste0928/cargo-install@v2
         with:
           crate: "cargo-nextest"
+          key: "debian11"
       - name: "Test (Release mode)"
         shell: bash
         run: "cargo nextest run --all --release --no-fail-fast"

--- a/.github/workflows/gen_debian11_continuous.yml
+++ b/.github/workflows/gen_debian11_continuous.yml
@@ -76,7 +76,7 @@ jobs:
         uses: baptiste0928/cargo-install@v2
         with:
           crate: "cargo-nextest"
-          key: "debian11"
+          cache-key: "debian11"
       - name: "Test (Release mode)"
         shell: bash
         run: "cargo nextest run --all --release --no-fail-fast"

--- a/.github/workflows/gen_debian11_tag.yml
+++ b/.github/workflows/gen_debian11_tag.yml
@@ -57,7 +57,7 @@ jobs:
           crate: "cargo-nextest"
       - name: "Test (Release mode)"
         shell: bash
-        run: "cargo nextest run --all --release"
+        run: "cargo nextest run --all --release --no-fail-fast"
       - name: "Package"
         shell: bash
         run: "bash ci/deploy.sh"

--- a/.github/workflows/gen_debian11_tag.yml
+++ b/.github/workflows/gen_debian11_tag.yml
@@ -51,9 +51,13 @@ jobs:
       - name: "Build (Release mode)"
         shell: bash
         run: "cargo build --all --release"
+      - name: "Install cargo-nextest from Cargo"
+        uses: baptiste0928/cargo-install@v2
+        with:
+          crate: "cargo-nextest"
       - name: "Test (Release mode)"
         shell: bash
-        run: "cargo test --all --release"
+        run: "cargo nextest run --all --release"
       - name: "Package"
         shell: bash
         run: "bash ci/deploy.sh"

--- a/.github/workflows/gen_debian11_tag.yml
+++ b/.github/workflows/gen_debian11_tag.yml
@@ -55,6 +55,7 @@ jobs:
         uses: baptiste0928/cargo-install@v2
         with:
           crate: "cargo-nextest"
+          key: "debian11"
       - name: "Test (Release mode)"
         shell: bash
         run: "cargo nextest run --all --release --no-fail-fast"

--- a/.github/workflows/gen_debian11_tag.yml
+++ b/.github/workflows/gen_debian11_tag.yml
@@ -55,7 +55,7 @@ jobs:
         uses: baptiste0928/cargo-install@v2
         with:
           crate: "cargo-nextest"
-          key: "debian11"
+          cache-key: "debian11"
       - name: "Test (Release mode)"
         shell: bash
         run: "cargo nextest run --all --release --no-fail-fast"

--- a/.github/workflows/gen_fedora35.yml
+++ b/.github/workflows/gen_fedora35.yml
@@ -66,7 +66,7 @@ jobs:
         uses: baptiste0928/cargo-install@v2
         with:
           crate: "cargo-nextest"
-          key: "fedora35"
+          cache-key: "fedora35"
       - name: "Test (Release mode)"
         shell: bash
         run: "cargo nextest run --all --release --no-fail-fast"

--- a/.github/workflows/gen_fedora35.yml
+++ b/.github/workflows/gen_fedora35.yml
@@ -68,7 +68,7 @@ jobs:
           crate: "cargo-nextest"
       - name: "Test (Release mode)"
         shell: bash
-        run: "cargo nextest run --all --release"
+        run: "cargo nextest run --all --release --no-fail-fast"
       - name: "Package"
         shell: bash
         run: "bash ci/deploy.sh"

--- a/.github/workflows/gen_fedora35.yml
+++ b/.github/workflows/gen_fedora35.yml
@@ -66,6 +66,7 @@ jobs:
         uses: baptiste0928/cargo-install@v2
         with:
           crate: "cargo-nextest"
+          key: "fedora35"
       - name: "Test (Release mode)"
         shell: bash
         run: "cargo nextest run --all --release --no-fail-fast"

--- a/.github/workflows/gen_fedora35.yml
+++ b/.github/workflows/gen_fedora35.yml
@@ -62,9 +62,13 @@ jobs:
       - name: "Build (Release mode)"
         shell: bash
         run: "cargo build --all --release"
+      - name: "Install cargo-nextest from Cargo"
+        uses: baptiste0928/cargo-install@v2
+        with:
+          crate: "cargo-nextest"
       - name: "Test (Release mode)"
         shell: bash
-        run: "cargo test --all --release"
+        run: "cargo nextest run --all --release"
       - name: "Package"
         shell: bash
         run: "bash ci/deploy.sh"

--- a/.github/workflows/gen_fedora35_continuous.yml
+++ b/.github/workflows/gen_fedora35_continuous.yml
@@ -70,6 +70,7 @@ jobs:
         uses: baptiste0928/cargo-install@v2
         with:
           crate: "cargo-nextest"
+          key: "fedora35"
       - name: "Test (Release mode)"
         shell: bash
         run: "cargo nextest run --all --release --no-fail-fast"

--- a/.github/workflows/gen_fedora35_continuous.yml
+++ b/.github/workflows/gen_fedora35_continuous.yml
@@ -66,9 +66,13 @@ jobs:
       - name: "Build (Release mode)"
         shell: bash
         run: "cargo build --all --release"
+      - name: "Install cargo-nextest from Cargo"
+        uses: baptiste0928/cargo-install@v2
+        with:
+          crate: "cargo-nextest"
       - name: "Test (Release mode)"
         shell: bash
-        run: "cargo test --all --release"
+        run: "cargo nextest run --all --release"
       - name: "Package"
         shell: bash
         run: "bash ci/deploy.sh"

--- a/.github/workflows/gen_fedora35_continuous.yml
+++ b/.github/workflows/gen_fedora35_continuous.yml
@@ -72,7 +72,7 @@ jobs:
           crate: "cargo-nextest"
       - name: "Test (Release mode)"
         shell: bash
-        run: "cargo nextest run --all --release"
+        run: "cargo nextest run --all --release --no-fail-fast"
       - name: "Package"
         shell: bash
         run: "bash ci/deploy.sh"

--- a/.github/workflows/gen_fedora35_continuous.yml
+++ b/.github/workflows/gen_fedora35_continuous.yml
@@ -70,7 +70,7 @@ jobs:
         uses: baptiste0928/cargo-install@v2
         with:
           crate: "cargo-nextest"
-          key: "fedora35"
+          cache-key: "fedora35"
       - name: "Test (Release mode)"
         shell: bash
         run: "cargo nextest run --all --release --no-fail-fast"

--- a/.github/workflows/gen_fedora35_tag.yml
+++ b/.github/workflows/gen_fedora35_tag.yml
@@ -49,7 +49,7 @@ jobs:
         uses: baptiste0928/cargo-install@v2
         with:
           crate: "cargo-nextest"
-          key: "fedora35"
+          cache-key: "fedora35"
       - name: "Test (Release mode)"
         shell: bash
         run: "cargo nextest run --all --release --no-fail-fast"

--- a/.github/workflows/gen_fedora35_tag.yml
+++ b/.github/workflows/gen_fedora35_tag.yml
@@ -45,9 +45,13 @@ jobs:
       - name: "Build (Release mode)"
         shell: bash
         run: "cargo build --all --release"
+      - name: "Install cargo-nextest from Cargo"
+        uses: baptiste0928/cargo-install@v2
+        with:
+          crate: "cargo-nextest"
       - name: "Test (Release mode)"
         shell: bash
-        run: "cargo test --all --release"
+        run: "cargo nextest run --all --release"
       - name: "Package"
         shell: bash
         run: "bash ci/deploy.sh"

--- a/.github/workflows/gen_fedora35_tag.yml
+++ b/.github/workflows/gen_fedora35_tag.yml
@@ -51,7 +51,7 @@ jobs:
           crate: "cargo-nextest"
       - name: "Test (Release mode)"
         shell: bash
-        run: "cargo nextest run --all --release"
+        run: "cargo nextest run --all --release --no-fail-fast"
       - name: "Package"
         shell: bash
         run: "bash ci/deploy.sh"

--- a/.github/workflows/gen_fedora35_tag.yml
+++ b/.github/workflows/gen_fedora35_tag.yml
@@ -49,6 +49,7 @@ jobs:
         uses: baptiste0928/cargo-install@v2
         with:
           crate: "cargo-nextest"
+          key: "fedora35"
       - name: "Test (Release mode)"
         shell: bash
         run: "cargo nextest run --all --release --no-fail-fast"

--- a/.github/workflows/gen_fedora36.yml
+++ b/.github/workflows/gen_fedora36.yml
@@ -68,7 +68,7 @@ jobs:
           crate: "cargo-nextest"
       - name: "Test (Release mode)"
         shell: bash
-        run: "cargo nextest run --all --release"
+        run: "cargo nextest run --all --release --no-fail-fast"
       - name: "Package"
         shell: bash
         run: "bash ci/deploy.sh"

--- a/.github/workflows/gen_fedora36.yml
+++ b/.github/workflows/gen_fedora36.yml
@@ -66,7 +66,7 @@ jobs:
         uses: baptiste0928/cargo-install@v2
         with:
           crate: "cargo-nextest"
-          key: "fedora36"
+          cache-key: "fedora36"
       - name: "Test (Release mode)"
         shell: bash
         run: "cargo nextest run --all --release --no-fail-fast"

--- a/.github/workflows/gen_fedora36.yml
+++ b/.github/workflows/gen_fedora36.yml
@@ -66,6 +66,7 @@ jobs:
         uses: baptiste0928/cargo-install@v2
         with:
           crate: "cargo-nextest"
+          key: "fedora36"
       - name: "Test (Release mode)"
         shell: bash
         run: "cargo nextest run --all --release --no-fail-fast"

--- a/.github/workflows/gen_fedora36.yml
+++ b/.github/workflows/gen_fedora36.yml
@@ -62,9 +62,13 @@ jobs:
       - name: "Build (Release mode)"
         shell: bash
         run: "cargo build --all --release"
+      - name: "Install cargo-nextest from Cargo"
+        uses: baptiste0928/cargo-install@v2
+        with:
+          crate: "cargo-nextest"
       - name: "Test (Release mode)"
         shell: bash
-        run: "cargo test --all --release"
+        run: "cargo nextest run --all --release"
       - name: "Package"
         shell: bash
         run: "bash ci/deploy.sh"

--- a/.github/workflows/gen_fedora36_continuous.yml
+++ b/.github/workflows/gen_fedora36_continuous.yml
@@ -70,7 +70,7 @@ jobs:
         uses: baptiste0928/cargo-install@v2
         with:
           crate: "cargo-nextest"
-          key: "fedora36"
+          cache-key: "fedora36"
       - name: "Test (Release mode)"
         shell: bash
         run: "cargo nextest run --all --release --no-fail-fast"

--- a/.github/workflows/gen_fedora36_continuous.yml
+++ b/.github/workflows/gen_fedora36_continuous.yml
@@ -66,9 +66,13 @@ jobs:
       - name: "Build (Release mode)"
         shell: bash
         run: "cargo build --all --release"
+      - name: "Install cargo-nextest from Cargo"
+        uses: baptiste0928/cargo-install@v2
+        with:
+          crate: "cargo-nextest"
       - name: "Test (Release mode)"
         shell: bash
-        run: "cargo test --all --release"
+        run: "cargo nextest run --all --release"
       - name: "Package"
         shell: bash
         run: "bash ci/deploy.sh"

--- a/.github/workflows/gen_fedora36_continuous.yml
+++ b/.github/workflows/gen_fedora36_continuous.yml
@@ -72,7 +72,7 @@ jobs:
           crate: "cargo-nextest"
       - name: "Test (Release mode)"
         shell: bash
-        run: "cargo nextest run --all --release"
+        run: "cargo nextest run --all --release --no-fail-fast"
       - name: "Package"
         shell: bash
         run: "bash ci/deploy.sh"

--- a/.github/workflows/gen_fedora36_continuous.yml
+++ b/.github/workflows/gen_fedora36_continuous.yml
@@ -70,6 +70,7 @@ jobs:
         uses: baptiste0928/cargo-install@v2
         with:
           crate: "cargo-nextest"
+          key: "fedora36"
       - name: "Test (Release mode)"
         shell: bash
         run: "cargo nextest run --all --release --no-fail-fast"

--- a/.github/workflows/gen_fedora36_tag.yml
+++ b/.github/workflows/gen_fedora36_tag.yml
@@ -45,9 +45,13 @@ jobs:
       - name: "Build (Release mode)"
         shell: bash
         run: "cargo build --all --release"
+      - name: "Install cargo-nextest from Cargo"
+        uses: baptiste0928/cargo-install@v2
+        with:
+          crate: "cargo-nextest"
       - name: "Test (Release mode)"
         shell: bash
-        run: "cargo test --all --release"
+        run: "cargo nextest run --all --release"
       - name: "Package"
         shell: bash
         run: "bash ci/deploy.sh"

--- a/.github/workflows/gen_fedora36_tag.yml
+++ b/.github/workflows/gen_fedora36_tag.yml
@@ -49,6 +49,7 @@ jobs:
         uses: baptiste0928/cargo-install@v2
         with:
           crate: "cargo-nextest"
+          key: "fedora36"
       - name: "Test (Release mode)"
         shell: bash
         run: "cargo nextest run --all --release --no-fail-fast"

--- a/.github/workflows/gen_fedora36_tag.yml
+++ b/.github/workflows/gen_fedora36_tag.yml
@@ -51,7 +51,7 @@ jobs:
           crate: "cargo-nextest"
       - name: "Test (Release mode)"
         shell: bash
-        run: "cargo nextest run --all --release"
+        run: "cargo nextest run --all --release --no-fail-fast"
       - name: "Package"
         shell: bash
         run: "bash ci/deploy.sh"

--- a/.github/workflows/gen_fedora36_tag.yml
+++ b/.github/workflows/gen_fedora36_tag.yml
@@ -49,7 +49,7 @@ jobs:
         uses: baptiste0928/cargo-install@v2
         with:
           crate: "cargo-nextest"
-          key: "fedora36"
+          cache-key: "fedora36"
       - name: "Test (Release mode)"
         shell: bash
         run: "cargo nextest run --all --release --no-fail-fast"

--- a/.github/workflows/gen_fedora37.yml
+++ b/.github/workflows/gen_fedora37.yml
@@ -66,7 +66,7 @@ jobs:
         uses: baptiste0928/cargo-install@v2
         with:
           crate: "cargo-nextest"
-          key: "fedora37"
+          cache-key: "fedora37"
       - name: "Test (Release mode)"
         shell: bash
         run: "cargo nextest run --all --release --no-fail-fast"

--- a/.github/workflows/gen_fedora37.yml
+++ b/.github/workflows/gen_fedora37.yml
@@ -66,6 +66,7 @@ jobs:
         uses: baptiste0928/cargo-install@v2
         with:
           crate: "cargo-nextest"
+          key: "fedora37"
       - name: "Test (Release mode)"
         shell: bash
         run: "cargo nextest run --all --release --no-fail-fast"

--- a/.github/workflows/gen_fedora37.yml
+++ b/.github/workflows/gen_fedora37.yml
@@ -68,7 +68,7 @@ jobs:
           crate: "cargo-nextest"
       - name: "Test (Release mode)"
         shell: bash
-        run: "cargo nextest run --all --release"
+        run: "cargo nextest run --all --release --no-fail-fast"
       - name: "Package"
         shell: bash
         run: "bash ci/deploy.sh"

--- a/.github/workflows/gen_fedora37.yml
+++ b/.github/workflows/gen_fedora37.yml
@@ -62,9 +62,13 @@ jobs:
       - name: "Build (Release mode)"
         shell: bash
         run: "cargo build --all --release"
+      - name: "Install cargo-nextest from Cargo"
+        uses: baptiste0928/cargo-install@v2
+        with:
+          crate: "cargo-nextest"
       - name: "Test (Release mode)"
         shell: bash
-        run: "cargo test --all --release"
+        run: "cargo nextest run --all --release"
       - name: "Package"
         shell: bash
         run: "bash ci/deploy.sh"

--- a/.github/workflows/gen_fedora37_continuous.yml
+++ b/.github/workflows/gen_fedora37_continuous.yml
@@ -70,6 +70,7 @@ jobs:
         uses: baptiste0928/cargo-install@v2
         with:
           crate: "cargo-nextest"
+          key: "fedora37"
       - name: "Test (Release mode)"
         shell: bash
         run: "cargo nextest run --all --release --no-fail-fast"

--- a/.github/workflows/gen_fedora37_continuous.yml
+++ b/.github/workflows/gen_fedora37_continuous.yml
@@ -70,7 +70,7 @@ jobs:
         uses: baptiste0928/cargo-install@v2
         with:
           crate: "cargo-nextest"
-          key: "fedora37"
+          cache-key: "fedora37"
       - name: "Test (Release mode)"
         shell: bash
         run: "cargo nextest run --all --release --no-fail-fast"

--- a/.github/workflows/gen_fedora37_continuous.yml
+++ b/.github/workflows/gen_fedora37_continuous.yml
@@ -66,9 +66,13 @@ jobs:
       - name: "Build (Release mode)"
         shell: bash
         run: "cargo build --all --release"
+      - name: "Install cargo-nextest from Cargo"
+        uses: baptiste0928/cargo-install@v2
+        with:
+          crate: "cargo-nextest"
       - name: "Test (Release mode)"
         shell: bash
-        run: "cargo test --all --release"
+        run: "cargo nextest run --all --release"
       - name: "Package"
         shell: bash
         run: "bash ci/deploy.sh"

--- a/.github/workflows/gen_fedora37_continuous.yml
+++ b/.github/workflows/gen_fedora37_continuous.yml
@@ -72,7 +72,7 @@ jobs:
           crate: "cargo-nextest"
       - name: "Test (Release mode)"
         shell: bash
-        run: "cargo nextest run --all --release"
+        run: "cargo nextest run --all --release --no-fail-fast"
       - name: "Package"
         shell: bash
         run: "bash ci/deploy.sh"

--- a/.github/workflows/gen_fedora37_tag.yml
+++ b/.github/workflows/gen_fedora37_tag.yml
@@ -49,7 +49,7 @@ jobs:
         uses: baptiste0928/cargo-install@v2
         with:
           crate: "cargo-nextest"
-          key: "fedora37"
+          cache-key: "fedora37"
       - name: "Test (Release mode)"
         shell: bash
         run: "cargo nextest run --all --release --no-fail-fast"

--- a/.github/workflows/gen_fedora37_tag.yml
+++ b/.github/workflows/gen_fedora37_tag.yml
@@ -49,6 +49,7 @@ jobs:
         uses: baptiste0928/cargo-install@v2
         with:
           crate: "cargo-nextest"
+          key: "fedora37"
       - name: "Test (Release mode)"
         shell: bash
         run: "cargo nextest run --all --release --no-fail-fast"

--- a/.github/workflows/gen_fedora37_tag.yml
+++ b/.github/workflows/gen_fedora37_tag.yml
@@ -45,9 +45,13 @@ jobs:
       - name: "Build (Release mode)"
         shell: bash
         run: "cargo build --all --release"
+      - name: "Install cargo-nextest from Cargo"
+        uses: baptiste0928/cargo-install@v2
+        with:
+          crate: "cargo-nextest"
       - name: "Test (Release mode)"
         shell: bash
-        run: "cargo test --all --release"
+        run: "cargo nextest run --all --release"
       - name: "Package"
         shell: bash
         run: "bash ci/deploy.sh"

--- a/.github/workflows/gen_fedora37_tag.yml
+++ b/.github/workflows/gen_fedora37_tag.yml
@@ -51,7 +51,7 @@ jobs:
           crate: "cargo-nextest"
       - name: "Test (Release mode)"
         shell: bash
-        run: "cargo nextest run --all --release"
+        run: "cargo nextest run --all --release --no-fail-fast"
       - name: "Package"
         shell: bash
         run: "bash ci/deploy.sh"

--- a/.github/workflows/gen_macos.yml
+++ b/.github/workflows/gen_macos.yml
@@ -43,9 +43,13 @@ jobs:
       - name: "Build (Release mode ARM)"
         shell: bash
         run: "cargo build --target aarch64-apple-darwin --all --release"
+      - name: "Install cargo-nextest from Cargo"
+        uses: baptiste0928/cargo-install@v2
+        with:
+          crate: "cargo-nextest"
       - name: "Test (Release mode)"
         shell: bash
-        run: "cargo test --target x86_64-apple-darwin --all --release"
+        run: "cargo nextest run --all --release --target=x86_64-apple-darwin"
       - name: "Package"
         shell: bash
         run: "bash ci/deploy.sh"

--- a/.github/workflows/gen_macos.yml
+++ b/.github/workflows/gen_macos.yml
@@ -47,7 +47,7 @@ jobs:
         uses: baptiste0928/cargo-install@v2
         with:
           crate: "cargo-nextest"
-          key: "macos"
+          cache-key: "macos"
       - name: "Test (Release mode)"
         shell: bash
         run: "cargo nextest run --all --release --no-fail-fast --target=x86_64-apple-darwin"

--- a/.github/workflows/gen_macos.yml
+++ b/.github/workflows/gen_macos.yml
@@ -47,6 +47,7 @@ jobs:
         uses: baptiste0928/cargo-install@v2
         with:
           crate: "cargo-nextest"
+          key: "macos"
       - name: "Test (Release mode)"
         shell: bash
         run: "cargo nextest run --all --release --no-fail-fast --target=x86_64-apple-darwin"

--- a/.github/workflows/gen_macos.yml
+++ b/.github/workflows/gen_macos.yml
@@ -49,7 +49,7 @@ jobs:
           crate: "cargo-nextest"
       - name: "Test (Release mode)"
         shell: bash
-        run: "cargo nextest run --all --release --target=x86_64-apple-darwin"
+        run: "cargo nextest run --all --release --no-fail-fast --target=x86_64-apple-darwin"
       - name: "Package"
         shell: bash
         run: "bash ci/deploy.sh"

--- a/.github/workflows/gen_macos_continuous.yml
+++ b/.github/workflows/gen_macos_continuous.yml
@@ -46,9 +46,13 @@ jobs:
       - name: "Build (Release mode ARM)"
         shell: bash
         run: "cargo build --target aarch64-apple-darwin --all --release"
+      - name: "Install cargo-nextest from Cargo"
+        uses: baptiste0928/cargo-install@v2
+        with:
+          crate: "cargo-nextest"
       - name: "Test (Release mode)"
         shell: bash
-        run: "cargo test --target x86_64-apple-darwin --all --release"
+        run: "cargo nextest run --all --release --target=x86_64-apple-darwin"
       - name: "Package"
         env:
           MACOS_APPLEID: ${{ secrets.MACOS_APPLEID }}

--- a/.github/workflows/gen_macos_continuous.yml
+++ b/.github/workflows/gen_macos_continuous.yml
@@ -52,7 +52,7 @@ jobs:
           crate: "cargo-nextest"
       - name: "Test (Release mode)"
         shell: bash
-        run: "cargo nextest run --all --release --target=x86_64-apple-darwin"
+        run: "cargo nextest run --all --release --no-fail-fast --target=x86_64-apple-darwin"
       - name: "Package"
         env:
           MACOS_APPLEID: ${{ secrets.MACOS_APPLEID }}

--- a/.github/workflows/gen_macos_continuous.yml
+++ b/.github/workflows/gen_macos_continuous.yml
@@ -50,7 +50,7 @@ jobs:
         uses: baptiste0928/cargo-install@v2
         with:
           crate: "cargo-nextest"
-          key: "macos"
+          cache-key: "macos"
       - name: "Test (Release mode)"
         shell: bash
         run: "cargo nextest run --all --release --no-fail-fast --target=x86_64-apple-darwin"

--- a/.github/workflows/gen_macos_continuous.yml
+++ b/.github/workflows/gen_macos_continuous.yml
@@ -50,6 +50,7 @@ jobs:
         uses: baptiste0928/cargo-install@v2
         with:
           crate: "cargo-nextest"
+          key: "macos"
       - name: "Test (Release mode)"
         shell: bash
         run: "cargo nextest run --all --release --no-fail-fast --target=x86_64-apple-darwin"

--- a/.github/workflows/gen_macos_tag.yml
+++ b/.github/workflows/gen_macos_tag.yml
@@ -37,7 +37,7 @@ jobs:
           crate: "cargo-nextest"
       - name: "Test (Release mode)"
         shell: bash
-        run: "cargo nextest run --all --release --target=x86_64-apple-darwin"
+        run: "cargo nextest run --all --release --no-fail-fast --target=x86_64-apple-darwin"
       - name: "Package"
         env:
           MACOS_APPLEID: ${{ secrets.MACOS_APPLEID }}

--- a/.github/workflows/gen_macos_tag.yml
+++ b/.github/workflows/gen_macos_tag.yml
@@ -35,7 +35,7 @@ jobs:
         uses: baptiste0928/cargo-install@v2
         with:
           crate: "cargo-nextest"
-          key: "macos"
+          cache-key: "macos"
       - name: "Test (Release mode)"
         shell: bash
         run: "cargo nextest run --all --release --no-fail-fast --target=x86_64-apple-darwin"

--- a/.github/workflows/gen_macos_tag.yml
+++ b/.github/workflows/gen_macos_tag.yml
@@ -31,9 +31,13 @@ jobs:
       - name: "Build (Release mode ARM)"
         shell: bash
         run: "cargo build --target aarch64-apple-darwin --all --release"
+      - name: "Install cargo-nextest from Cargo"
+        uses: baptiste0928/cargo-install@v2
+        with:
+          crate: "cargo-nextest"
       - name: "Test (Release mode)"
         shell: bash
-        run: "cargo test --target x86_64-apple-darwin --all --release"
+        run: "cargo nextest run --all --release --target=x86_64-apple-darwin"
       - name: "Package"
         env:
           MACOS_APPLEID: ${{ secrets.MACOS_APPLEID }}

--- a/.github/workflows/gen_macos_tag.yml
+++ b/.github/workflows/gen_macos_tag.yml
@@ -35,6 +35,7 @@ jobs:
         uses: baptiste0928/cargo-install@v2
         with:
           crate: "cargo-nextest"
+          key: "macos"
       - name: "Test (Release mode)"
         shell: bash
         run: "cargo nextest run --all --release --no-fail-fast --target=x86_64-apple-darwin"

--- a/.github/workflows/gen_opensuse_leap.yml
+++ b/.github/workflows/gen_opensuse_leap.yml
@@ -71,7 +71,7 @@ jobs:
           crate: "cargo-nextest"
       - name: "Test (Release mode)"
         shell: bash
-        run: "cargo nextest run --all --release"
+        run: "cargo nextest run --all --release --no-fail-fast"
       - name: "Package"
         shell: bash
         run: "bash ci/deploy.sh"

--- a/.github/workflows/gen_opensuse_leap.yml
+++ b/.github/workflows/gen_opensuse_leap.yml
@@ -25,7 +25,7 @@ on:
 jobs:
   build:
     runs-on: "ubuntu-latest"
-    container: "registry.opensuse.org/opensuse/leap:15.3"
+    container: "registry.opensuse.org/opensuse/leap:15.4"
 
     steps:
       - name: "Seed GITHUB_PATH to work around possible @action/core bug"

--- a/.github/workflows/gen_opensuse_leap.yml
+++ b/.github/workflows/gen_opensuse_leap.yml
@@ -69,6 +69,7 @@ jobs:
         uses: baptiste0928/cargo-install@v2
         with:
           crate: "cargo-nextest"
+          key: "opensuse_leap"
       - name: "Test (Release mode)"
         shell: bash
         run: "cargo nextest run --all --release --no-fail-fast"

--- a/.github/workflows/gen_opensuse_leap.yml
+++ b/.github/workflows/gen_opensuse_leap.yml
@@ -65,9 +65,13 @@ jobs:
       - name: "Build (Release mode)"
         shell: bash
         run: "cargo build --all --release"
+      - name: "Install cargo-nextest from Cargo"
+        uses: baptiste0928/cargo-install@v2
+        with:
+          crate: "cargo-nextest"
       - name: "Test (Release mode)"
         shell: bash
-        run: "cargo test --all --release"
+        run: "cargo nextest run --all --release"
       - name: "Package"
         shell: bash
         run: "bash ci/deploy.sh"

--- a/.github/workflows/gen_opensuse_leap.yml
+++ b/.github/workflows/gen_opensuse_leap.yml
@@ -69,7 +69,7 @@ jobs:
         uses: baptiste0928/cargo-install@v2
         with:
           crate: "cargo-nextest"
-          key: "opensuse_leap"
+          cache-key: "opensuse_leap"
       - name: "Test (Release mode)"
         shell: bash
         run: "cargo nextest run --all --release --no-fail-fast"

--- a/.github/workflows/gen_opensuse_leap_continuous.yml
+++ b/.github/workflows/gen_opensuse_leap_continuous.yml
@@ -73,7 +73,7 @@ jobs:
         uses: baptiste0928/cargo-install@v2
         with:
           crate: "cargo-nextest"
-          key: "opensuse_leap"
+          cache-key: "opensuse_leap"
       - name: "Test (Release mode)"
         shell: bash
         run: "cargo nextest run --all --release --no-fail-fast"

--- a/.github/workflows/gen_opensuse_leap_continuous.yml
+++ b/.github/workflows/gen_opensuse_leap_continuous.yml
@@ -27,7 +27,7 @@ on:
 jobs:
   build:
     runs-on: "ubuntu-latest"
-    container: "registry.opensuse.org/opensuse/leap:15.3"
+    container: "registry.opensuse.org/opensuse/leap:15.4"
     env:
       BUILD_REASON: "Schedule"
 

--- a/.github/workflows/gen_opensuse_leap_continuous.yml
+++ b/.github/workflows/gen_opensuse_leap_continuous.yml
@@ -69,9 +69,13 @@ jobs:
       - name: "Build (Release mode)"
         shell: bash
         run: "cargo build --all --release"
+      - name: "Install cargo-nextest from Cargo"
+        uses: baptiste0928/cargo-install@v2
+        with:
+          crate: "cargo-nextest"
       - name: "Test (Release mode)"
         shell: bash
-        run: "cargo test --all --release"
+        run: "cargo nextest run --all --release"
       - name: "Package"
         shell: bash
         run: "bash ci/deploy.sh"

--- a/.github/workflows/gen_opensuse_leap_continuous.yml
+++ b/.github/workflows/gen_opensuse_leap_continuous.yml
@@ -73,6 +73,7 @@ jobs:
         uses: baptiste0928/cargo-install@v2
         with:
           crate: "cargo-nextest"
+          key: "opensuse_leap"
       - name: "Test (Release mode)"
         shell: bash
         run: "cargo nextest run --all --release --no-fail-fast"

--- a/.github/workflows/gen_opensuse_leap_continuous.yml
+++ b/.github/workflows/gen_opensuse_leap_continuous.yml
@@ -75,7 +75,7 @@ jobs:
           crate: "cargo-nextest"
       - name: "Test (Release mode)"
         shell: bash
-        run: "cargo nextest run --all --release"
+        run: "cargo nextest run --all --release --no-fail-fast"
       - name: "Package"
         shell: bash
         run: "bash ci/deploy.sh"

--- a/.github/workflows/gen_opensuse_leap_tag.yml
+++ b/.github/workflows/gen_opensuse_leap_tag.yml
@@ -52,6 +52,7 @@ jobs:
         uses: baptiste0928/cargo-install@v2
         with:
           crate: "cargo-nextest"
+          key: "opensuse_leap"
       - name: "Test (Release mode)"
         shell: bash
         run: "cargo nextest run --all --release --no-fail-fast"

--- a/.github/workflows/gen_opensuse_leap_tag.yml
+++ b/.github/workflows/gen_opensuse_leap_tag.yml
@@ -52,7 +52,7 @@ jobs:
         uses: baptiste0928/cargo-install@v2
         with:
           crate: "cargo-nextest"
-          key: "opensuse_leap"
+          cache-key: "opensuse_leap"
       - name: "Test (Release mode)"
         shell: bash
         run: "cargo nextest run --all --release --no-fail-fast"

--- a/.github/workflows/gen_opensuse_leap_tag.yml
+++ b/.github/workflows/gen_opensuse_leap_tag.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build:
     runs-on: "ubuntu-latest"
-    container: "registry.opensuse.org/opensuse/leap:15.3"
+    container: "registry.opensuse.org/opensuse/leap:15.4"
 
     steps:
       - name: "Seed GITHUB_PATH to work around possible @action/core bug"

--- a/.github/workflows/gen_opensuse_leap_tag.yml
+++ b/.github/workflows/gen_opensuse_leap_tag.yml
@@ -48,9 +48,13 @@ jobs:
       - name: "Build (Release mode)"
         shell: bash
         run: "cargo build --all --release"
+      - name: "Install cargo-nextest from Cargo"
+        uses: baptiste0928/cargo-install@v2
+        with:
+          crate: "cargo-nextest"
       - name: "Test (Release mode)"
         shell: bash
-        run: "cargo test --all --release"
+        run: "cargo nextest run --all --release"
       - name: "Package"
         shell: bash
         run: "bash ci/deploy.sh"

--- a/.github/workflows/gen_opensuse_leap_tag.yml
+++ b/.github/workflows/gen_opensuse_leap_tag.yml
@@ -54,7 +54,7 @@ jobs:
           crate: "cargo-nextest"
       - name: "Test (Release mode)"
         shell: bash
-        run: "cargo nextest run --all --release"
+        run: "cargo nextest run --all --release --no-fail-fast"
       - name: "Package"
         shell: bash
         run: "bash ci/deploy.sh"

--- a/.github/workflows/gen_opensuse_tumbleweed.yml
+++ b/.github/workflows/gen_opensuse_tumbleweed.yml
@@ -74,7 +74,7 @@ jobs:
           crate: "cargo-nextest"
       - name: "Test (Release mode)"
         shell: bash
-        run: "cargo nextest run --all --release"
+        run: "cargo nextest run --all --release --no-fail-fast"
       - name: "Package"
         shell: bash
         run: "bash ci/deploy.sh"

--- a/.github/workflows/gen_opensuse_tumbleweed.yml
+++ b/.github/workflows/gen_opensuse_tumbleweed.yml
@@ -72,7 +72,7 @@ jobs:
         uses: baptiste0928/cargo-install@v2
         with:
           crate: "cargo-nextest"
-          key: "opensuse_tumbleweed"
+          cache-key: "opensuse_tumbleweed"
       - name: "Test (Release mode)"
         shell: bash
         run: "cargo nextest run --all --release --no-fail-fast"

--- a/.github/workflows/gen_opensuse_tumbleweed.yml
+++ b/.github/workflows/gen_opensuse_tumbleweed.yml
@@ -72,6 +72,7 @@ jobs:
         uses: baptiste0928/cargo-install@v2
         with:
           crate: "cargo-nextest"
+          key: "opensuse_tumbleweed"
       - name: "Test (Release mode)"
         shell: bash
         run: "cargo nextest run --all --release --no-fail-fast"

--- a/.github/workflows/gen_opensuse_tumbleweed.yml
+++ b/.github/workflows/gen_opensuse_tumbleweed.yml
@@ -68,9 +68,13 @@ jobs:
       - name: "Build (Release mode)"
         shell: bash
         run: "cargo build --all --release"
+      - name: "Install cargo-nextest from Cargo"
+        uses: baptiste0928/cargo-install@v2
+        with:
+          crate: "cargo-nextest"
       - name: "Test (Release mode)"
         shell: bash
-        run: "cargo test --all --release"
+        run: "cargo nextest run --all --release"
       - name: "Package"
         shell: bash
         run: "bash ci/deploy.sh"

--- a/.github/workflows/gen_opensuse_tumbleweed_continuous.yml
+++ b/.github/workflows/gen_opensuse_tumbleweed_continuous.yml
@@ -72,9 +72,13 @@ jobs:
       - name: "Build (Release mode)"
         shell: bash
         run: "cargo build --all --release"
+      - name: "Install cargo-nextest from Cargo"
+        uses: baptiste0928/cargo-install@v2
+        with:
+          crate: "cargo-nextest"
       - name: "Test (Release mode)"
         shell: bash
-        run: "cargo test --all --release"
+        run: "cargo nextest run --all --release"
       - name: "Package"
         shell: bash
         run: "bash ci/deploy.sh"

--- a/.github/workflows/gen_opensuse_tumbleweed_continuous.yml
+++ b/.github/workflows/gen_opensuse_tumbleweed_continuous.yml
@@ -78,7 +78,7 @@ jobs:
           crate: "cargo-nextest"
       - name: "Test (Release mode)"
         shell: bash
-        run: "cargo nextest run --all --release"
+        run: "cargo nextest run --all --release --no-fail-fast"
       - name: "Package"
         shell: bash
         run: "bash ci/deploy.sh"

--- a/.github/workflows/gen_opensuse_tumbleweed_continuous.yml
+++ b/.github/workflows/gen_opensuse_tumbleweed_continuous.yml
@@ -76,6 +76,7 @@ jobs:
         uses: baptiste0928/cargo-install@v2
         with:
           crate: "cargo-nextest"
+          key: "opensuse_tumbleweed"
       - name: "Test (Release mode)"
         shell: bash
         run: "cargo nextest run --all --release --no-fail-fast"

--- a/.github/workflows/gen_opensuse_tumbleweed_continuous.yml
+++ b/.github/workflows/gen_opensuse_tumbleweed_continuous.yml
@@ -76,7 +76,7 @@ jobs:
         uses: baptiste0928/cargo-install@v2
         with:
           crate: "cargo-nextest"
-          key: "opensuse_tumbleweed"
+          cache-key: "opensuse_tumbleweed"
       - name: "Test (Release mode)"
         shell: bash
         run: "cargo nextest run --all --release --no-fail-fast"

--- a/.github/workflows/gen_opensuse_tumbleweed_tag.yml
+++ b/.github/workflows/gen_opensuse_tumbleweed_tag.yml
@@ -57,7 +57,7 @@ jobs:
           crate: "cargo-nextest"
       - name: "Test (Release mode)"
         shell: bash
-        run: "cargo nextest run --all --release"
+        run: "cargo nextest run --all --release --no-fail-fast"
       - name: "Package"
         shell: bash
         run: "bash ci/deploy.sh"

--- a/.github/workflows/gen_opensuse_tumbleweed_tag.yml
+++ b/.github/workflows/gen_opensuse_tumbleweed_tag.yml
@@ -51,9 +51,13 @@ jobs:
       - name: "Build (Release mode)"
         shell: bash
         run: "cargo build --all --release"
+      - name: "Install cargo-nextest from Cargo"
+        uses: baptiste0928/cargo-install@v2
+        with:
+          crate: "cargo-nextest"
       - name: "Test (Release mode)"
         shell: bash
-        run: "cargo test --all --release"
+        run: "cargo nextest run --all --release"
       - name: "Package"
         shell: bash
         run: "bash ci/deploy.sh"

--- a/.github/workflows/gen_opensuse_tumbleweed_tag.yml
+++ b/.github/workflows/gen_opensuse_tumbleweed_tag.yml
@@ -55,6 +55,7 @@ jobs:
         uses: baptiste0928/cargo-install@v2
         with:
           crate: "cargo-nextest"
+          key: "opensuse_tumbleweed"
       - name: "Test (Release mode)"
         shell: bash
         run: "cargo nextest run --all --release --no-fail-fast"

--- a/.github/workflows/gen_opensuse_tumbleweed_tag.yml
+++ b/.github/workflows/gen_opensuse_tumbleweed_tag.yml
@@ -55,7 +55,7 @@ jobs:
         uses: baptiste0928/cargo-install@v2
         with:
           crate: "cargo-nextest"
-          key: "opensuse_tumbleweed"
+          cache-key: "opensuse_tumbleweed"
       - name: "Test (Release mode)"
         shell: bash
         run: "cargo nextest run --all --release --no-fail-fast"

--- a/.github/workflows/gen_ubuntu20.04.yml
+++ b/.github/workflows/gen_ubuntu20.04.yml
@@ -77,7 +77,7 @@ jobs:
         uses: baptiste0928/cargo-install@v2
         with:
           crate: "cargo-nextest"
-          key: "ubuntu20.04"
+          cache-key: "ubuntu20.04"
       - name: "Test (Release mode)"
         shell: bash
         run: "cargo nextest run --all --release --no-fail-fast"

--- a/.github/workflows/gen_ubuntu20.04.yml
+++ b/.github/workflows/gen_ubuntu20.04.yml
@@ -73,9 +73,13 @@ jobs:
       - name: "Build (Release mode)"
         shell: bash
         run: "cargo build --all --release"
+      - name: "Install cargo-nextest from Cargo"
+        uses: baptiste0928/cargo-install@v2
+        with:
+          crate: "cargo-nextest"
       - name: "Test (Release mode)"
         shell: bash
-        run: "cargo test --all --release"
+        run: "cargo nextest run --all --release"
       - name: "Package"
         shell: bash
         run: "bash ci/deploy.sh"

--- a/.github/workflows/gen_ubuntu20.04.yml
+++ b/.github/workflows/gen_ubuntu20.04.yml
@@ -79,7 +79,7 @@ jobs:
           crate: "cargo-nextest"
       - name: "Test (Release mode)"
         shell: bash
-        run: "cargo nextest run --all --release"
+        run: "cargo nextest run --all --release --no-fail-fast"
       - name: "Package"
         shell: bash
         run: "bash ci/deploy.sh"

--- a/.github/workflows/gen_ubuntu20.04.yml
+++ b/.github/workflows/gen_ubuntu20.04.yml
@@ -77,6 +77,7 @@ jobs:
         uses: baptiste0928/cargo-install@v2
         with:
           crate: "cargo-nextest"
+          key: "ubuntu20.04"
       - name: "Test (Release mode)"
         shell: bash
         run: "cargo nextest run --all --release --no-fail-fast"

--- a/.github/workflows/gen_ubuntu20.04_continuous.yml
+++ b/.github/workflows/gen_ubuntu20.04_continuous.yml
@@ -83,7 +83,7 @@ jobs:
           crate: "cargo-nextest"
       - name: "Test (Release mode)"
         shell: bash
-        run: "cargo nextest run --all --release"
+        run: "cargo nextest run --all --release --no-fail-fast"
       - name: "Package"
         shell: bash
         run: "bash ci/deploy.sh"

--- a/.github/workflows/gen_ubuntu20.04_continuous.yml
+++ b/.github/workflows/gen_ubuntu20.04_continuous.yml
@@ -81,7 +81,7 @@ jobs:
         uses: baptiste0928/cargo-install@v2
         with:
           crate: "cargo-nextest"
-          key: "ubuntu20.04"
+          cache-key: "ubuntu20.04"
       - name: "Test (Release mode)"
         shell: bash
         run: "cargo nextest run --all --release --no-fail-fast"

--- a/.github/workflows/gen_ubuntu20.04_continuous.yml
+++ b/.github/workflows/gen_ubuntu20.04_continuous.yml
@@ -81,6 +81,7 @@ jobs:
         uses: baptiste0928/cargo-install@v2
         with:
           crate: "cargo-nextest"
+          key: "ubuntu20.04"
       - name: "Test (Release mode)"
         shell: bash
         run: "cargo nextest run --all --release --no-fail-fast"

--- a/.github/workflows/gen_ubuntu20.04_continuous.yml
+++ b/.github/workflows/gen_ubuntu20.04_continuous.yml
@@ -77,9 +77,13 @@ jobs:
       - name: "Build (Release mode)"
         shell: bash
         run: "cargo build --all --release"
+      - name: "Install cargo-nextest from Cargo"
+        uses: baptiste0928/cargo-install@v2
+        with:
+          crate: "cargo-nextest"
       - name: "Test (Release mode)"
         shell: bash
-        run: "cargo test --all --release"
+        run: "cargo nextest run --all --release"
       - name: "Package"
         shell: bash
         run: "bash ci/deploy.sh"

--- a/.github/workflows/gen_ubuntu20.04_tag.yml
+++ b/.github/workflows/gen_ubuntu20.04_tag.yml
@@ -57,6 +57,7 @@ jobs:
         uses: baptiste0928/cargo-install@v2
         with:
           crate: "cargo-nextest"
+          key: "ubuntu20.04"
       - name: "Test (Release mode)"
         shell: bash
         run: "cargo nextest run --all --release --no-fail-fast"

--- a/.github/workflows/gen_ubuntu20.04_tag.yml
+++ b/.github/workflows/gen_ubuntu20.04_tag.yml
@@ -59,7 +59,7 @@ jobs:
           crate: "cargo-nextest"
       - name: "Test (Release mode)"
         shell: bash
-        run: "cargo nextest run --all --release"
+        run: "cargo nextest run --all --release --no-fail-fast"
       - name: "Package"
         shell: bash
         run: "bash ci/deploy.sh"

--- a/.github/workflows/gen_ubuntu20.04_tag.yml
+++ b/.github/workflows/gen_ubuntu20.04_tag.yml
@@ -57,7 +57,7 @@ jobs:
         uses: baptiste0928/cargo-install@v2
         with:
           crate: "cargo-nextest"
-          key: "ubuntu20.04"
+          cache-key: "ubuntu20.04"
       - name: "Test (Release mode)"
         shell: bash
         run: "cargo nextest run --all --release --no-fail-fast"

--- a/.github/workflows/gen_ubuntu20.04_tag.yml
+++ b/.github/workflows/gen_ubuntu20.04_tag.yml
@@ -53,9 +53,13 @@ jobs:
       - name: "Build (Release mode)"
         shell: bash
         run: "cargo build --all --release"
+      - name: "Install cargo-nextest from Cargo"
+        uses: baptiste0928/cargo-install@v2
+        with:
+          crate: "cargo-nextest"
       - name: "Test (Release mode)"
         shell: bash
-        run: "cargo test --all --release"
+        run: "cargo nextest run --all --release"
       - name: "Package"
         shell: bash
         run: "bash ci/deploy.sh"

--- a/.github/workflows/gen_ubuntu22.04.yml
+++ b/.github/workflows/gen_ubuntu22.04.yml
@@ -72,7 +72,7 @@ jobs:
         uses: baptiste0928/cargo-install@v2
         with:
           crate: "cargo-nextest"
-          key: "ubuntu22.04"
+          cache-key: "ubuntu22.04"
       - name: "Test (Release mode)"
         shell: bash
         run: "cargo nextest run --all --release --no-fail-fast"

--- a/.github/workflows/gen_ubuntu22.04.yml
+++ b/.github/workflows/gen_ubuntu22.04.yml
@@ -74,7 +74,7 @@ jobs:
           crate: "cargo-nextest"
       - name: "Test (Release mode)"
         shell: bash
-        run: "cargo nextest run --all --release"
+        run: "cargo nextest run --all --release --no-fail-fast"
       - name: "Package"
         shell: bash
         run: "bash ci/deploy.sh"

--- a/.github/workflows/gen_ubuntu22.04.yml
+++ b/.github/workflows/gen_ubuntu22.04.yml
@@ -68,9 +68,13 @@ jobs:
       - name: "Build (Release mode)"
         shell: bash
         run: "cargo build --all --release"
+      - name: "Install cargo-nextest from Cargo"
+        uses: baptiste0928/cargo-install@v2
+        with:
+          crate: "cargo-nextest"
       - name: "Test (Release mode)"
         shell: bash
-        run: "cargo test --all --release"
+        run: "cargo nextest run --all --release"
       - name: "Package"
         shell: bash
         run: "bash ci/deploy.sh"

--- a/.github/workflows/gen_ubuntu22.04.yml
+++ b/.github/workflows/gen_ubuntu22.04.yml
@@ -72,6 +72,7 @@ jobs:
         uses: baptiste0928/cargo-install@v2
         with:
           crate: "cargo-nextest"
+          key: "ubuntu22.04"
       - name: "Test (Release mode)"
         shell: bash
         run: "cargo nextest run --all --release --no-fail-fast"

--- a/.github/workflows/gen_ubuntu22.04_continuous.yml
+++ b/.github/workflows/gen_ubuntu22.04_continuous.yml
@@ -72,9 +72,13 @@ jobs:
       - name: "Build (Release mode)"
         shell: bash
         run: "cargo build --all --release"
+      - name: "Install cargo-nextest from Cargo"
+        uses: baptiste0928/cargo-install@v2
+        with:
+          crate: "cargo-nextest"
       - name: "Test (Release mode)"
         shell: bash
-        run: "cargo test --all --release"
+        run: "cargo nextest run --all --release"
       - name: "Package"
         shell: bash
         run: "bash ci/deploy.sh"

--- a/.github/workflows/gen_ubuntu22.04_continuous.yml
+++ b/.github/workflows/gen_ubuntu22.04_continuous.yml
@@ -78,7 +78,7 @@ jobs:
           crate: "cargo-nextest"
       - name: "Test (Release mode)"
         shell: bash
-        run: "cargo nextest run --all --release"
+        run: "cargo nextest run --all --release --no-fail-fast"
       - name: "Package"
         shell: bash
         run: "bash ci/deploy.sh"

--- a/.github/workflows/gen_ubuntu22.04_continuous.yml
+++ b/.github/workflows/gen_ubuntu22.04_continuous.yml
@@ -76,6 +76,7 @@ jobs:
         uses: baptiste0928/cargo-install@v2
         with:
           crate: "cargo-nextest"
+          key: "ubuntu22.04"
       - name: "Test (Release mode)"
         shell: bash
         run: "cargo nextest run --all --release --no-fail-fast"

--- a/.github/workflows/gen_ubuntu22.04_continuous.yml
+++ b/.github/workflows/gen_ubuntu22.04_continuous.yml
@@ -76,7 +76,7 @@ jobs:
         uses: baptiste0928/cargo-install@v2
         with:
           crate: "cargo-nextest"
-          key: "ubuntu22.04"
+          cache-key: "ubuntu22.04"
       - name: "Test (Release mode)"
         shell: bash
         run: "cargo nextest run --all --release --no-fail-fast"

--- a/.github/workflows/gen_ubuntu22.04_tag.yml
+++ b/.github/workflows/gen_ubuntu22.04_tag.yml
@@ -57,7 +57,7 @@ jobs:
           crate: "cargo-nextest"
       - name: "Test (Release mode)"
         shell: bash
-        run: "cargo nextest run --all --release"
+        run: "cargo nextest run --all --release --no-fail-fast"
       - name: "Package"
         shell: bash
         run: "bash ci/deploy.sh"

--- a/.github/workflows/gen_ubuntu22.04_tag.yml
+++ b/.github/workflows/gen_ubuntu22.04_tag.yml
@@ -51,9 +51,13 @@ jobs:
       - name: "Build (Release mode)"
         shell: bash
         run: "cargo build --all --release"
+      - name: "Install cargo-nextest from Cargo"
+        uses: baptiste0928/cargo-install@v2
+        with:
+          crate: "cargo-nextest"
       - name: "Test (Release mode)"
         shell: bash
-        run: "cargo test --all --release"
+        run: "cargo nextest run --all --release"
       - name: "Package"
         shell: bash
         run: "bash ci/deploy.sh"

--- a/.github/workflows/gen_ubuntu22.04_tag.yml
+++ b/.github/workflows/gen_ubuntu22.04_tag.yml
@@ -55,7 +55,7 @@ jobs:
         uses: baptiste0928/cargo-install@v2
         with:
           crate: "cargo-nextest"
-          key: "ubuntu22.04"
+          cache-key: "ubuntu22.04"
       - name: "Test (Release mode)"
         shell: bash
         run: "cargo nextest run --all --release --no-fail-fast"

--- a/.github/workflows/gen_ubuntu22.04_tag.yml
+++ b/.github/workflows/gen_ubuntu22.04_tag.yml
@@ -55,6 +55,7 @@ jobs:
         uses: baptiste0928/cargo-install@v2
         with:
           crate: "cargo-nextest"
+          key: "ubuntu22.04"
       - name: "Test (Release mode)"
         shell: bash
         run: "cargo nextest run --all --release --no-fail-fast"

--- a/.github/workflows/gen_windows.yml
+++ b/.github/workflows/gen_windows.yml
@@ -43,6 +43,7 @@ jobs:
         uses: baptiste0928/cargo-install@v2
         with:
           crate: "cargo-nextest"
+          key: "windows"
       - name: "Test (Release mode)"
         shell: bash
         run: "cargo nextest run --all --release --no-fail-fast"

--- a/.github/workflows/gen_windows.yml
+++ b/.github/workflows/gen_windows.yml
@@ -39,9 +39,13 @@ jobs:
 
           PATH C:\Strawberry\perl\bin;%PATH%
           cargo build --all --release
+      - name: "Install cargo-nextest from Cargo"
+        uses: baptiste0928/cargo-install@v2
+        with:
+          crate: "cargo-nextest"
       - name: "Test (Release mode)"
         shell: bash
-        run: "cargo test --all --release"
+        run: "cargo nextest run --all --release"
       - name: "Package"
         shell: bash
         run: "bash ci/deploy.sh"

--- a/.github/workflows/gen_windows.yml
+++ b/.github/workflows/gen_windows.yml
@@ -45,7 +45,7 @@ jobs:
           crate: "cargo-nextest"
       - name: "Test (Release mode)"
         shell: bash
-        run: "cargo nextest run --all --release"
+        run: "cargo nextest run --all --release --no-fail-fast"
       - name: "Package"
         shell: bash
         run: "bash ci/deploy.sh"

--- a/.github/workflows/gen_windows.yml
+++ b/.github/workflows/gen_windows.yml
@@ -43,7 +43,7 @@ jobs:
         uses: baptiste0928/cargo-install@v2
         with:
           crate: "cargo-nextest"
-          key: "windows"
+          cache-key: "windows"
       - name: "Test (Release mode)"
         shell: bash
         run: "cargo nextest run --all --release --no-fail-fast"

--- a/.github/workflows/gen_windows_continuous.yml
+++ b/.github/workflows/gen_windows_continuous.yml
@@ -43,9 +43,13 @@ jobs:
 
           PATH C:\Strawberry\perl\bin;%PATH%
           cargo build --all --release
+      - name: "Install cargo-nextest from Cargo"
+        uses: baptiste0928/cargo-install@v2
+        with:
+          crate: "cargo-nextest"
       - name: "Test (Release mode)"
         shell: bash
-        run: "cargo test --all --release"
+        run: "cargo nextest run --all --release"
       - name: "Package"
         shell: bash
         run: "bash ci/deploy.sh"

--- a/.github/workflows/gen_windows_continuous.yml
+++ b/.github/workflows/gen_windows_continuous.yml
@@ -47,6 +47,7 @@ jobs:
         uses: baptiste0928/cargo-install@v2
         with:
           crate: "cargo-nextest"
+          key: "windows"
       - name: "Test (Release mode)"
         shell: bash
         run: "cargo nextest run --all --release --no-fail-fast"

--- a/.github/workflows/gen_windows_continuous.yml
+++ b/.github/workflows/gen_windows_continuous.yml
@@ -49,7 +49,7 @@ jobs:
           crate: "cargo-nextest"
       - name: "Test (Release mode)"
         shell: bash
-        run: "cargo nextest run --all --release"
+        run: "cargo nextest run --all --release --no-fail-fast"
       - name: "Package"
         shell: bash
         run: "bash ci/deploy.sh"

--- a/.github/workflows/gen_windows_continuous.yml
+++ b/.github/workflows/gen_windows_continuous.yml
@@ -47,7 +47,7 @@ jobs:
         uses: baptiste0928/cargo-install@v2
         with:
           crate: "cargo-nextest"
-          key: "windows"
+          cache-key: "windows"
       - name: "Test (Release mode)"
         shell: bash
         run: "cargo nextest run --all --release --no-fail-fast"

--- a/.github/workflows/gen_windows_tag.yml
+++ b/.github/workflows/gen_windows_tag.yml
@@ -35,7 +35,7 @@ jobs:
           crate: "cargo-nextest"
       - name: "Test (Release mode)"
         shell: bash
-        run: "cargo nextest run --all --release"
+        run: "cargo nextest run --all --release --no-fail-fast"
       - name: "Package"
         shell: bash
         run: "bash ci/deploy.sh"

--- a/.github/workflows/gen_windows_tag.yml
+++ b/.github/workflows/gen_windows_tag.yml
@@ -33,6 +33,7 @@ jobs:
         uses: baptiste0928/cargo-install@v2
         with:
           crate: "cargo-nextest"
+          key: "windows"
       - name: "Test (Release mode)"
         shell: bash
         run: "cargo nextest run --all --release --no-fail-fast"

--- a/.github/workflows/gen_windows_tag.yml
+++ b/.github/workflows/gen_windows_tag.yml
@@ -33,7 +33,7 @@ jobs:
         uses: baptiste0928/cargo-install@v2
         with:
           crate: "cargo-nextest"
-          key: "windows"
+          cache-key: "windows"
       - name: "Test (Release mode)"
         shell: bash
         run: "cargo nextest run --all --release --no-fail-fast"

--- a/.github/workflows/gen_windows_tag.yml
+++ b/.github/workflows/gen_windows_tag.yml
@@ -29,9 +29,13 @@ jobs:
 
           PATH C:\Strawberry\perl\bin;%PATH%
           cargo build --all --release
+      - name: "Install cargo-nextest from Cargo"
+        uses: baptiste0928/cargo-install@v2
+        with:
+          crate: "cargo-nextest"
       - name: "Test (Release mode)"
         shell: bash
-        run: "cargo test --all --release"
+        run: "cargo nextest run --all --release"
       - name: "Package"
         shell: bash
         run: "bash ci/deploy.sh"

--- a/.github/workflows/termwiz.yml
+++ b/.github/workflows/termwiz.yml
@@ -42,7 +42,7 @@ jobs:
         run: |
           source $HOME/.cargo/env
           cargo build -p termwiz --all-features
-          cargo nextest run --package termwiz --all-features
+          cargo nextest run --no-fail-fast --package termwiz --all-features
 
   fuzz-termwiz:
     runs-on: ubuntu-latest

--- a/.github/workflows/termwiz.yml
+++ b/.github/workflows/termwiz.yml
@@ -42,7 +42,7 @@ jobs:
         run: |
           source $HOME/.cargo/env
           cargo build -p termwiz --all-features
-          cargo test -p termwiz --all-features
+          cargo nextest run --package termwiz --all-features
 
   fuzz-termwiz:
     runs-on: ubuntu-latest

--- a/.github/workflows/termwiz.yml
+++ b/.github/workflows/termwiz.yml
@@ -38,6 +38,10 @@ jobs:
           workspaces: |
             termwiz
           key: "termwiz-${{ runner.os }}"
+      - name: "Install cargo-nextest from Cargo"
+        uses: baptiste0928/cargo-install@v2
+        with:
+          crate: "cargo-nextest"
       - name: Build
         run: |
           source $HOME/.cargo/env

--- a/.github/workflows/wezterm_ssh.yml
+++ b/.github/workflows/wezterm_ssh.yml
@@ -36,6 +36,10 @@ jobs:
           workspaces: |
             wezterm-ssh
           key: "wezterm-ssh-libssh-rs-${{ runner.os }}"
+      - name: "Install cargo-nextest from Cargo"
+        uses: baptiste0928/cargo-install@v2
+        with:
+          crate: "cargo-nextest"
       - name: Build
         run: |
           source $HOME/.cargo/env
@@ -54,6 +58,10 @@ jobs:
           workspaces: |
             wezterm-ssh
           key: "wezterm-ssh-ssh2-${{ runner.os }}"
+      - name: "Install cargo-nextest from Cargo"
+        uses: baptiste0928/cargo-install@v2
+        with:
+          crate: "cargo-nextest"
       - name: Build
         run: |
           source $HOME/.cargo/env

--- a/.github/workflows/wezterm_ssh.yml
+++ b/.github/workflows/wezterm_ssh.yml
@@ -40,7 +40,7 @@ jobs:
         run: |
           source $HOME/.cargo/env
           cargo build -p wezterm-ssh --no-default-features --features "libssh-rs vendored-openssl-libssh-rs"
-          cargo nextest run -p wezterm-ssh --no-default-features --features "libssh-rs vendored-openssl-libssh-rs"
+          cargo nextest run --no-fail-fast -p wezterm-ssh --no-default-features --features "libssh-rs vendored-openssl-libssh-rs"
   build-wezterm-ssh-feature-ssh2:
     runs-on: ubuntu-latest
     steps:
@@ -58,5 +58,5 @@ jobs:
         run: |
           source $HOME/.cargo/env
           cargo build -p wezterm-ssh --no-default-features --features "ssh2 vendored-openssl-ssh2"
-          cargo nextest run -p wezterm-ssh --no-default-features --features "ssh2 vendored-openssl-ssh2"
+          cargo nextest run --no-fail-fast -p wezterm-ssh --no-default-features --features "ssh2 vendored-openssl-ssh2"
 

--- a/.github/workflows/wezterm_ssh.yml
+++ b/.github/workflows/wezterm_ssh.yml
@@ -40,7 +40,7 @@ jobs:
         run: |
           source $HOME/.cargo/env
           cargo build -p wezterm-ssh --no-default-features --features "libssh-rs vendored-openssl-libssh-rs"
-          cargo test -p wezterm-ssh --no-default-features --features "libssh-rs vendored-openssl-libssh-rs"
+          cargo nextest run -p wezterm-ssh --no-default-features --features "libssh-rs vendored-openssl-libssh-rs"
   build-wezterm-ssh-feature-ssh2:
     runs-on: ubuntu-latest
     steps:
@@ -58,5 +58,5 @@ jobs:
         run: |
           source $HOME/.cargo/env
           cargo build -p wezterm-ssh --no-default-features --features "ssh2 vendored-openssl-ssh2"
-          cargo test -p wezterm-ssh --no-default-features --features "ssh2 vendored-openssl-ssh2"
+          cargo nextest run -p wezterm-ssh --no-default-features --features "ssh2 vendored-openssl-ssh2"
 

--- a/ci/generate-workflows.py
+++ b/ci/generate-workflows.py
@@ -437,7 +437,7 @@ cargo build --all --release""",
         ]
 
     def test_all_release(self):
-        run = "cargo nextest run --all --release"
+        run = "cargo nextest run --all --release --no-fail-fast"
         if "macos" in self.name:
             run += " --target=x86_64-apple-darwin"
         if self.name == "centos7":

--- a/ci/generate-workflows.py
+++ b/ci/generate-workflows.py
@@ -919,7 +919,7 @@ TARGETS = [
     Target(container="fedora:36"),
     Target(container="fedora:37"),
     Target(container="alpine:3.15"),
-    Target(name="opensuse_leap", container="registry.opensuse.org/opensuse/leap:15.3"),
+    Target(name="opensuse_leap", container="registry.opensuse.org/opensuse/leap:15.4"),
     Target(
         name="opensuse_tumbleweed",
         container="registry.opensuse.org/opensuse/tumbleweed",

--- a/ci/generate-workflows.py
+++ b/ci/generate-workflows.py
@@ -143,7 +143,7 @@ class CheckoutStep(ActionStep):
 
 class InstallCrateStep(ActionStep):
     def __init__(self, crate: str, key: str, version=None):
-        params = {"crate": crate, "key": key}
+        params = {"crate": crate, "cache-key": key}
         if version is not None:
             params["version"] = version
         super().__init__(

--- a/ci/generate-workflows.py
+++ b/ci/generate-workflows.py
@@ -141,6 +141,18 @@ class CheckoutStep(ActionStep):
         super().__init__(name, action="actions/checkout@v3", params=params)
 
 
+class InstallCrateStep(ActionStep):
+    def __init__(self, crate: str, version=None):
+        params = {"crate": crate}
+        if version is not None:
+            params["version"] = version
+        super().__init__(
+            f"Install {crate} from Cargo",
+            action="baptiste0928/cargo-install@v2",
+            params=params
+        )
+
+
 class Job(object):
     def __init__(self, runs_on, container=None, steps=None, env=None):
         self.runs_on = runs_on
@@ -425,22 +437,21 @@ cargo build --all --release""",
         ]
 
     def test_all_release(self):
+        run = "cargo nextest run --all --release"
         if "macos" in self.name:
-            return [
-                RunStep(
-                    name="Test (Release mode)",
-                    run="cargo test --target x86_64-apple-darwin --all --release",
-                )
-            ]
+            run += " --target=x86_64-apple-darwin"
         if self.name == "centos7":
-            enable = "source /opt/rh/devtoolset-9/enable && "
-        else:
-            enable = ""
+            run = "source /opt/rh/devtoolset-9/enable\n" + run
         return [
+            # Install cargo-nextest
+            InstallCrateStep("cargo-nextest"),
+            # Run tests
             RunStep(
-                name="Test (Release mode)", run=enable + "cargo test --all --release"
-            )
+                name="Test (Release mode)",
+                run=run,
+            ),
         ]
+        
 
     def package(self, trusted=False):
         steps = []

--- a/ci/generate-workflows.py
+++ b/ci/generate-workflows.py
@@ -142,8 +142,8 @@ class CheckoutStep(ActionStep):
 
 
 class InstallCrateStep(ActionStep):
-    def __init__(self, crate: str, version=None):
-        params = {"crate": crate}
+    def __init__(self, crate: str, key: str, version=None):
+        params = {"crate": crate, "key": key}
         if version is not None:
             params["version"] = version
         super().__init__(
@@ -444,7 +444,7 @@ cargo build --all --release""",
             run = "source /opt/rh/devtoolset-9/enable\n" + run
         return [
             # Install cargo-nextest
-            InstallCrateStep("cargo-nextest"),
+            InstallCrateStep("cargo-nextest", key=self.name),
             # Run tests
             RunStep(
                 name="Test (Release mode)",


### PR DESCRIPTION
## Blockers

- [x] Merge #3327 , it has conflicts with this PR.
- [x] Merge #3341 , it has conflicts with this PR.
- [x] Fix OpenSUSE failing `wezterm-ssh` tests see [this comment](https://github.com/wez/wezterm/pull/3342#issuecomment-1483164632)
- [x] Allow `baptiste0928/cargo-install@v2` in CI.

## Reasoning

As discussed in #3327 , nextest no longer has problems with flaky tests and can be used to speed up CI.

_The more I work with the generate-workflows.py, the more I get the urge to RiiR_