### PR TITLE
add color config for char select

### DIFF
--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -136,6 +136,12 @@ pub struct Config {
     #[dynamic(default = "default_char_select_font_size")]
     pub char_select_font_size: f64,
 
+    #[dynamic(default = "default_char_select_fg_color")]
+    pub char_select_fg_color: RgbaColor,
+
+    #[dynamic(default = "default_char_select_bg_color")]
+    pub char_select_bg_color: RgbaColor,
+
     #[dynamic(default = "default_command_palette_font_size")]
     pub command_palette_font_size: f64,
 
@@ -1533,6 +1539,14 @@ fn default_integrated_title_buttons() -> Vec<IntegratedTitleButton> {
 
 fn default_char_select_font_size() -> f64 {
     18.0
+}
+
+fn default_char_select_fg_color() -> RgbaColor {
+    SrgbaTuple(0.75, 0.75, 0.75, 1.0).into()
+}
+
+fn default_char_select_bg_color() -> RgbaColor {
+    (0x33, 0x33, 0x33).into()
 }
 
 fn default_command_palette_font_size() -> f64 {

--- a/docs/config/lua/config/char_select_bg_color.md
+++ b/docs/config/lua/config/char_select_bg_color.md
@@ -1,11 +1,12 @@
 ---
 tags:
-  - color
+  - appearance
   - char_select
+  - color
 ---
 # `char_select_bg_color = "#333333"`
 
-*Since: nightly builds only*
+{{since('nightly')}}
 
 Specifies the background color used by
 [CharSelect](../keyassignment/CharSelect.md).

--- a/docs/config/lua/config/char_select_bg_color.md
+++ b/docs/config/lua/config/char_select_bg_color.md
@@ -1,0 +1,11 @@
+---
+tags:
+  - color
+  - char_select
+---
+# `char_select_bg_color = "#333333"`
+
+*Since: nightly builds only*
+
+Specifies the background color used by
+[CharSelect](../keyassignment/CharSelect.md).

--- a/docs/config/lua/config/char_select_fg_color.md
+++ b/docs/config/lua/config/char_select_fg_color.md
@@ -1,11 +1,12 @@
 ---
 tags:
-  - color
+  - appearance
   - char_select
+  - color
 ---
 # `char_select_fg_color = rgba(0.75, 0.75, 0.75, 1.0)`
 
-*Since: nightly builds only*
+{{since('nightly')}}
 
 Specifies the text color used by
 [CharSelect](../keyassignment/CharSelect.md).

--- a/docs/config/lua/config/char_select_fg_color.md
+++ b/docs/config/lua/config/char_select_fg_color.md
@@ -1,0 +1,11 @@
+---
+tags:
+  - color
+  - char_select
+---
+# `char_select_fg_color = rgba(0.75, 0.75, 0.75, 1.0)`
+
+*Since: nightly builds only*
+
+Specifies the text color used by
+[CharSelect](../keyassignment/CharSelect.md).

--- a/docs/config/lua/config/char_select_font_size.md
+++ b/docs/config/lua/config/char_select_font_size.md
@@ -1,11 +1,12 @@
 ---
 tags:
-  - font
+  - appearance
   - char_select
+  - font
 ---
 # `char_select_font_size = 14.0`
 
-*Since: nightly builds only*
+{{since('20220903-194523-3bb1ed61')}}
 
 Specifies the size of the font used with
 [CharSelect](../keyassignment/CharSelect.md).

--- a/docs/config/lua/config/char_select_font_size.md
+++ b/docs/config/lua/config/char_select_font_size.md
@@ -1,0 +1,11 @@
+---
+tags:
+  - font
+  - char_select
+---
+# `char_select_font_size = 14.0`
+
+*Since: nightly builds only*
+
+Specifies the size of the font used with
+[CharSelect](../keyassignment/CharSelect.md).

--- a/docs/config/lua/keyassignment/CharSelect.md
+++ b/docs/config/lua/keyassignment/CharSelect.md
@@ -72,3 +72,7 @@ The `CharSelect` action accepts a lua table with the following fields:
   `"RecentlyUsed"` if you have previously selected an item, or
   `"SmileysAndEmotion"` otherwise.
 
+See also:
+* [char_select_font_size](../config/char_select_font_size.md)
+* [char_select_fg_color](../config/char_select_fg_color.md)
+* [char_select_bg_color](../config/char_select_bg_color.md)

--- a/wezterm-gui/src/termwindow/charselect.rs
+++ b/wezterm-gui/src/termwindow/charselect.rs
@@ -387,7 +387,7 @@ impl CharSelector {
         .colors(ElementColors {
             border: BorderColor::default(),
             bg: LinearRgba::TRANSPARENT.into(),
-            text: term_window.config.pane_select_fg_color.to_linear().into(),
+            text: term_window.config.char_select_fg_color.to_linear().into(),
         })
         .display(DisplayType::Block)];
 
@@ -401,13 +401,13 @@ impl CharSelector {
         {
             let (bg, text) = if display_idx == selected_row {
                 (
-                    term_window.config.pane_select_fg_color.to_linear().into(),
-                    term_window.config.pane_select_bg_color.to_linear().into(),
+                    term_window.config.char_select_fg_color.to_linear().into(),
+                    term_window.config.char_select_bg_color.to_linear().into(),
                 )
             } else {
                 (
                     LinearRgba::TRANSPARENT.into(),
-                    term_window.config.pane_select_fg_color.to_linear().into(),
+                    term_window.config.char_select_fg_color.to_linear().into(),
                 )
             };
             elements.push(
@@ -438,10 +438,10 @@ impl CharSelector {
         let element = Element::new(&font, ElementContent::Children(elements))
             .colors(ElementColors {
                 border: BorderColor::new(
-                    term_window.config.pane_select_bg_color.to_linear().into(),
+                    term_window.config.char_select_bg_color.to_linear().into(),
                 ),
-                bg: term_window.config.pane_select_bg_color.to_linear().into(),
-                text: term_window.config.pane_select_fg_color.to_linear().into(),
+                bg: term_window.config.char_select_bg_color.to_linear().into(),
+                text: term_window.config.char_select_fg_color.to_linear().into(),
             })
             .margin(BoxDimension {
                 left: Dimension::Cells(1.25),


### PR DESCRIPTION
Now the char select window relies on the color configuration of pane select, making it impossible to distinguish between the two.

I want to configure them by adding two colors: `char_select_fg_color` and `char_select_bg_color`.