### PR TITLE
Add custom eighth block corner glyphs

### DIFF
--- a/wezterm-gui/src/customglyph.rs
+++ b/wezterm-gui/src/customglyph.rs
@@ -130,11 +130,8 @@ impl BlockCoord {
     }
 }
 
-/// Represents a Block Element glyph, decoded from
-/// <https://en.wikipedia.org/wiki/Block_Elements>
-/// <https://www.unicode.org/charts/PDF/U2580.pdf>
 #[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
-pub enum BlockKey {
+pub enum Edge {
     /// Number of 1/8ths in the upper half
     Upper(u8),
     /// Number of 1/8ths in the lower half
@@ -143,6 +140,16 @@ pub enum BlockKey {
     Left(u8),
     /// Number of 1/8ths in the right half
     Right(u8),
+}
+
+/// Represents a Block Element glyph, decoded from
+/// <https://en.wikipedia.org/wiki/Block_Elements>
+/// <https://www.unicode.org/charts/PDF/U2580.pdf>
+#[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
+pub enum BlockKey {
+    /// List of edge rectangles
+    Edges(&'static [Edge]),
+
     /// Full block with alpha level
     Full(BlockAlpha),
     /// A combination of quadrants
@@ -3196,17 +3203,39 @@ impl BlockKey {
             ]),
 
             // [▀] UPPER HALF BLOCK
-            0x2580 => Self::Upper(4),
-            // LOWER 1..7 EIGHTH BLOCK
-            // [▁] [▂] [▃] [▄] [▅] [▆] [▇]
-            0x2581..=0x2587 => Self::Lower((c - 0x2580) as u8),
+            0x2580 => Self::Edges(&[Edge::Upper(4)]),
+            // [▁] LOWER 1 EIGHTH BLOCK
+            0x2581 => Self::Edges(&[Edge::Lower(1)]),
+            // [▂] LOWER 2 EIGHTHS BLOCK
+            0x2582 => Self::Edges(&[Edge::Lower(2)]),
+            // [▃] LOWER 3 EIGHTHS BLOCK
+            0x2583 => Self::Edges(&[Edge::Lower(3)]),
+            // [▄] LOWER 4 EIGHTHS BLOCK
+            0x2584 => Self::Edges(&[Edge::Lower(4)]),
+            // [▅] LOWER 5 EIGHTHS BLOCK
+            0x2585 => Self::Edges(&[Edge::Lower(5)]),
+            // [▆] LOWER 6 EIGHTHS BLOCK
+            0x2586 => Self::Edges(&[Edge::Lower(6)]),
+            // [▇] LOWER 7 EIGHTHS BLOCK
+            0x2587 => Self::Edges(&[Edge::Lower(7)]),
             // [█] FULL BLOCK
             0x2588 => Self::Full(BlockAlpha::Full),
-            // LEFT 7..1 EIGHTHS BLOCK
-            // [▉] [▊] [▋] [▌] [▍] [▎] [▏]
-            0x2589..=0x258f => Self::Left((0x2590 - c) as u8),
+            // [▉] LEFT 7 EIGHTHS BLOCK
+            0x2589 => Self::Edges(&[Edge::Left(7)]),
+            // [▊] LEFT 6 EIGHTHS BLOCK
+            0x258a => Self::Edges(&[Edge::Left(6)]),
+            // [▋] LEFT 5 EIGHTHS BLOCK
+            0x258b => Self::Edges(&[Edge::Left(5)]),
+            // [▌] LEFT 4 EIGHTHS BLOCK
+            0x258c => Self::Edges(&[Edge::Left(4)]),
+            // [▍] LEFT 3 EIGHTHS BLOCK
+            0x258d => Self::Edges(&[Edge::Left(3)]),
+            // [▎] LEFT 2 EIGHTHS BLOCK
+            0x258e => Self::Edges(&[Edge::Left(2)]),
+            // [▏] LEFT 1 EIGHTHS BLOCK
+            0x258f => Self::Edges(&[Edge::Left(1)]),
             // [▐] RIGHT HALF BLOCK
-            0x2590 => Self::Right(4),
+            0x2590 => Self::Edges(&[Edge::Right(4)]),
             // [░] LIGHT SHADE
             0x2591 => Self::Full(BlockAlpha::Light),
             // [▒] MEDIUM SHADE
@@ -3214,9 +3243,9 @@ impl BlockKey {
             // [▓] DARK SHADE
             0x2593 => Self::Full(BlockAlpha::Dark),
             // [▔] UPPER ONE EIGHTH BLOCK
-            0x2594 => Self::Upper(1),
+            0x2594 => Self::Edges(&[Edge::Upper(1)]),
             // [▕] RIGHT ONE EIGHTH BLOCK
-            0x2595 => Self::Right(1),
+            0x2595 => Self::Edges(&[Edge::Right(1)]),
             // [▖] QUADRANT LOWER LEFT
             0x2596 => Self::Quadrants(Quadrant::LOWER_LEFT),
             // [▗] QUADRANT LOWER RIGHT
@@ -3456,27 +3485,34 @@ impl BlockKey {
                 intensity: BlockAlpha::Full,
                 style: PolyStyle::Fill,
             }]),
+            // [🭼] Left and lower one eighth block
+            0x1fb7c => Self::Edges(&[Edge::Left(1), Edge::Lower(1)]),
+            // [🭽] Left and upper one eighth block
+            0x1fb7d => Self::Edges(&[Edge::Left(1), Edge::Upper(1)]),
+            // [🭾] Right and upper one eighth block
+            0x1fb7e => Self::Edges(&[Edge::Right(1), Edge::Upper(1)]),
+            // [🭿] Right and lower one eighth block
+            0x1fb7f => Self::Edges(&[Edge::Right(1), Edge::Lower(1)]),
             // [🮂] Upper One Quarter Block
-            0x1fb82 => Self::Upper(2),
+            0x1fb82 => Self::Edges(&[Edge::Upper(2)]),
             // [🮃] Upper three eighths block
-            0x1fb83 => Self::Upper(3),
+            0x1fb83 => Self::Edges(&[Edge::Upper(3)]),
             // [🮄] Upper five eighths block
-            0x1fb84 => Self::Upper(5),
+            0x1fb84 => Self::Edges(&[Edge::Upper(5)]),
             // [🮅] Upper three quarters block
-            0x1fb85 => Self::Upper(6),
+            0x1fb85 => Self::Edges(&[Edge::Upper(6)]),
             // [🮆] Upper seven eighths block
-            0x1fb86 => Self::Upper(7),
+            0x1fb86 => Self::Edges(&[Edge::Upper(7)]),
             // [🮇] Right One Quarter Block
-            0x1fb87 => Self::Right(2),
+            0x1fb87 => Self::Edges(&[Edge::Right(2)]),
             // [🮈] Right three eighths block
-            0x1fb88 => Self::Right(3),
+            0x1fb88 => Self::Edges(&[Edge::Right(3)]),
             // [🮉] Right five eighths block
-            0x1fb89 => Self::Right(5),
+            0x1fb89 => Self::Edges(&[Edge::Right(5)]),
             // [🮊] Right three quarters block
-            0x1fb8a => Self::Right(6),
+            0x1fb8a => Self::Edges(&[Edge::Right(6)]),
             // [🮋] Right seven eighths block
-            0x1fb8b => Self::Right(7),
-
+            0x1fb8b => Self::Edges(&[Edge::Right(7)]),
             // [] Powerline filled right arrow
             0xe0b0 => Self::Poly(&[Poly {
                 path: &[
@@ -3841,28 +3877,36 @@ impl GlyphCache {
         buffer.clear_rect(cell_rect, black);
 
         match key.block {
-            BlockKey::Upper(num) => {
-                let lower = metrics.cell_size.height as f32 * (num as f32) / 8.;
-                let width = metrics.cell_size.width as usize;
-                fill_rect(&mut buffer, 0..width, 0..scale(lower));
+            
+            BlockKey::Edges(edges) => {
+                for edge in edges.iter() {
+                    match edge {
+                        Edge::Upper(num) => {
+                            let lower = metrics.cell_size.height as f32 * (*num as f32) / 8.;
+                            let width = metrics.cell_size.width as usize;
+                            fill_rect(&mut buffer, 0..width, 0..scale(lower));
+                        }
+                        Edge::Lower(num) => {
+                            let upper = metrics.cell_size.height as f32 * ((8 - num) as f32) / 8.;
+                            let width = metrics.cell_size.width as usize;
+                            let height = metrics.cell_size.height as usize;
+                            fill_rect(&mut buffer, 0..width, scale(upper)..height);
+                        }
+                        Edge::Left(num) => {
+                            let width = metrics.cell_size.width as f32 * (*num as f32) / 8.;
+                            let height = metrics.cell_size.height as usize;
+                            fill_rect(&mut buffer, 0..scale(width), 0..height);
+                        }
+                        Edge::Right(num) => {
+                            let left = metrics.cell_size.width as f32 * ((8 - num) as f32) / 8.;
+                            let width = metrics.cell_size.width as usize;
+                            let height = metrics.cell_size.height as usize;
+                            fill_rect(&mut buffer, scale(left)..width, 0..height);
+                        }
+                    }
+                }
             }
-            BlockKey::Lower(num) => {
-                let upper = metrics.cell_size.height as f32 * ((8 - num) as f32) / 8.;
-                let width = metrics.cell_size.width as usize;
-                let height = metrics.cell_size.height as usize;
-                fill_rect(&mut buffer, 0..width, scale(upper)..height);
-            }
-            BlockKey::Left(num) => {
-                let width = metrics.cell_size.width as f32 * (num as f32) / 8.;
-                let height = metrics.cell_size.height as usize;
-                fill_rect(&mut buffer, 0..scale(width), 0..height);
-            }
-            BlockKey::Right(num) => {
-                let left = metrics.cell_size.width as f32 * ((8 - num) as f32) / 8.;
-                let width = metrics.cell_size.width as usize;
-                let height = metrics.cell_size.height as usize;
-                fill_rect(&mut buffer, scale(left)..width, 0..height);
-            }
+            
             BlockKey::Full(alpha) => {
                 let alpha = alpha.to_scale();
                 let fill = LinearRgba::with_components(alpha, alpha, alpha, alpha);


### PR DESCRIPTION
Hello,

This adds custom glyphs for the following box drawing characters:

```
🭽 🭾 🭼 🭿
```

| Before | After |
|---|---|
| ![image](https://user-images.githubusercontent.com/12154190/232896296-6809e839-cde6-4472-9c55-1f66167bb2f6.png) | ![image](https://user-images.githubusercontent.com/12154190/232896319-71c614d2-c0ea-4fcb-b216-477fb8cab620.png) |