### PR TITLE
CI: Delay less important Linux Distros' workflows

### DIFF
--- a/.github/workflows/gen_alpine3.15.yml
+++ b/.github/workflows/gen_alpine3.15.yml
@@ -5,22 +5,11 @@ on:
     branches:
       - main
     paths:
-      - "**/*.rs"
-      - "**/Cargo.lock"
-      - "**/Cargo.toml"
       - ".github/workflows/gen_alpine3.15.yml"
-      - "assets/fonts/**/*"
-      - "assets/icon/*"
-      - "assets/open-wezterm-here"
-      - "assets/shell-completion/**/*"
-      - "assets/shell-integration/**/*"
-      - "assets/wezterm-nautilus.py"
-      - "assets/wezterm.appdata.xml"
-      - "assets/wezterm.desktop"
-      - "ci/deploy.sh"
-      - "ci/tag-name.sh"
-      - "get-deps"
-      - "termwiz/data/wezterm.terminfo"
+  workflow_run:
+    types: [completed]
+    branches: [main]
+    workflows: ['ubuntu22.04', 'macos', 'windows']
 
 jobs:
   build:

--- a/.github/workflows/gen_alpine3.15.yml
+++ b/.github/workflows/gen_alpine3.15.yml
@@ -1,15 +1,14 @@
 name: alpine3.15
 
 on:
-  pull_request:
-    branches:
-      - main
-    paths:
-      - ".github/workflows/gen_alpine3.15.yml"
   workflow_run:
     types: [completed]
     branches: [main]
     workflows: ['ubuntu22.04', 'macos', 'windows']
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/gen_alpine3.15.yml"
 
 jobs:
   build:

--- a/.github/workflows/gen_alpine3.15_continuous.yml
+++ b/.github/workflows/gen_alpine3.15_continuous.yml
@@ -3,9 +3,12 @@ name: alpine3.15_continuous
 on:
   schedule:
     - cron: "10 3 * * *"
-  push:
-    branches:
-      - main
+  workflow_run:
+    types: [completed]
+    branches: [main]
+    workflows: ['ubuntu22.04', 'macos', 'windows']
+  pull_request:
+    branches: [main]
     paths:
       - "**/*.rs"
       - "**/Cargo.lock"

--- a/.github/workflows/gen_centos7.yml
+++ b/.github/workflows/gen_centos7.yml
@@ -1,15 +1,14 @@
 name: centos7
 
 on:
-  pull_request:
-    branches:
-      - main
-    paths:
-      - ".github/workflows/gen_centos7.yml"
   workflow_run:
     types: [completed]
     branches: [main]
     workflows: ['ubuntu22.04', 'macos', 'windows']
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/gen_centos7.yml"
 
 jobs:
   build:

--- a/.github/workflows/gen_centos7.yml
+++ b/.github/workflows/gen_centos7.yml
@@ -5,22 +5,11 @@ on:
     branches:
       - main
     paths:
-      - "**/*.rs"
-      - "**/Cargo.lock"
-      - "**/Cargo.toml"
       - ".github/workflows/gen_centos7.yml"
-      - "assets/fonts/**/*"
-      - "assets/icon/*"
-      - "assets/open-wezterm-here"
-      - "assets/shell-completion/**/*"
-      - "assets/shell-integration/**/*"
-      - "assets/wezterm-nautilus.py"
-      - "assets/wezterm.appdata.xml"
-      - "assets/wezterm.desktop"
-      - "ci/deploy.sh"
-      - "ci/tag-name.sh"
-      - "get-deps"
-      - "termwiz/data/wezterm.terminfo"
+  workflow_run:
+    types: [completed]
+    branches: [main]
+    workflows: ['ubuntu22.04', 'macos', 'windows']
 
 jobs:
   build:

--- a/.github/workflows/gen_centos7_continuous.yml
+++ b/.github/workflows/gen_centos7_continuous.yml
@@ -3,9 +3,12 @@ name: centos7_continuous
 on:
   schedule:
     - cron: "10 3 * * *"
-  push:
-    branches:
-      - main
+  workflow_run:
+    types: [completed]
+    branches: [main]
+    workflows: ['ubuntu22.04', 'macos', 'windows']
+  pull_request:
+    branches: [main]
     paths:
       - "**/*.rs"
       - "**/Cargo.lock"

--- a/.github/workflows/gen_centos8.yml
+++ b/.github/workflows/gen_centos8.yml
@@ -1,15 +1,14 @@
 name: centos8
 
 on:
