### PR TITLE
Fix typo.

### DIFF
--- a/docs/config/lua/window-events/augment-command-palette.md
+++ b/docs/config/lua/window-events/augment-command-palette.md
@@ -14,7 +14,7 @@ returned table may have the following fields:
 
 * `brief` - required: the brief description for the entry
 * `doc` - optional: a long description that may be shown after the entry, or that
-  may be used in future wezterms of wezterm to provide more information about the
+  may be used in future versions of wezterm to provide more information about the
   command.
 * `action` - the action to take when the item is activated. Can be any key assignment
   action.


### PR DESCRIPTION
While I very much look forward to "future wezterms of wezterm", I think perhaps their existence should only be referred to by use of the codeword "version" for now. :)
