### PR TITLE
Remove reserved native buttons space in full screen

### DIFF
--- a/wezterm-gui/src/termwindow/render/fancy_tab_bar.rs
+++ b/wezterm-gui/src/termwindow/render/fancy_tab_bar.rs
@@ -309,6 +309,7 @@ impl crate::TermWindow {
             .window_decorations
             .contains(::window::WindowDecorations::INTEGRATED_BUTTONS)
             && self.config.integrated_title_button_style == IntegratedTitleButtonStyle::MacOsNative
+            && !self.window_state.contains(window::WindowState::FULL_SCREEN)
         {
             left_status.push(
                 Element::new(&font, ElementContent::Text("".to_string())).margin(BoxDimension {


### PR DESCRIPTION
When configuring `window_decorations= 'INTEGRATED_BUTTONS|RESIZE'`, there will be extra blank space in full screen mode.

<img width="250" alt="image" src="https://user-images.githubusercontent.com/8097526/235628021-22d44d9f-a705-4af3-b8e0-a37beb736411.png">