-  pull_request:
-    branches:
-      - main
-    paths:
-      - ".github/workflows/gen_centos8.yml"
   workflow_run:
     types: [completed]
     branches: [main]
     workflows: ['ubuntu22.04', 'macos', 'windows']
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/gen_centos8.yml"
 
 jobs:
   build:

--- a/.github/workflows/gen_centos8.yml
+++ b/.github/workflows/gen_centos8.yml
@@ -5,22 +5,11 @@ on:
     branches:
       - main
     paths:
-      - "**/*.rs"
-      - "**/Cargo.lock"
-      - "**/Cargo.toml"
       - ".github/workflows/gen_centos8.yml"
-      - "assets/fonts/**/*"
-      - "assets/icon/*"
-      - "assets/open-wezterm-here"
-      - "assets/shell-completion/**/*"
-      - "assets/shell-integration/**/*"
-      - "assets/wezterm-nautilus.py"
-      - "assets/wezterm.appdata.xml"
-      - "assets/wezterm.desktop"
-      - "ci/deploy.sh"
-      - "ci/tag-name.sh"
-      - "get-deps"
-      - "termwiz/data/wezterm.terminfo"
+  workflow_run:
+    types: [completed]
+    branches: [main]
+    workflows: ['ubuntu22.04', 'macos', 'windows']
 
 jobs:
   build:

--- a/.github/workflows/gen_centos8_continuous.yml
+++ b/.github/workflows/gen_centos8_continuous.yml
@@ -3,9 +3,12 @@ name: centos8_continuous
 on:
   schedule:
     - cron: "10 3 * * *"
-  push:
-    branches:
-      - main
+  workflow_run:
+    types: [completed]
+    branches: [main]
+    workflows: ['ubuntu22.04', 'macos', 'windows']
+  pull_request:
+    branches: [main]
     paths:
       - "**/*.rs"
       - "**/Cargo.lock"

--- a/.github/workflows/gen_centos9.yml
+++ b/.github/workflows/gen_centos9.yml
@@ -1,15 +1,14 @@
 name: centos9
 
 on:
-  pull_request:
-    branches:
-      - main
-    paths:
-      - ".github/workflows/gen_centos9.yml"
   workflow_run:
     types: [completed]
     branches: [main]
     workflows: ['ubuntu22.04', 'macos', 'windows']
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/gen_centos9.yml"
 
 jobs:
   build:

--- a/.github/workflows/gen_centos9.yml
+++ b/.github/workflows/gen_centos9.yml
@@ -5,22 +5,11 @@ on:
     branches:
       - main
     paths:
-      - "**/*.rs"
-      - "**/Cargo.lock"
-      - "**/Cargo.toml"
       - ".github/workflows/gen_centos9.yml"
-      - "assets/fonts/**/*"
-      - "assets/icon/*"
-      - "assets/open-wezterm-here"
-      - "assets/shell-completion/**/*"
-      - "assets/shell-integration/**/*"
-      - "assets/wezterm-nautilus.py"
-      - "assets/wezterm.appdata.xml"
-      - "assets/wezterm.desktop"
-      - "ci/deploy.sh"
-      - "ci/tag-name.sh"
-      - "get-deps"
-      - "termwiz/data/wezterm.terminfo"
+  workflow_run:
+    types: [completed]
+    branches: [main]
+    workflows: ['ubuntu22.04', 'macos', 'windows']
 
 jobs:
   build:

--- a/.github/workflows/gen_centos9_continuous.yml
+++ b/.github/workflows/gen_centos9_continuous.yml
@@ -3,9 +3,12 @@ name: centos9_continuous
 on:
   schedule:
     - cron: "10 3 * * *"
-  push:
-    branches:
-      - main
+  workflow_run:
+    types: [completed]
+    branches: [main]
+    workflows: ['ubuntu22.04', 'macos', 'windows']
+  pull_request:
+    branches: [main]
     paths:
       - "**/*.rs"
       - "**/Cargo.lock"

--- a/.github/workflows/gen_debian10.3.yml
+++ b/.github/workflows/gen_debian10.3.yml
@@ -5,22 +5,11 @@ on:
     branches:
       - main
     paths:
-      - "**/*.rs"
-      - "**/Cargo.lock"
-      - "**/Cargo.toml"
       - ".github/workflows/gen_debian10.3.yml"
