### PR TITLE
Fix minor typo

### DIFF
--- a/docs/config/files.md
+++ b/docs/config/files.md
@@ -1,7 +1,7 @@
 
 ## Quick Start
 
-Create a file named `wezterm.lua` in your home directory, with the following
+Create a file named `.wezterm.lua` in your home directory, with the following
 contents:
 
 ```lua


### PR DESCRIPTION
As a new user,  I got confused as to why nothing happened when I created a config file named `wezterm.lua` when it should have been named `.wezterm.lua`