### PR TITLE
hyperlink_rules.md: add link to the supported regex syntax

### DIFF
--- a/docs/config/lua/config/hyperlink_rules.md
+++ b/docs/config/lua/config/hyperlink_rules.md
@@ -5,7 +5,7 @@ clickable links.
 
 The value is a list of rule entries. Each entry has the following fields:
 
-* `regex` - the regular expression to match
+* `regex` - the regular expression to match (see supported [Regex syntax](https://docs.rs/regex/latest/regex/#syntax))
 * `format` - Controls what will be used to form the link. The string
   can use placeholders like `$0`, `$1`, `$2` etc. that will be replaced
   with that numbered capture group.  So, `$0` will take the entire


### PR DESCRIPTION
I was using  `\c` in a regex and spent hours wondering why it was not working, the regex was working OK in a different program, and it was not producing any error from wezterm, it just didn't match as expected, until I found out the `\c` character class was not supported and instead I had to use the equivalent in ascii format `[:cntrl:]`

So add a link in the docs to the supported syntax so users have a way to avoid similar headaches  🙂 .