-      - "assets/fonts/**/*"
-      - "assets/icon/*"
-      - "assets/open-wezterm-here"
-      - "assets/shell-completion/**/*"
-      - "assets/shell-integration/**/*"
-      - "assets/wezterm-nautilus.py"
-      - "assets/wezterm.appdata.xml"
-      - "assets/wezterm.desktop"
-      - "ci/deploy.sh"
-      - "ci/tag-name.sh"
-      - "get-deps"
-      - "termwiz/data/wezterm.terminfo"
+  workflow_run:
+    types: [completed]
+    branches: [main]
+    workflows: ['ubuntu22.04', 'macos', 'windows']
 
 jobs:
   build:

--- a/.github/workflows/gen_debian10.3.yml
+++ b/.github/workflows/gen_debian10.3.yml
@@ -1,15 +1,14 @@
 name: debian10.3
 
 on:
-  pull_request:
-    branches:
-      - main
-    paths:
-      - ".github/workflows/gen_debian10.3.yml"
   workflow_run:
     types: [completed]
     branches: [main]
     workflows: ['ubuntu22.04', 'macos', 'windows']
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/gen_debian10.3.yml"
 
 jobs:
   build:

--- a/.github/workflows/gen_debian10.3_continuous.yml
+++ b/.github/workflows/gen_debian10.3_continuous.yml
@@ -3,9 +3,12 @@ name: debian10.3_continuous
 on:
   schedule:
     - cron: "10 3 * * *"
-  push:
-    branches:
-      - main
+  workflow_run:
+    types: [completed]
+    branches: [main]
+    workflows: ['ubuntu22.04', 'macos', 'windows']
+  pull_request:
+    branches: [main]
     paths:
       - "**/*.rs"
       - "**/Cargo.lock"

--- a/.github/workflows/gen_debian11.yml
+++ b/.github/workflows/gen_debian11.yml
@@ -1,15 +1,14 @@
 name: debian11
 
 on:
-  pull_request:
-    branches:
-      - main
-    paths:
-      - ".github/workflows/gen_debian11.yml"
   workflow_run:
     types: [completed]
     branches: [main]
     workflows: ['ubuntu22.04', 'macos', 'windows']
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/gen_debian11.yml"
 
 jobs:
   build:

--- a/.github/workflows/gen_debian11.yml
+++ b/.github/workflows/gen_debian11.yml
@@ -5,22 +5,11 @@ on:
     branches:
       - main
     paths:
-      - "**/*.rs"
-      - "**/Cargo.lock"
-      - "**/Cargo.toml"
       - ".github/workflows/gen_debian11.yml"
-      - "assets/fonts/**/*"
-      - "assets/icon/*"
-      - "assets/open-wezterm-here"
-      - "assets/shell-completion/**/*"
-      - "assets/shell-integration/**/*"
-      - "assets/wezterm-nautilus.py"
-      - "assets/wezterm.appdata.xml"
-      - "assets/wezterm.desktop"
-      - "ci/deploy.sh"
-      - "ci/tag-name.sh"
-      - "get-deps"
-      - "termwiz/data/wezterm.terminfo"
+  workflow_run:
+    types: [completed]
+    branches: [main]
+    workflows: ['ubuntu22.04', 'macos', 'windows']
 
 jobs:
   build:

--- a/.github/workflows/gen_debian11_continuous.yml
+++ b/.github/workflows/gen_debian11_continuous.yml
@@ -3,9 +3,12 @@ name: debian11_continuous
 on:
   schedule:
     - cron: "10 3 * * *"
-  push:
-    branches:
-      - main
+  workflow_run:
+    types: [completed]
+    branches: [main]
+    workflows: ['ubuntu22.04', 'macos', 'windows']
+  pull_request:
+    branches: [main]
     paths:
       - "**/*.rs"
       - "**/Cargo.lock"

--- a/.github/workflows/gen_fedora35.yml
+++ b/.github/workflows/gen_fedora35.yml
@@ -5,22 +5,11 @@ on:
     branches:
       - main
     paths:
-      - "**/*.rs"
-      - "**/Cargo.lock"
-      - "**/Cargo.toml"
       - ".github/workflows/gen_fedora35.yml"
-      - "assets/fonts/**/*"
-      - "assets/icon/*"
-      - "assets/open-wezterm-here"
-      - "assets/shell-completion/**/*"
-      - "assets/shell-integration/**/*"
-      - "assets/wezterm-nautilus.py"
-      - "assets/wezterm.appdata.xml"
-      - "assets/wezterm.desktop"
-      - "ci/deploy.sh"
-      - "ci/tag-name.sh"
-      - "get-deps"
-      - "termwiz/data/wezterm.terminfo"
+  workflow_run:
+    types: [completed]
+    branches: [main]
+    workflows: ['ubuntu22.04', 'macos', 'windows']
 
 jobs:
   build:

