### PR TITLE
character select pgup/down, less jerky navigation, selected centered in list

### DIFF
--- a/wezterm-gui/src/termwindow/charselect.rs
+++ b/wezterm-gui/src/termwindow/charselect.rs
@@ -508,9 +508,9 @@ impl CharSelector {
         *self.top_row.borrow_mut() = 0;
     }
 
-    fn move_up(&self) {
+    fn move_up(&self, count: usize) {
         let mut row = self.selected_row.borrow_mut();
-        *row = row.saturating_sub(1);
+        *row = row.saturating_sub(count);
 
         let mut top_row = self.top_row.borrow_mut();
         if *row < *top_row {
@@ -518,7 +518,7 @@ impl CharSelector {
         }
     }
 
-    fn move_down(&self) {
+    fn move_down(&self, count:usize) {
         let max_rows_on_screen = *self.max_rows_on_screen.borrow();
         let limit = self
             .matches
@@ -526,12 +526,12 @@ impl CharSelector {
             .as_ref()
             .map(|m| m.matches.len())
             .unwrap_or_else(|| self.aliases.len())
-            .saturating_sub(1);
+            .saturating_sub(count);
         let mut row = self.selected_row.borrow_mut();
-        *row = row.saturating_add(1).min(limit);
+        *row = row.saturating_add(count).min(limit);
         let mut top_row = self.top_row.borrow_mut();
-        if *row + *top_row > max_rows_on_screen - 1 {
-            *top_row = row.saturating_sub(max_rows_on_screen - 1);
+        if *row + *top_row > max_rows_on_screen - count {
+            *top_row = row.saturating_sub(max_rows_on_screen - count);
         }
     }
 }
@@ -575,11 +575,17 @@ impl Modal for CharSelector {
                 self.selection.borrow_mut().clear();
                 self.updated_input();
             }
+            (KeyCode::PageUp, KeyModifiers::NONE) => {
+                self.move_up(6);
+            }
+            (KeyCode::PageDown, KeyModifiers::NONE) => {
+                self.move_down(6);
+            }
             (KeyCode::UpArrow, KeyModifiers::NONE) => {
-                self.move_up();
+                self.move_up(1);
             }
             (KeyCode::DownArrow, KeyModifiers::NONE) => {
-                self.move_down();
+                self.move_down(1);
             }
             (KeyCode::Char(c), KeyModifiers::NONE) | (KeyCode::Char(c), KeyModifiers::SHIFT) => {
                 // Type to add to the selection

--- a/wezterm-gui/src/termwindow/charselect.rs
+++ b/wezterm-gui/src/termwindow/charselect.rs
@@ -532,7 +532,6 @@ impl CharSelector {
             if *row < *top_row {
                 *top_row = *row;
             }
-            // *row = row.saturating_add(count).min(limit);
             if *row + *top_row > max_rows_on_screen / 2 {
                 *top_row = row.saturating_sub(max_rows_on_screen / 2);
             }

--- a/wezterm-gui/src/termwindow/charselect.rs
+++ b/wezterm-gui/src/termwindow/charselect.rs
@@ -528,7 +528,7 @@ impl CharSelector {
         {
             let mut row = self.selected_row.borrow_mut();
             let mut top_row = self.top_row.borrow_mut();
-            *row = row.min(limit-1);
+            *row = row.min(limit.saturating_sub(1));
             if *row < *top_row {
                 *top_row = *row;
             }

--- a/wezterm-gui/src/termwindow/charselect.rs
+++ b/wezterm-gui/src/termwindow/charselect.rs
@@ -510,12 +510,30 @@ impl CharSelector {
 
     fn move_up(&self, count: usize) {
         {
+            let count = if count==0 {
+                *self.max_rows_on_screen.borrow()
+            } else {
+                count
+            };
             let mut row = self.selected_row.borrow_mut();
             *row = row.saturating_sub(count);
         }
         self.nav_selection()
     }
 
+    fn move_down(&self, count: usize) {
+        {
+            let count = if count==0 {
+                *self.max_rows_on_screen.borrow()
+            } else {
+                count
+            };
+            let mut row = self.selected_row.borrow_mut();
+            *row = row.saturating_add(count);
+        }
+        self.nav_selection()
+    }
+    
     // handles selection constraints, moving list, keeping selection centered  
     fn nav_selection(&self) {
         let max_rows_on_screen = *self.max_rows_on_screen.borrow();
@@ -538,13 +556,6 @@ impl CharSelector {
         }
     }
 
-    fn move_down(&self, count: usize) {
-        {
-            let mut row = self.selected_row.borrow_mut();
-            *row = row.saturating_add(count);
-        }
-        self.nav_selection()
-    }
 }
 
 impl Modal for CharSelector {
@@ -587,10 +598,10 @@ impl Modal for CharSelector {
                 self.updated_input();
             }
             (KeyCode::PageUp, KeyModifiers::NONE) => {
-                self.move_up(6);
+                self.move_up(0);
             }
             (KeyCode::PageDown, KeyModifiers::NONE) => {
-                self.move_down(6);
+                self.move_down(0);
             }
             (KeyCode::UpArrow, KeyModifiers::NONE) => {
                 self.move_up(1);

--- a/wezterm-gui/src/termwindow/charselect.rs
+++ b/wezterm-gui/src/termwindow/charselect.rs
@@ -510,7 +510,7 @@ impl CharSelector {
 
     fn move_up(&self, count: usize) {
         {
-            let count = if count==0 {
+            let count = if count == 0 {
                 *self.max_rows_on_screen.borrow()
             } else {
                 count
@@ -523,7 +523,7 @@ impl CharSelector {
 
     fn move_down(&self, count: usize) {
         {
-            let count = if count==0 {
+            let count = if count == 0 {
                 *self.max_rows_on_screen.borrow()
             } else {
                 count
@@ -533,8 +533,8 @@ impl CharSelector {
         }
         self.nav_selection()
     }
-    
-    // handles selection constraints, moving list, keeping selection centered  
+
+    // handles selection constraints, moving list, keeping selection centered
     fn nav_selection(&self) {
         let max_rows_on_screen = *self.max_rows_on_screen.borrow();
         let limit = self
@@ -555,7 +555,6 @@ impl CharSelector {
             }
         }
     }
-
 }
 
 impl Modal for CharSelector {


### PR DESCRIPTION
Figured this was simplest, to make the movements require a number, and just have a small number for arrows, big for pgup/down... Maybe later we can configure/optionify it.