### PR TITLE
feat: add systembackdrop like acrylic and mica for windows os

### DIFF
--- a/config/src/background.rs
+++ b/config/src/background.rs
@@ -1,5 +1,6 @@
 use crate::{default_one_point_oh, Config, Dimension, HsbTransform, PixelUnit, RgbaColor};
 use luahelper::impl_lua_conversion_dynamic;
+use termwiz::color::SrgbaTuple;
 use wezterm_dynamic::{FromDynamic, FromDynamicOptions, ToDynamic, Value};
 
 #[derive(Debug, Clone, FromDynamic, ToDynamic)]
@@ -298,6 +299,10 @@ pub enum SystemBackdrop {
     Acrylic,
     Mica,
     Tabbed,
+}
+
+pub fn default_win32_acrylic_accent_color() -> RgbaColor {
+    SrgbaTuple(0.156863, 0.156863, 0.156863, 0.003922).into()
 }
 
 #[derive(Debug, Copy, Clone, FromDynamic, ToDynamic, PartialEq, Default)]

--- a/config/src/background.rs
+++ b/config/src/background.rs
@@ -291,6 +291,16 @@ impl Default for BackgroundOrigin {
 }
 
 #[derive(Debug, Copy, Clone, FromDynamic, ToDynamic, PartialEq, Default)]