--- a/.github/workflows/gen_fedora35.yml
+++ b/.github/workflows/gen_fedora35.yml
@@ -1,15 +1,14 @@
 name: fedora35
 
 on:
-  pull_request:
-    branches:
-      - main
-    paths:
-      - ".github/workflows/gen_fedora35.yml"
   workflow_run:
     types: [completed]
     branches: [main]
     workflows: ['ubuntu22.04', 'macos', 'windows']
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/gen_fedora35.yml"
 
 jobs:
   build:

--- a/.github/workflows/gen_fedora35_continuous.yml
+++ b/.github/workflows/gen_fedora35_continuous.yml
@@ -3,9 +3,12 @@ name: fedora35_continuous
 on:
   schedule:
     - cron: "10 3 * * *"
-  push:
-    branches:
-      - main
+  workflow_run:
+    types: [completed]
+    branches: [main]
+    workflows: ['ubuntu22.04', 'macos', 'windows']
+  pull_request:
+    branches: [main]
     paths:
       - "**/*.rs"
       - "**/Cargo.lock"

--- a/.github/workflows/gen_fedora36.yml
+++ b/.github/workflows/gen_fedora36.yml
@@ -1,15 +1,14 @@
 name: fedora36
 
 on:
-  pull_request:
-    branches:
-      - main
-    paths:
-      - ".github/workflows/gen_fedora36.yml"
   workflow_run:
     types: [completed]
     branches: [main]
     workflows: ['ubuntu22.04', 'macos', 'windows']
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/gen_fedora36.yml"
 
 jobs:
   build:

--- a/.github/workflows/gen_fedora36.yml
+++ b/.github/workflows/gen_fedora36.yml
@@ -5,22 +5,11 @@ on:
     branches:
       - main
     paths:
-      - "**/*.rs"
-      - "**/Cargo.lock"
-      - "**/Cargo.toml"
       - ".github/workflows/gen_fedora36.yml"
-      - "assets/fonts/**/*"
-      - "assets/icon/*"
-      - "assets/open-wezterm-here"
-      - "assets/shell-completion/**/*"
-      - "assets/shell-integration/**/*"
-      - "assets/wezterm-nautilus.py"
-      - "assets/wezterm.appdata.xml"
-      - "assets/wezterm.desktop"
-      - "ci/deploy.sh"
-      - "ci/tag-name.sh"
-      - "get-deps"
-      - "termwiz/data/wezterm.terminfo"
+  workflow_run:
+    types: [completed]
+    branches: [main]
+    workflows: ['ubuntu22.04', 'macos', 'windows']
 
 jobs:
   build:

--- a/.github/workflows/gen_fedora36_continuous.yml
+++ b/.github/workflows/gen_fedora36_continuous.yml
@@ -3,9 +3,12 @@ name: fedora36_continuous
 on:
   schedule:
     - cron: "10 3 * * *"
-  push:
-    branches:
-      - main
+  workflow_run:
+    types: [completed]
+    branches: [main]
+    workflows: ['ubuntu22.04', 'macos', 'windows']
+  pull_request:
+    branches: [main]
     paths:
       - "**/*.rs"
       - "**/Cargo.lock"

--- a/.github/workflows/gen_fedora37.yml
+++ b/.github/workflows/gen_fedora37.yml
@@ -5,22 +5,11 @@ on:
     branches:
       - main
     paths:
-      - "**/*.rs"
-      - "**/Cargo.lock"
-      - "**/Cargo.toml"
       - ".github/workflows/gen_fedora37.yml"
-      - "assets/fonts/**/*"
-      - "assets/icon/*"
-      - "assets/open-wezterm-here"
-      - "assets/shell-completion/**/*"
-      - "assets/shell-integration/**/*"
-      - "assets/wezterm-nautilus.py"
-      - "assets/wezterm.appdata.xml"
-      - "assets/wezterm.desktop"
-      - "ci/deploy.sh"
-      - "ci/tag-name.sh"
-      - "get-deps"
-      - "termwiz/data/wezterm.terminfo"
+  workflow_run:
+    types: [completed]
+    branches: [main]
+    workflows: ['ubuntu22.04', 'macos', 'windows']
 
 jobs:
   build:

--- a/.github/workflows/gen_fedora37.yml
+++ b/.github/workflows/gen_fedora37.yml
@@ -1,15 +1,14 @@
 name: fedora37
 
 on:
