### PR TITLE
Use install action instead of manually calling `cargo install`

### DIFF
--- a/.github/workflows/termwiz.yml
+++ b/.github/workflows/termwiz.yml
@@ -53,11 +53,10 @@ jobs:
             ~/.cargo/git
             target
           key: "ubuntu-latest-termwiz-fuzz-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}-cargo"
-      - name: Install fuzzer
-        run: |
-          source $HOME/.cargo/env
-          cargo install cargo-fuzz
-          cd termwiz/fuzz
+      - name: "Install cargo-fuzz from Cargo"
+        uses: baptiste0928/cargo-install@v2
+        with:
+          crate: "cargo-fuzz"
       - name: Fuzz
         run: |
           source $HOME/.cargo/env


### PR DESCRIPTION
As part of #3342 I found that `cargo install` was being called directly to install `cargo-fuzz`, this is a smaller PR that fixes just that.

The result should be cached thus making the termwiz CI faster. 