+pub enum SystemBackdrop {
+    #[default]
+    Auto,
+    Disable,
+    Acrylic,
+    Mica,
+    Tabbed,
+}
+
+#[derive(Debug, Copy, Clone, FromDynamic, ToDynamic, PartialEq, Default)]
 pub enum Interpolation {
     #[default]
     Linear,

--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -22,9 +22,10 @@ use crate::unix::UnixDomain;
 use crate::wsl::WslDomain;
 use crate::{
     default_config_with_overrides_applied, default_one_point_oh, default_one_point_oh_f64,
-    default_true, GpuInfo, IntegratedTitleButtonColor, KeyMapPreference, LoadedConfig,
-    MouseEventTriggerMods, RgbaColor, SerialDomain, SystemBackdrop, WebGpuPowerPreference,
-    CONFIG_DIRS, CONFIG_FILE_OVERRIDE, CONFIG_OVERRIDES, CONFIG_SKIP, HOME_DIR,
+    default_true, default_win32_acrylic_accent_color, GpuInfo, IntegratedTitleButtonColor,
+    KeyMapPreference, LoadedConfig, MouseEventTriggerMods, RgbaColor, SerialDomain, SystemBackdrop,
+    WebGpuPowerPreference, CONFIG_DIRS, CONFIG_FILE_OVERRIDE, CONFIG_OVERRIDES, CONFIG_SKIP,
+    HOME_DIR,
 };
 use anyhow::Context;
 use luahelper::impl_lua_conversion_dynamic;
@@ -512,7 +513,10 @@ pub struct Config {
 
     /// Only works on Windows
     #[dynamic(default)]
-    pub windows_system_backdrop: SystemBackdrop,
+    pub win32_system_backdrop: SystemBackdrop,
+
+    #[dynamic(default = "default_win32_acrylic_accent_color")]
+    pub win32_acrylic_accent_color: RgbaColor,
 
     /// Specifies the alpha value to use when rendering the background
     /// of the window.  The background is taken either from the

--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -23,8 +23,8 @@ use crate::wsl::WslDomain;
 use crate::{
     default_config_with_overrides_applied, default_one_point_oh, default_one_point_oh_f64,
     default_true, GpuInfo, IntegratedTitleButtonColor, KeyMapPreference, LoadedConfig,
-    MouseEventTriggerMods, RgbaColor, SerialDomain, WebGpuPowerPreference, CONFIG_DIRS,
-    CONFIG_FILE_OVERRIDE, CONFIG_OVERRIDES, CONFIG_SKIP, HOME_DIR,
+    MouseEventTriggerMods, RgbaColor, SerialDomain, SystemBackdrop, WebGpuPowerPreference,
+    CONFIG_DIRS, CONFIG_FILE_OVERRIDE, CONFIG_OVERRIDES, CONFIG_SKIP, HOME_DIR,
 };
 use anyhow::Context;
 use luahelper::impl_lua_conversion_dynamic;
@@ -509,6 +509,10 @@ pub struct Config {
     /// Only works on MacOS
     #[dynamic(default)]
     pub macos_window_background_blur: i64,
+
+    /// Only works on Windows
+    #[dynamic(default)]
+    pub windows_system_backdrop: SystemBackdrop,
 
     /// Specifies the alpha value to use when rendering the background
     /// of the window.  The background is taken either from the

--- a/window/src/os/windows/window.rs
+++ b/window/src/os/windows/window.rs
@@ -1375,7 +1375,7 @@ fn apply_theme(hwnd: HWND) -> Option<LRESULT> {
             let mut inner = inner.borrow_mut();
 
             // Set Arylic or Mica system Backdrop
-            let pv_attribute = match inner.config.windows_system_backdrop {
+            let pv_attribute = match inner.config.win32_system_backdrop {
                 SystemBackdrop::Auto => DWM_SYSTEMBACKDROP_TYPE::DWMSBT_AUTO,
                 SystemBackdrop::Disable => DWM_SYSTEMBACKDROP_TYPE::DWMSBT_NONE,
                 SystemBackdrop::Acrylic => DWM_SYSTEMBACKDROP_TYPE::DWMSBT_TRANSIENTWINDOW,
@@ -1389,18 +1389,19 @@ fn apply_theme(hwnd: HWND) -> Option<LRESULT> {
                     hwnd,
                     DWMWA_SYSTEMBACKDROP_TYPE,
                     &pv_attribute as *const _ as _,
-                    4,
+                    std::mem::size_of_val(&pv_attribute) as u32,
                 );
-            } else if inner.config.windows_system_backdrop == SystemBackdrop::Acrylic {
-                let colour: [u8; 4] = [40, 40, 40, 1]; // acrylic doesn't like to have 0 alpha
+            } else if inner.config.win32_system_backdrop == SystemBackdrop::Acrylic {
+                let mut colour = inner.config.win32_acrylic_accent_color.to_srgb_u8();
+                colour.3 = if colour.3 == 0 { 1 } else { colour.3 }; // acrylic doesn't like to have 0 alpha
 
                 let mut policy = ACCENT_POLICY {
                     AccentState: ACCENT_STATE::ACCENT_ENABLE_ACRYLICBLURBEHIND as _,
                     AccentFlags: 2,
-                    GradientColour: (colour[0] as u32)
-                        | (colour[1] as u32) << 8
-                        | (colour[2] as u32) << 16
-                        | (colour[3] as u32) << 24,
+                    GradientColour: (colour.0 as u32)
+                        | (colour.1 as u32) << 8
+                        | (colour.2 as u32) << 16
+                        | (colour.3 as u32) << 24,
                     AnimationId: 0,
                 };
 
@@ -1410,16 +1411,25 @@ fn apply_theme(hwnd: HWND) -> Option<LRESULT> {
                         &mut WINDOWCOMPOSITIONATTRIBDATA {
                             Attrib: 0x13,
                             pvData: &mut policy as *mut _ as _,
-                            cbData: std::mem::size_of_val(&policy),
+                            cbData: std::mem::size_of_val(&policy) as _,
                         },
                     );
                 };
             } else if !*IS_WIN10 && !*IS_WIN11_22H2 {
                 // For build versions less than 22h2 but are
                 // still win11
-                if inner.config.windows_system_backdrop == SystemBackdrop::Mica {
-                    DwmSetWindowAttribute(hwnd, DWMWA_MICA_EFFECT, &1 as *const _ as _, 4);
-                }
+                let mica_enabled: u32 =
+                    if inner.config.win32_system_backdrop == SystemBackdrop::Mica {
+                        1
+                    } else {
+                        0
+                    };
+                DwmSetWindowAttribute(
+                    hwnd,
+                    DWMWA_MICA_EFFECT,
+                    &mica_enabled as *const _ as _,
+                    std::mem::size_of_val(&mica_enabled) as u32,
+                );
             }
 
             if appearance != inner.appearance {

--- a/window/src/os/windows/window.rs
+++ b/window/src/os/windows/window.rs
@@ -1284,7 +1284,8 @@ fn apply_theme(hwnd: HWND) -> Option<LRESULT> {
     // Check for OS app theme, and set window attributes accordingly.
     // Note that the MS terminal app uses the logic found here for this stuff:
     // https://github.com/microsoft/terminal/blob/9b92986b49bed8cc41fde4d6ef080921c41e6d9e/src/interactivity/win32/windowtheme.cpp#L62
-    use winapi::um::dwmapi::DwmSetWindowAttribute;
+    use winapi::um::dwmapi::{DwmExtendFrameIntoClientArea, DwmSetWindowAttribute};
+    use winapi::um::uxtheme::MARGINS;
 
     #[allow(non_snake_case)]
     type WINDOWCOMPOSITIONATTRIB = u32;
@@ -1370,6 +1371,16 @@ fn apply_theme(hwnd: HWND) -> Option<LRESULT> {
                 },
             );
         };
+
+        DwmExtendFrameIntoClientArea(
+            hwnd,
+            &MARGINS {
+                cxLeftWidth: -1,
+                cxRightWidth: -1,
+                cyTopHeight: -1,
+                cyBottomHeight: -1,
+            },
+        );
 
         if let Some(inner) = rc_from_hwnd(hwnd) {
             let mut inner = inner.borrow_mut();


### PR DESCRIPTION
Added functionality which enables Setting SystemBackdrop for windows os like mica, Acrylic, tabbed. 

based on [SystemBackDrop](https://learn.microsoft.com/en-us/windows/win32/api/dwmapi/ne-dwmapi-dwm_systembackdrop_type) and [Vibe](https://github.com/pykeio/vibe/blob/main/src/dwm_win32.rs)

Adds a config option `win32_system_backdrop` with values `Auto`, `Disable`, `Acrylic`, `Mica`, `Tabbed` to configure the backdrop.
Also another config option `win32_acrylic_accent_color` for adding accent color to acrylic for windows build version less than `22621` 
resolves #1614

Screenshots

Acrylic:

<img width="925" alt="acrylic" src="https://user-images.githubusercontent.com/31726036/232248641-5156cf1a-2c5e-4f72-8ca0-c13f096b9032.png">

Mica:

<img width="922" alt="mica" src="https://user-images.githubusercontent.com/31726036/232248664-7fd2f447-2136-4ddd-8005-b00bcf7b2663.png">

Tabbed(Mica Alt):

<img width="917" alt="tabbed" src="https://user-images.githubusercontent.com/31726036/232248674-729230ad-9c95-4c02-a04a-1f361d4c6bed.png">