-  pull_request:
-    branches:
-      - main
-    paths:
-      - ".github/workflows/gen_fedora37.yml"
   workflow_run:
     types: [completed]
     branches: [main]
     workflows: ['ubuntu22.04', 'macos', 'windows']
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/gen_fedora37.yml"
 
 jobs:
   build:

--- a/.github/workflows/gen_fedora37_continuous.yml
+++ b/.github/workflows/gen_fedora37_continuous.yml
@@ -3,9 +3,12 @@ name: fedora37_continuous
 on:
   schedule:
     - cron: "10 3 * * *"
-  push:
-    branches:
-      - main
+  workflow_run:
+    types: [completed]
+    branches: [main]
+    workflows: ['ubuntu22.04', 'macos', 'windows']
+  pull_request:
+    branches: [main]
     paths:
       - "**/*.rs"
       - "**/Cargo.lock"

--- a/.github/workflows/gen_macos.yml
+++ b/.github/workflows/gen_macos.yml
@@ -1,9 +1,22 @@
 name: macos
 
 on:
+  push:
+    branches: [main]
+    paths:
+      - "**/*.rs"
+      - "**/Cargo.lock"
+      - "**/Cargo.toml"
+      - ".github/workflows/gen_macos.yml"
+      - "assets/fonts/**/*"
+      - "assets/icon/*"
+      - "assets/macos/**/*"
+      - "ci/deploy.sh"
+      - "ci/macos-entitlement.plist"
+      - "ci/tag-name.sh"
+      - "get-deps"
   pull_request:
-    branches:
-      - main
+    branches: [main]
     paths:
       - "**/*.rs"
       - "**/Cargo.lock"

--- a/.github/workflows/gen_macos_continuous.yml
+++ b/.github/workflows/gen_macos_continuous.yml
@@ -1,7 +1,22 @@
 name: macos_continuous
 
 on:
-
+  schedule:
+    - cron: "10 3 * * *"
+  push:
+    branches: [main]
+    paths:
+      - "**/*.rs"
+      - "**/Cargo.lock"
+      - "**/Cargo.toml"
+      - ".github/workflows/gen_macos_continuous.yml"
+      - "assets/fonts/**/*"
+      - "assets/icon/*"
+      - "assets/macos/**/*"
+      - "ci/deploy.sh"
+      - "ci/macos-entitlement.plist"
+      - "ci/tag-name.sh"
+      - "get-deps"
 
 jobs:
   build:

--- a/.github/workflows/gen_macos_continuous.yml
+++ b/.github/workflows/gen_macos_continuous.yml
@@ -1,23 +1,7 @@
 name: macos_continuous
 
 on:
-  schedule:
-    - cron: "10 3 * * *"
-  push:
-    branches:
-      - main
-    paths:
-      - "**/*.rs"
-      - "**/Cargo.lock"
-      - "**/Cargo.toml"
-      - ".github/workflows/gen_macos_continuous.yml"
-      - "assets/fonts/**/*"
-      - "assets/icon/*"
-      - "assets/macos/**/*"
-      - "ci/deploy.sh"
-      - "ci/macos-entitlement.plist"
-      - "ci/tag-name.sh"
-      - "get-deps"
+
 
 jobs:
   build:

--- a/.github/workflows/gen_opensuse_leap.yml
+++ b/.github/workflows/gen_opensuse_leap.yml
@@ -1,15 +1,14 @@
 name: opensuse_leap
 
 on:
-  pull_request:
-    branches:
-      - main
-    paths:
-      - ".github/workflows/gen_opensuse_leap.yml"
   workflow_run:
     types: [completed]
     branches: [main]
     workflows: ['ubuntu22.04', 'macos', 'windows']
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/gen_opensuse_leap.yml"
 
 jobs:
   build:

--- a/.github/workflows/gen_opensuse_leap.yml
+++ b/.github/workflows/gen_opensuse_leap.yml
@@ -5,22 +5,11 @@ on:
     branches:
       - main
     paths:
-      - "**/*.rs"
-      - "**/Cargo.lock"
-      - "**/Cargo.toml"
       - ".github/workflows/gen_opensuse_leap.yml"
