### PR TITLE
Update termwiz dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5065,7 +5065,7 @@ dependencies = [
  "semver 0.11.0",
  "serde",
  "sha2",
- "signal-hook 0.1.17",
+ "signal-hook",
  "siphasher",
  "tempfile",
  "terminfo",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -978,7 +978,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb2a7d3066da2de787b7f032c736763eb7ae5d355f81a68bab2675a96008b0bf"
 dependencies = [
  "lab",
- "phf 0.11.1",
+ "phf",
 ]
 
 [[package]]
@@ -1267,7 +1267,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44fe60b864b6544ad211d4053ced474a9b9d2c8d66b77f01d6c6bcfed10c6bf0"
 dependencies = [
- "phf 0.11.1",
+ "phf",
 ]
 
 [[package]]
@@ -3522,21 +3522,12 @@ dependencies = [
 
 [[package]]
 name = "phf"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fabbf1ead8a5bcbc20f5f8b939ee3f5b0f6f281b6ad3468b84656b658b455259"
-dependencies = [
- "phf_shared 0.10.0",
-]
-
-[[package]]
-name = "phf"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "928c6535de93548188ef63bb7c4036bd415cd8f36ad25af44b9789b2ee72a48c"
 dependencies = [
  "phf_macros",
- "phf_shared 0.11.1",
+ "phf_shared",
 ]
 
 [[package]]
@@ -3546,7 +3537,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a56ac890c5e3ca598bbdeaa99964edb5b0258a583a9eb6ef4e89fc85d9224770"
 dependencies = [
  "phf_generator",
- "phf_shared 0.11.1",
+ "phf_shared",
 ]
 
 [[package]]
@@ -3555,7 +3546,7 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1181c94580fa345f50f19d738aaa39c0ed30a600d95cb2d3e23f94266f14fbf"
 dependencies = [
- "phf_shared 0.11.1",
+ "phf_shared",
  "rand",
 ]
 
@@ -3566,19 +3557,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92aacdc5f16768709a569e913f7451034034178b05bdc8acda226659a3dccc66"
 dependencies = [
  "phf_generator",
- "phf_shared 0.11.1",
+ "phf_shared",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "phf_shared"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6796ad771acdc0123d2a88dc428b5e38ef24456743ddb1744ed628f9815c096"
-dependencies = [
- "siphasher",
 ]
 
 [[package]]
@@ -4937,7 +4919,7 @@ dependencies = [
  "dirs",
  "fnv",
  "nom",
- "phf 0.11.1",
+ "phf",
  "phf_codegen",
 ]
 
@@ -4992,7 +4974,7 @@ dependencies = [
  "ordered-float",
  "pest",
  "pest_derive",
- "phf 0.10.1",
+ "phf",
  "regex",
  "semver 0.11.0",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -65,6 +65,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstyle"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -214,7 +220,7 @@ dependencies = [
  "event-listener",
  "futures-lite",
  "libc",
- "signal-hook 0.3.15",
+ "signal-hook",
  "windows-sys 0.42.0",
 ]
 
@@ -529,6 +535,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "ciborium"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c137568cc60b904a7724001b35ce2630fd00d5d84805fbb608ab89509d788f"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346de753af073cc87b52b2083a506b38ac176a44cfb05497b622e27be899b369"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213030a2b5a4e0c0892b6652260cf6ccac84827b83a85a534e178e3906c4cf1b"
+dependencies = [
+ "ciborium-io",
+ "half 1.8.2",
+]
+
+[[package]]
 name = "clap"
 version = "2.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -541,13 +574,25 @@ dependencies = [
 
 [[package]]
 name = "clap"
+version = "3.2.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71655c45cb9845d3270c9d6df84ebe72b4dad3c2ba3f7023ad47c144e4e473a5"
+dependencies = [
+ "bitflags 1.3.2",
+ "clap_lex 0.2.4",
+ "indexmap",
+ "textwrap 0.16.0",
+]
+
+[[package]]
+name = "clap"
 version = "4.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c911b090850d79fc64fe9ea01e28e465f65e821e08813ced95bced72f7a8a9b"
 dependencies = [
  "bitflags 1.3.2",
  "clap_derive",
- "clap_lex",
+ "clap_lex 0.3.3",
  "is-terminal",
  "once_cell",
  "strsim",
@@ -584,6 +629,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.10",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+dependencies = [
+ "os_str_bytes",
 ]
 
 [[package]]
@@ -867,7 +921,7 @@ dependencies = [
  "atty",
  "cast",
  "clap 2.34.0",
- "criterion-plot",
+ "criterion-plot 0.4.5",
  "csv",
  "itertools",
  "lazy_static",
@@ -885,10 +939,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c76e09c1aae2bc52b3d2f29e13c6572553b30c4aa1b8a49fd70de6412654cb"
+dependencies = [
+ "anes",
+ "atty",
+ "cast",
+ "ciborium",
+ "clap 3.2.23",
+ "criterion-plot 0.5.0",
+ "itertools",
+ "lazy_static",
+ "num-traits",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
 name = "criterion-plot"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2673cc8207403546f45f5fd319a974b1e6983ad1a3ee7e6041650013be041876"
+dependencies = [
+ "cast",
+ "itertools",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
 dependencies = [
  "cast",
  "itertools",
@@ -3931,7 +4021,7 @@ checksum = "9c8a99fddc9f0ba0a85884b8d14e3592853e787d581ca1816c91349b10e4eeab"
 name = "rangeset"
 version = "0.1.0"
 dependencies = [
- "criterion",
+ "criterion 0.3.6",
  "num",
 ]
 
@@ -4516,16 +4606,6 @@ checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
 
 [[package]]
 name = "signal-hook"
-version = "0.1.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e31d442c16f047a671b5a71e2161d6e68814012b7f5379d269ebd915fac2729"
-dependencies = [
- "libc",
- "signal-hook-registry",
-]
-
-[[package]]
-name = "signal-hook"
 version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "732768f1176d21d09e076c23a93123d40bba92d50c4058da34d45c8de8e682b9"
@@ -4961,7 +5041,7 @@ dependencies = [
  "base64 0.21.0",
  "bitflags 2.0.2",
  "cassowary",
- "criterion",
+ "criterion 0.4.0",
  "env_logger",
  "filedescriptor",
  "finl_unicode",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -365,6 +365,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitflags"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "487f1e0fcbe47deb8b0574e646def1c903389d95241dd1bbcc6ce4a715dfc0c1"
+
+[[package]]
 name = "block"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -528,7 +534,7 @@ version = "2.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "textwrap 0.11.0",
  "unicode-width",
 ]
@@ -539,7 +545,7 @@ version = "4.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c911b090850d79fc64fe9ea01e28e465f65e821e08813ced95bced72f7a8a9b"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "clap_derive",
  "clap_lex",
  "is-terminal",
@@ -615,7 +621,7 @@ version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c49e86fc36d5704151f5996b7b3795385f50ce09e3be0f47a0cfde869681cf8"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "block",
  "core-foundation 0.7.0",
  "core-graphics 0.19.2",
@@ -723,7 +729,7 @@ name = "config"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 1.3.2",
  "colorgrad",
  "dirs-next",
  "enum-display-derive",
@@ -791,7 +797,7 @@ version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3889374e6ea6ab25dba90bb5d96202f61108058361f6dc72e8b03e6f8bbe923"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "core-foundation 0.7.0",
  "foreign-types",
  "libc",
@@ -803,7 +809,7 @@ version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2581bbab3b8ffc6fcbd550bf46c355135d16e9ff2a6ea032ad6b9bf1d7efe4fb"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "core-foundation 0.9.3",
  "core-graphics-types",
  "foreign-types",
@@ -816,7 +822,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a68b68b3446082644c91ac778bf50cd4104bfb002b5a6a7c44cca5a2c70788b"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "core-foundation 0.9.3",
  "foreign-types",
  "libc",
@@ -1052,7 +1058,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8f0de2f5a8e7bd4a9eec0e3c781992a4ce1724f68aec7d7a3715344de8b39da"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "libloading 0.7.4",
  "winapi",
 ]
@@ -1790,7 +1796,7 @@ version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf7f68c2995f392c49fffb4f95ae2c873297830eb25c6bc4c114ce8f4562acc"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "libc",
  "libgit2-sys",
  "log",
@@ -1844,7 +1850,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93e3af942408868f6934a7b85134a3230832b9977cf66125df2f9edcfce4ddcc"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "ignore",
  "walkdir",
 ]
@@ -1884,7 +1890,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fc59e5f710e310e76e6707f86c561dd646f69a8876da9131703b2f717de818d"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "gpu-alloc-types",
 ]
 
@@ -1894,7 +1900,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54804d0d6bc9d7f26db4eaec1ad10def69b599315f487d32c334a80d1efe67a5"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -1916,7 +1922,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b0c02e1ba0bdb14e965058ca34e09c020f8e507a760df1121728e0aef68d57a"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "gpu-descriptor-types",
  "hashbrown 0.12.3",
 ]
@@ -1927,7 +1933,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "363e3677e55ad168fef68cf9de3a4a310b53124c5e784c53a1d70e92d23f2126"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -2015,7 +2021,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90601c6189668c7345fc53842cb3f3a3d872203d523be1b3cb44a36a3e62fb85"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "com-rs",
  "libc",
  "libloading 0.7.4",
@@ -2279,7 +2285,7 @@ version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8069d3ec154eb856955c1c0fbffefbf5f3c40a104ec912d4797314c1801abff"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "inotify-sys",
  "libc",
 ]
@@ -2452,7 +2458,7 @@ version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8367585489f01bc55dd27404dcf56b95e6da061a256a666ab23be9ba96a2e587"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "libc",
 ]
 
@@ -2579,7 +2585,7 @@ name = "libssh-rs"
 version = "0.1.7"
 source = "git+https://github.com/wez/libssh-rs.git#44a08196acd1a2277ec7ebce2a47618775f3c59c"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "libssh-rs-sys",
  "openssl-sys",
  "thiserror",
@@ -2836,7 +2842,7 @@ version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de11355d1f6781482d027a3b4d4de7825dcedb197bf573e0596d00008402d060"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "block",
  "core-graphics-types",
  "foreign-types",
@@ -2947,7 +2953,7 @@ dependencies = [
  "async-trait",
  "base64 0.21.0",
  "bintree",
- "bitflags",
+ "bitflags 1.3.2",
  "chrono",
  "config",
  "crossbeam",
@@ -3013,7 +3019,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5eafe22a23b797c9bc227c6c896419b26b5bb88fa903417a3adaed08778850d5"
 dependencies = [
  "bit-set",
- "bitflags",
+ "bitflags 1.3.2",
  "codespan-reporting",
  "hexf-parse",
  "indexmap",
@@ -3068,7 +3074,7 @@ version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f3790c00a0150112de0f4cd161e3d7fc4b2d8a5542ffc35f099a2562aecb35c"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cc",
  "cfg-if",
  "libc",
@@ -3081,7 +3087,7 @@ version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa52e972a9a719cecb6864fb88568781eb706bac2cd1d4f04a648542dbf78069"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cfg-if",
  "libc",
  "memoffset 0.6.5",
@@ -3094,7 +3100,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f346ff70e7dbfd675fe90590b92d59ef2de15a8779ae305ebcbfd3f0caf59be4"
 dependencies = [
  "autocfg",
- "bitflags",
+ "bitflags 1.3.2",
  "cfg-if",
  "libc",
  "memoffset 0.6.5",
@@ -3107,7 +3113,7 @@ version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfdda3d196821d6af13126e40375cdf7da646a96114af134d5f417a9a1dc8e1a"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cfg-if",
  "libc",
  "memoffset 0.7.1",
@@ -3149,7 +3155,7 @@ version = "5.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58ea850aa68a06e48fdb069c0ec44d0d64c8dbffa49bf3b6f7f0a901fdea1ba9"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "crossbeam-channel",
  "filetime",
  "fsevent-sys",
@@ -3344,7 +3350,7 @@ version = "0.10.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c7ae222234c30df141154f159066c5093ff73b63204dcda7121eb082fc56a95"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -3671,7 +3677,7 @@ version = "0.17.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d708eaf860a19b19ce538740d2b4bdeeb8337fa53f7738455e706623ad5c638"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "crc32fast",
  "flate2",
  "miniz_oxide 0.6.2",
@@ -3684,7 +3690,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e1f879b2998099c2d69ab9605d145d5b661195627eccc680002c4918a7fb6fa"
 dependencies = [
  "autocfg",
- "bitflags",
+ "bitflags 1.3.2",
  "cfg-if",
  "concurrent-queue",
  "libc",
@@ -3698,7 +3704,7 @@ name = "portable-pty"
 version = "0.8.1"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 1.3.2",
  "downcast-rs",
  "filedescriptor",
  "futures",
@@ -3821,7 +3827,7 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d9cc634bc78768157b5cbfe988ffcd1dcba95cd2b2f03a88316c08c6d00ed63"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "getopts",
  "memchr",
  "unicase",
@@ -3943,7 +3949,7 @@ version = "10.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c297679cb867470fa8c9f67dbba74a78d78e3e98d7cf2b08d6d71540f797332"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -3992,7 +3998,7 @@ version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -4143,7 +4149,7 @@ version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85127183a999f7db96d1a976a309eebbfb6ea3b0b400ddd8340190129de6eb7a"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "fallible-iterator",
  "fallible-streaming-iterator",
  "hashlink",
@@ -4179,7 +4185,7 @@ version = "0.36.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db4165c9963ab29e422d6c26fbc1d37f15bace6b2810221f9d925023480fcf0e"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "errno 0.2.8",
  "io-lifetimes",
  "libc",
@@ -4193,7 +4199,7 @@ version = "0.37.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62b24138615de35e32031d041a09032ef3487a616d901ca4db224e7d557efae2"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "errno 0.3.0",
  "io-lifetimes",
  "libc",
@@ -4255,7 +4261,7 @@ version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a332be01508d814fed64bf28f798a146d73792121129962fdf335bb3c49a4254"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "core-foundation 0.9.3",
  "core-foundation-sys 0.8.3",
  "libc",
@@ -4585,7 +4591,7 @@ version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f307c47d32d2715eb2e0ece5589057820e0e5e70d07c247d1063e844e107f454"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "dlib",
  "lazy_static",
  "log",
@@ -4700,7 +4706,7 @@ version = "0.2.0+1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "246bfa38fe3db3f1dfc8ca5a2cdeb7348c78be2112740cc0ec8ef18b6d94f830"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "num-traits",
 ]
 
@@ -4732,7 +4738,7 @@ version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7fe461910559f6d5604c3731d00d2aafc4a83d1665922e280f42f9a168d5455"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "libc",
  "libssh2-sys",
  "parking_lot 0.11.2",
@@ -4953,7 +4959,7 @@ version = "0.22.0"
 dependencies = [
  "anyhow",
  "base64 0.21.0",
- "bitflags",
+ "bitflags 2.0.2",
  "cassowary",
  "criterion",
  "env_logger",
@@ -5618,7 +5624,7 @@ version = "0.29.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f3b068c05a039c9f755f881dc50f01732214f5685e379829759088967c46715"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "downcast-rs",
  "libc",
  "nix 0.24.3",
@@ -5667,7 +5673,7 @@ version = "0.29.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b950621f9354b322ee817a23474e479b34be96c2e909c14f7bc0100e9a970bc6"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "wayland-client",
  "wayland-commons",
  "wayland-scanner",
@@ -5890,7 +5896,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "benchmarking",
- "bitflags",
+ "bitflags 1.3.2",
  "bytemuck",
  "cc",
  "chrono",
@@ -5986,7 +5992,7 @@ dependencies = [
 name = "wezterm-input-types"
 version = "0.1.0"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "euclid",
  "lazy_static",
  "serde",
@@ -6057,7 +6063,7 @@ dependencies = [
  "assert_fs",
  "async_ossl",
  "base64 0.21.0",
- "bitflags",
+ "bitflags 1.3.2",
  "camino",
  "clap 4.1.13",
  "dirs-next",
@@ -6089,7 +6095,7 @@ name = "wezterm-term"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 1.3.2",
  "csscolorparser",
  "env_logger",
  "finl_unicode",
@@ -6162,7 +6168,7 @@ checksum = "7131408d940e335792645a98f03639573b0480e9e2e7cddbbab74f7c6d9f3fff"
 dependencies = [
  "arrayvec",
  "bit-vec",
- "bitflags",
+ "bitflags 1.3.2",
  "codespan-reporting",
  "fxhash",
  "log",
@@ -6187,7 +6193,7 @@ dependencies = [
  "arrayvec",
  "ash",
  "bit-set",
- "bitflags",
+ "bitflags 1.3.2",
  "block",
  "core-graphics-types",
  "d3d12",
@@ -6225,7 +6231,7 @@ version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32444e121b0bd00cb02c0de32fde457a9491bd44e03e7a5db6df9b1da2f6f110"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "js-sys",
  "web-sys",
 ]
@@ -6286,7 +6292,7 @@ dependencies = [
  "async-io",
  "async-task",
  "async-trait",
- "bitflags",
+ "bitflags 1.3.2",
  "bytes",
  "cgl",
  "clipboard-win",
@@ -6561,7 +6567,7 @@ version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0faeb4d7e2d54fff4a0584f61297e86b106914af2029778de7b427f72564d6c5"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "libc",
  "quick-xml 0.22.0",
  "x11",
@@ -6572,7 +6578,7 @@ name = "xcb-imdkit"
 version = "0.2.0"
 source = "git+https://github.com/wez/xcb-imdkit-rs.git?branch=hangfix#c6859ab2b8a233ca5dda5e8e4f1634d34ce9c85c"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cc",
  "lazy_static",
  "pkg-config",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4974,7 +4974,7 @@ dependencies = [
  "libc",
  "log",
  "memmem",
- "nix 0.24.3",
+ "nix 0.26.2",
  "num-derive",
  "num-traits",
  "ordered-float",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -375,6 +375,9 @@ name = "bitflags"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "487f1e0fcbe47deb8b0574e646def1c903389d95241dd1bbcc6ce4a715dfc0c1"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "block"

--- a/term/src/test/csi.rs
+++ b/term/src/test/csi.rs
@@ -198,7 +198,9 @@ fn test_789() {
         ),
         zones: [],
         seqno: 5,
-        bits: NONE,
+        bits: LineBits(
+            0x0,
+        ),
         appdata: Mutex {
             data: None,
             poisoned: false,

--- a/termwiz/Cargo.toml
+++ b/termwiz/Cargo.toml
@@ -31,7 +31,7 @@ num-traits = "0.2"
 ordered-float = "3.0"
 pest = "2.1"
 pest_derive = "2.1"
-phf = "0.10"
+phf = "0.11"
 regex = "1"
 semver = "0.11"
 serde = {version="1.0", features = ["rc", "derive"], optional=true}

--- a/termwiz/Cargo.toml
+++ b/termwiz/Cargo.toml
@@ -65,7 +65,7 @@ features = ["full-syntax"]
 version = "0.3"
 
 [target."cfg(unix)".dependencies]
-signal-hook = "0.1"
+signal-hook = "0.3"
 termios = "0.3"
 nix = "0.26"
 

--- a/termwiz/Cargo.toml
+++ b/termwiz/Cargo.toml
@@ -55,7 +55,7 @@ use_image = ["image"]
 docs = ["widgets", "use_serde"]
 
 [dev-dependencies]
-criterion = "0.3"
+criterion = "0.4"
 varbincode = "0.1"
 k9 = "0.11"
 env_logger = "0.10"

--- a/termwiz/Cargo.toml
+++ b/termwiz/Cargo.toml
@@ -50,7 +50,7 @@ wezterm-dynamic = { path = "../wezterm-dynamic", version="0.1" }
 
 [features]
 widgets = ["cassowary", "fnv"]
-use_serde = ["serde", "wezterm-color-types/use_serde", "wezterm-blob-leases/serde"]
+use_serde = ["serde", "wezterm-color-types/use_serde", "wezterm-blob-leases/serde", "bitflags/serde"]
 use_image = ["image"]
 docs = ["widgets", "use_serde"]
 

--- a/termwiz/Cargo.toml
+++ b/termwiz/Cargo.toml
@@ -67,7 +67,7 @@ version = "0.3"
 [target."cfg(unix)".dependencies]
 signal-hook = "0.1"
 termios = "0.3"
-nix = "0.24"
+nix = "0.26"
 
 [target."cfg(windows)".dependencies.winapi]
 features = [

--- a/termwiz/Cargo.toml
+++ b/termwiz/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 [dependencies]
 # backtrace = "0.3"
 base64 = "0.21"
-bitflags = "1.3"
+bitflags = "2.0"
 cassowary = {version="0.3", optional=true}
 anyhow = "1.0"
 filedescriptor = { version="0.8", path = "../filedescriptor" }

--- a/termwiz/src/escape/csi.rs
+++ b/termwiz/src/escape/csi.rs
@@ -53,6 +53,7 @@ fn csi_size() {
 }
 
 bitflags::bitflags! {
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct KittyKeyboardFlags: u16 {
     const NONE = 0;
     const DISAMBIGUATE_ESCAPE_CODES = 1;

--- a/termwiz/src/escape/osc.rs
+++ b/termwiz/src/escape/osc.rs
@@ -72,6 +72,7 @@ pub struct ChangeColorPair {
 }
 
 bitflags! {
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Selection :u16{
     const NONE = 0;
     const CLIPBOARD = 1<<1;

--- a/termwiz/src/escape/osc.rs
+++ b/termwiz/src/escape/osc.rs
@@ -72,7 +72,7 @@ pub struct ChangeColorPair {
 }
 
 bitflags! {
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Selection :u16{
     const NONE = 0;
     const CLIPBOARD = 1<<1;

--- a/termwiz/src/input.rs
+++ b/termwiz/src/input.rs
@@ -44,7 +44,7 @@ use winapi::um::wincon::{
 
 bitflags! {
     #[cfg_attr(feature="use_serde", derive(Serialize, Deserialize))]
-    #[derive(Default)]
+    #[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
     pub struct Modifiers: u8 {
         const NONE = 0;
         const SHIFT = 1<<1;
@@ -58,7 +58,7 @@ bitflags! {
 }
 bitflags! {
     #[cfg_attr(feature="use_serde", derive(Serialize, Deserialize))]
-    #[derive(Default)]
+    #[derive(Debug, Default, Clone, PartialEq, Eq)]
     pub struct MouseButtons: u8 {
         const NONE = 0;
         const LEFT = 1<<1;

--- a/termwiz/src/surface/line/linebits.rs
+++ b/termwiz/src/surface/line/linebits.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 
 bitflags! {
     #[cfg_attr(feature="use_serde", derive(Serialize, Deserialize))]
+    #[derive(Debug, Clone, Copy, PartialEq)]
     pub(crate) struct LineBits : u16 {
         const NONE = 0;
         /// The line contains 1+ cells with explicit hyperlinks set
@@ -26,9 +27,9 @@ bitflags! {
         const DOUBLE_HEIGHT_BOTTOM = 1<<6;
 
         const DOUBLE_WIDTH_HEIGHT_MASK =
-            Self::DOUBLE_WIDTH.bits |
-            Self::DOUBLE_HEIGHT_TOP.bits |
-            Self::DOUBLE_HEIGHT_BOTTOM.bits;
+            Self::DOUBLE_WIDTH.bits() |
+            Self::DOUBLE_HEIGHT_TOP.bits() |
+            Self::DOUBLE_HEIGHT_BOTTOM.bits();
 
         /// true if the line should have the bidi algorithm
         /// applied as part of presentation.

--- a/termwiz/src/surface/line/test.rs
+++ b/termwiz/src/surface/line/test.rs
@@ -288,7 +288,9 @@ Line {
     ),
     zones: [],
     seqno: 1,
-    bits: NONE,
+    bits: LineBits(
+        0x0,
+    ),
     appdata: Mutex {
         data: None,
         poisoned: false,
@@ -598,7 +600,9 @@ Line {
     ),
     zones: [],
     seqno: 5,
-    bits: NONE,
+    bits: LineBits(
+        0x0,
+    ),
     appdata: Mutex {
         data: None,
         poisoned: false,

--- a/termwiz/src/terminal/unix.rs
+++ b/termwiz/src/terminal/unix.rs
@@ -232,7 +232,8 @@ impl UnixTerminal {
         let input_queue = VecDeque::new();
 
         let (sigwinch_pipe, sigwinch_pipe_write) = UnixStream::pair()?;
-        let sigwinch_id = signal_hook::low_level::pipe::register(libc::SIGWINCH, sigwinch_pipe_write)?;
+        let sigwinch_id =
+            signal_hook::low_level::pipe::register(libc::SIGWINCH, sigwinch_pipe_write)?;
         sigwinch_pipe.set_nonblocking(true)?;
         let (wake_pipe, wake_pipe_write) = UnixStream::pair()?;
         wake_pipe.set_nonblocking(true)?;

--- a/termwiz/src/terminal/unix.rs
+++ b/termwiz/src/terminal/unix.rs
@@ -232,7 +232,7 @@ impl UnixTerminal {
         let input_queue = VecDeque::new();
 
         let (sigwinch_pipe, sigwinch_pipe_write) = UnixStream::pair()?;
-        let sigwinch_id = signal_hook::pipe::register(libc::SIGWINCH, sigwinch_pipe_write)?;
+        let sigwinch_id = signal_hook::low_level::pipe::register(libc::SIGWINCH, sigwinch_pipe_write)?;
         sigwinch_pipe.set_nonblocking(true)?;
         let (wake_pipe, wake_pipe_write) = UnixStream::pair()?;
         wake_pipe.set_nonblocking(true)?;
@@ -532,7 +532,7 @@ impl Drop for UnixTerminal {
         self.exit_alternate_screen().unwrap();
         self.write.flush().unwrap();
 
-        signal_hook::unregister(self.sigwinch_id);
+        signal_hook::low_level::unregister(self.sigwinch_id);
         self.write
             .set_termios(&self.saved_termios, SetAttributeWhen::Now)
             .expect("failed to restore original termios state");


### PR DESCRIPTION
# Changes

- chore: Update termwiz::sha2 to 0.10
- chore: Update phf to 0.11
- fix: Update bitflags to 2.0 and fix compilation errors
- chore: Update nix to 0.26
- chore: Update criterion to 0.4
- fix: Update signal-hook to 0.3 and fix compilation errors

## Reasoning

Should reduce the number of duplicated dependecies and help improve compile
times/reduce the CI cache size
