### PR TITLE
Fixed double-skewing behavior

### DIFF
--- a/wezterm-font/src/rasterizer/mod.rs
+++ b/wezterm-font/src/rasterizer/mod.rs
@@ -2,6 +2,10 @@ use crate::parser::ParsedFont;
 use crate::units::*;
 use config::FontRasterizerSelection;
 
+/// The amount, as a number in [0,1], to horizontally skew a glyph when rendering synthetic
+/// italics
+pub(crate) const FAKE_ITALIC_SKEW: f64 = 0.2;
+
 pub mod freetype;
 
 /// A bitmap representation of a glyph.
@@ -14,65 +18,6 @@ pub struct RasterizedGlyph {
     pub bearing_x: PixelLength,
     pub bearing_y: PixelLength,
     pub has_color: bool,
-}
-
-impl RasterizedGlyph {
-    /// Computes a skewed version of this glyph to produce a synthesized oblique variant
-    pub fn skew(&self) -> Self {
-        // This function is derived from code which is subject to the terms of the
-        // Mozilla Public License, v. 2.0. http://mozilla.org/MPL/2.0/
-
-        let factor = 0.2f64; // Skew factor
-        let stride = self.width * 4;
-
-        // Calculate the skewed horizontal offsets of the bottom and top of the glyph.
-        let bottom = self.bearing_y.get().round() as f64 - self.height as f64;
-        let skew_min = ((bottom + 0.5) * factor).floor();
-        let skew_max = ((self.bearing_y.get() as f64 - 0.5) * factor).ceil();
-
-        // Allocate enough extra width for the min/max skew offsets.
-        let skew_width = self.width + (skew_max - skew_min) as usize;
-        let mut skew_buffer = vec![0u8; skew_width * self.height * 4];
-        for y in 0..self.height {
-            // Calculate a skew offset at the vertical center of the current row.
-            let offset = (self.bearing_y.get() - y as f64 - 0.5) * factor - skew_min;
-            // Get a blend factor in 0..256 constant across all pixels in the row.
-            let blend = (offset.fract() * 256.0) as u32;
-            let src_row = y * stride;
-            let dest_row = (y * skew_width + offset.floor() as usize) * 4;
-            let mut prev_px = [0u32; 4];
-            for (src, dest) in self.data[src_row..src_row + stride]
-                .chunks(4)
-                .zip(skew_buffer[dest_row..dest_row + stride].chunks_mut(4))
-            {
-                let px = [src[0] as u32, src[1] as u32, src[2] as u32, src[3] as u32];
-                // Blend current pixel with previous pixel based on blend factor.
-                let next_px = [px[0] * blend, px[1] * blend, px[2] * blend, px[3] * blend];
-                dest[0] = ((((px[0] << 8) - next_px[0]) + prev_px[0] + 128) >> 8) as u8;
-                dest[1] = ((((px[1] << 8) - next_px[1]) + prev_px[1] + 128) >> 8) as u8;
-                dest[2] = ((((px[2] << 8) - next_px[2]) + prev_px[2] + 128) >> 8) as u8;
-                dest[3] = ((((px[3] << 8) - next_px[3]) + prev_px[3] + 128) >> 8) as u8;
-                // Save the remainder for blending onto the next pixel.
-                prev_px = next_px;
-            }
-            // If the skew misaligns the final pixel, write out the remainder.
-            if blend > 0 {
-                let dest = &mut skew_buffer[dest_row + stride..dest_row + stride + 4];
-                dest[0] = ((prev_px[0] + 128) >> 8) as u8;
-                dest[1] = ((prev_px[1] + 128) >> 8) as u8;
-                dest[2] = ((prev_px[2] + 128) >> 8) as u8;
-                dest[3] = ((prev_px[3] + 128) >> 8) as u8;
-            }
-        }
-        Self {
-            data: skew_buffer,
-            height: self.height,
-            width: skew_width,
-            bearing_x: self.bearing_x + PixelLength::new(skew_min),
-            bearing_y: self.bearing_y,
-            has_color: self.has_color,
-        }
-    }
 }
 
 /// Rasterizes the specified glyph index in the associated font


### PR DESCRIPTION
Previously, synthetiszed italic glyphs went through a face transform as well as a manual skewing operation. This resulted in a glyph being skewed twice. This PR removes the latter skewing operation. Here's a side by side with iTerm2 now:

<img width="736" alt="Screenshot 2023-04-24 at 23 59 56" src="https://user-images.githubusercontent.com/752802/234172428-864ab521-af7c-43cf-9b75-ac698f161471.png">
<img width="770" alt="Screenshot 2023-04-25 at 00 10 06" src="https://user-images.githubusercontent.com/752802/234172435-7f787d08-8eec-41a8-a8c7-84e4c8decd48.png">


This partially fixes #3555.

I played around with configurable skew factor but decided it was more effort than was worth it. iTerm2 doesn't let you adjust this factor, and I think that's fine.

# Remaining work

There's still a text highlighting bug when italics are synthesized. Notice that part of the `r` below is not highlighted, while part of the adjacent `a` is:
<img width="251" alt="Screenshot 2023-04-25 at 00 04 54" src="https://user-images.githubusercontent.com/752802/234172645-d9d43c73-e48a-45b9-beda-6159d9450bde.png">

For comparison, iTerm2 highlights _all_ of `r` and none of `a`, despite the fact that some of `r` is not inside the cursor's boundary. I'd imagine that the fix for this would be quite annoying, and I don't care too much.
<img width="317" alt="Screenshot 2023-04-25 at 00 05 31" src="https://user-images.githubusercontent.com/752802/234172745-edb34741-0ec7-4648-9720-ca6999ad44f9.png">