-      - "assets/fonts/**/*"
-      - "assets/icon/*"
-      - "assets/open-wezterm-here"
-      - "assets/shell-completion/**/*"
-      - "assets/shell-integration/**/*"
-      - "assets/wezterm-nautilus.py"
-      - "assets/wezterm.appdata.xml"
-      - "assets/wezterm.desktop"
-      - "ci/deploy.sh"
-      - "ci/tag-name.sh"
-      - "get-deps"
-      - "termwiz/data/wezterm.terminfo"
+  workflow_run:
+    types: [completed]
+    branches: [main]
+    workflows: ['ubuntu22.04', 'macos', 'windows']
 
 jobs:
   build:

--- a/.github/workflows/gen_opensuse_leap_continuous.yml
+++ b/.github/workflows/gen_opensuse_leap_continuous.yml
@@ -3,9 +3,12 @@ name: opensuse_leap_continuous
 on:
   schedule:
     - cron: "10 3 * * *"
-  push:
-    branches:
-      - main
+  workflow_run:
+    types: [completed]
+    branches: [main]
+    workflows: ['ubuntu22.04', 'macos', 'windows']
+  pull_request:
+    branches: [main]
     paths:
       - "**/*.rs"
       - "**/Cargo.lock"

--- a/.github/workflows/gen_opensuse_tumbleweed.yml
+++ b/.github/workflows/gen_opensuse_tumbleweed.yml
@@ -5,22 +5,11 @@ on:
     branches:
       - main
     paths:
-      - "**/*.rs"
-      - "**/Cargo.lock"
-      - "**/Cargo.toml"
       - ".github/workflows/gen_opensuse_tumbleweed.yml"
-      - "assets/fonts/**/*"
-      - "assets/icon/*"
-      - "assets/open-wezterm-here"
-      - "assets/shell-completion/**/*"
-      - "assets/shell-integration/**/*"
-      - "assets/wezterm-nautilus.py"
-      - "assets/wezterm.appdata.xml"
-      - "assets/wezterm.desktop"
-      - "ci/deploy.sh"
-      - "ci/tag-name.sh"
-      - "get-deps"
-      - "termwiz/data/wezterm.terminfo"
+  workflow_run:
+    types: [completed]
+    branches: [main]
+    workflows: ['ubuntu22.04', 'macos', 'windows']
 
 jobs:
   build:

--- a/.github/workflows/gen_opensuse_tumbleweed.yml
+++ b/.github/workflows/gen_opensuse_tumbleweed.yml
@@ -1,15 +1,14 @@
 name: opensuse_tumbleweed
 
 on:
-  pull_request:
-    branches:
-      - main
-    paths:
-      - ".github/workflows/gen_opensuse_tumbleweed.yml"
   workflow_run:
     types: [completed]
     branches: [main]
     workflows: ['ubuntu22.04', 'macos', 'windows']
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/gen_opensuse_tumbleweed.yml"
 
 jobs:
   build:

--- a/.github/workflows/gen_opensuse_tumbleweed_continuous.yml
+++ b/.github/workflows/gen_opensuse_tumbleweed_continuous.yml
@@ -3,9 +3,12 @@ name: opensuse_tumbleweed_continuous
 on:
   schedule:
     - cron: "10 3 * * *"
-  push:
-    branches:
-      - main
+  workflow_run:
+    types: [completed]
+    branches: [main]
+    workflows: ['ubuntu22.04', 'macos', 'windows']
+  pull_request:
+    branches: [main]
     paths:
       - "**/*.rs"
       - "**/Cargo.lock"

--- a/.github/workflows/gen_ubuntu20.04.yml
+++ b/.github/workflows/gen_ubuntu20.04.yml
@@ -1,15 +1,14 @@
 name: ubuntu20.04
 
 on:
-  pull_request:
-    branches:
-      - main
-    paths:
-      - ".github/workflows/gen_ubuntu20.04.yml"
   workflow_run:
     types: [completed]
     branches: [main]
     workflows: ['ubuntu22.04', 'macos', 'windows']
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/gen_ubuntu20.04.yml"
 
 jobs:
   build:

--- a/.github/workflows/gen_ubuntu20.04.yml
+++ b/.github/workflows/gen_ubuntu20.04.yml
@@ -5,25 +5,11 @@ on:
     branches:
       - main
     paths:
-      - "**/*.rs"
-      - "**/Cargo.lock"
-      - "**/Cargo.toml"
       - ".github/workflows/gen_ubuntu20.04.yml"
-      - "assets/fonts/**/*"
-      - "assets/icon/*"
-      - "assets/open-wezterm-here"
-      - "assets/shell-completion/**/*"
-      - "assets/shell-integration/**/*"
-      - "assets/wezterm-nautilus.py"
-      - "assets/wezterm.appdata.xml"
-      - "assets/wezterm.desktop"
-      - "ci/appimage.sh"
-      - "ci/appstreamcli"
-      - "ci/deploy.sh"
-      - "ci/source-archive.sh"
-      - "ci/tag-name.sh"
-      - "get-deps"
-      - "termwiz/data/wezterm.terminfo"
+  workflow_run:
+    types: [completed]
+    branches: [main]
+    workflows: ['ubuntu22.04', 'macos', 'windows']
 
 jobs:
   build:

--- a/.github/workflows/gen_ubuntu20.04_continuous.yml
+++ b/.github/workflows/gen_ubuntu20.04_continuous.yml
@@ -3,9 +3,12 @@ name: ubuntu20.04_continuous
 on:
   schedule:
     - cron: "10 3 * * *"
-  push:
-    branches:
-      - main
+  workflow_run:
+    types: [completed]
+    branches: [main]
+    workflows: ['ubuntu22.04', 'macos', 'windows']
+  pull_request:
+    branches: [main]
     paths:
       - "**/*.rs"
       - "**/Cargo.lock"

--- a/.github/workflows/gen_ubuntu22.04.yml
+++ b/.github/workflows/gen_ubuntu22.04.yml
@@ -1,9 +1,27 @@
 name: ubuntu22.04
 
 on:
+  push:
+    branches: [main]
+    paths:
+      - "**/*.rs"
+      - "**/Cargo.lock"
+      - "**/Cargo.toml"
+      - ".github/workflows/gen_ubuntu22.04.yml"
+      - "assets/fonts/**/*"
+      - "assets/icon/*"
+      - "assets/open-wezterm-here"
+      - "assets/shell-completion/**/*"
+      - "assets/shell-integration/**/*"
+      - "assets/wezterm-nautilus.py"
+      - "assets/wezterm.appdata.xml"
+      - "assets/wezterm.desktop"
+      - "ci/deploy.sh"
+      - "ci/tag-name.sh"
+      - "get-deps"
+      - "termwiz/data/wezterm.terminfo"
   pull_request:
-    branches:
-      - main
+    branches: [main]
     paths:
       - "**/*.rs"
       - "**/Cargo.lock"

--- a/.github/workflows/gen_ubuntu22.04_continuous.yml
+++ b/.github/workflows/gen_ubuntu22.04_continuous.yml
@@ -1,7 +1,27 @@
 name: ubuntu22.04_continuous
 
 on:
-
+  schedule:
+    - cron: "10 3 * * *"
+  push:
+    branches: [main]
+    paths:
+      - "**/*.rs"
+      - "**/Cargo.lock"
+      - "**/Cargo.toml"
+      - ".github/workflows/gen_ubuntu22.04_continuous.yml"
+      - "assets/fonts/**/*"
+      - "assets/icon/*"
+      - "assets/open-wezterm-here"
+      - "assets/shell-completion/**/*"
+      - "assets/shell-integration/**/*"
+      - "assets/wezterm-nautilus.py"
+      - "assets/wezterm.appdata.xml"
+      - "assets/wezterm.desktop"
+      - "ci/deploy.sh"
+      - "ci/tag-name.sh"
+      - "get-deps"
+      - "termwiz/data/wezterm.terminfo"
 
 jobs:
   build:

--- a/.github/workflows/gen_ubuntu22.04_continuous.yml
+++ b/.github/workflows/gen_ubuntu22.04_continuous.yml
@@ -1,28 +1,7 @@
 name: ubuntu22.04_continuous
 
 on:
-  schedule:
-    - cron: "10 3 * * *"
-  push:
-    branches:
-      - main
-    paths:
-      - "**/*.rs"
-      - "**/Cargo.lock"
-      - "**/Cargo.toml"
-      - ".github/workflows/gen_ubuntu22.04_continuous.yml"
-      - "assets/fonts/**/*"
-      - "assets/icon/*"
-      - "assets/open-wezterm-here"
-      - "assets/shell-completion/**/*"
-      - "assets/shell-integration/**/*"
-      - "assets/wezterm-nautilus.py"
-      - "assets/wezterm.appdata.xml"
-      - "assets/wezterm.desktop"
-      - "ci/deploy.sh"
-      - "ci/tag-name.sh"
-      - "get-deps"
-      - "termwiz/data/wezterm.terminfo"
+
 
 jobs:
   build:

--- a/.github/workflows/gen_windows.yml
+++ b/.github/workflows/gen_windows.yml
@@ -1,9 +1,20 @@
 name: windows
 
 on:
+  push:
+    branches: [main]
+    paths:
+      - "**/*.rs"
+      - "**/Cargo.lock"
+      - "**/Cargo.toml"
+      - ".github/workflows/gen_windows.yml"
+      - "assets/fonts/**/*"
+      - "assets/icon/*"
+      - "assets/windows/**/*"
+      - "ci/deploy.sh"
+      - "ci/windows-installer.iss"
   pull_request:
-    branches:
-      - main
+    branches: [main]
     paths:
       - "**/*.rs"
       - "**/Cargo.lock"

--- a/.github/workflows/gen_windows_continuous.yml
+++ b/.github/workflows/gen_windows_continuous.yml
@@ -1,21 +1,7 @@
 name: windows_continuous
 
 on:
-  schedule:
-    - cron: "10 3 * * *"
-  push:
-    branches:
-      - main
-    paths:
-      - "**/*.rs"
-      - "**/Cargo.lock"
-      - "**/Cargo.toml"
-      - ".github/workflows/gen_windows_continuous.yml"
-      - "assets/fonts/**/*"
-      - "assets/icon/*"
-      - "assets/windows/**/*"
-      - "ci/deploy.sh"
-      - "ci/windows-installer.iss"
+
 
 jobs:
   build:

--- a/.github/workflows/gen_windows_continuous.yml
+++ b/.github/workflows/gen_windows_continuous.yml
@@ -1,7 +1,20 @@
 name: windows_continuous
 
 on:
-
+  schedule:
+    - cron: "10 3 * * *"
+  push:
+    branches: [main]
+    paths:
+      - "**/*.rs"
+      - "**/Cargo.lock"
+      - "**/Cargo.toml"
+      - ".github/workflows/gen_windows_continuous.yml"
+      - "assets/fonts/**/*"
+      - "assets/icon/*"
+      - "assets/windows/**/*"
+      - "ci/deploy.sh"
+      - "ci/windows-installer.iss"
 
 jobs:
   build:

--- a/ci/generate-workflows.py
+++ b/ci/generate-workflows.py
@@ -975,7 +975,7 @@ def generate_actions(namer, jobber, trigger, is_continuous, is_tag=False):
 
         trigger_paths = "- " + "\n      - ".join(yv(p) for p in sorted(trigger_paths))
         trigger_with_paths = trigger.replace("@PATHS@", trigger_paths)
-        on_workflow = "" if t.hi_pri or is_continuous or is_tag else f"  workflow_run:\n    types: [completed]\n    branches: [main]\n    workflows: {yv(PRIORITY_TARGETS)}\n"
+        on_workflow = "" if t.hi_pri or is_tag else f"  workflow_run:\n    types: [completed]\n    branches: [main]\n    workflows: {yv(PRIORITY_TARGETS)}\n"
 
         with open(file_name, "w") as f:
             f.write(

--- a/ci/generate-workflows.py
+++ b/ci/generate-workflows.py
@@ -978,15 +978,16 @@ def generate_actions(namer, jobber, is_continuous, is_tag=False):
             container = ""
 
         triggers = []
-        if is_continuous and not t.hi_pri and not is_tag:
+        if is_continuous and not is_tag:
             triggers.append(SCHED_TRIGGER)
 
         if is_tag:
             triggers.append(TAG_TRIGGER)
 
-        if t.hi_pri and not is_tag and not is_continuous:
+        if t.hi_pri and not is_tag:
             triggers.append(PUSH_TRIGGER)
-            triggers.append(PULL_REQ_TRIGGER)
+            if not is_continuous:
+                triggers.append(PULL_REQ_TRIGGER)
 
         if not (t.hi_pri or is_tag):
             triggers.append(PRIO_TRIGGER)


### PR DESCRIPTION
# Changes

Closes #3360

Priorize workflows:

- Windows
- MacOS
- Ubuntu 22.02

Every other target specific workflow, ie. CenOS 7, will run after any of the
above mentioned targets' workflow finishes.

## Reasoning

Ubuntu 22.04 covers a high percentage of the Linux testing needed by Wezterm,
delaying other workflows is therefore undesireable.

See issue #3360 for a more in depth discussion

## Quirks

### Changeable

Windows and MacOS might trigger every other Linux Distro's workflow to run even
if any of their trigger paths don't change, fixing this is a bit more involved
but might be desireable.

### Not Changeable

As it waits for the workflows to complete the minimum time it takes for all the
workflows to complete will be higher.
