### PR TITLE
Fix wezterm.plugin.require giving an access denied error on Windows when it has to checkout a repository

### DIFF
--- a/lua-api-crates/plugin/src/lib.rs
+++ b/lua-api-crates/plugin/src/lib.rs
@@ -143,7 +143,7 @@ impl RepoSpec {
         std::fs::create_dir_all(&plugins_dir)?;
         let target_dir = TempDir::new_in(&plugins_dir)?;
         log::debug!("Cloning {} into temporary dir {target_dir:?}", self.url);
-        let _repo = Repository::clone_recurse(&self.url, target_dir.path())?;
+        Repository::clone_recurse(&self.url, target_dir.path())?;
         let target_dir = target_dir.into_path();
         let checkout_path = self.checkout_path();
         match std::fs::rename(&target_dir, &checkout_path) {


### PR DESCRIPTION
~~`std::fs::rename` gives an access denied error on windows when trying to rename a directory so instead recursively copy the files and create the necessary directories.~~

~~Removing the temporary directory for some reason still gives an error, but this isn't fatal, as it can just be removed by the user manually.~~

~~the `copy_dir` function should probably be moved to someplace better suited, though unsure where that would be so I just placed it at the top of the file to start.
I did find the [copy_dir crate](https://docs.rs/copy_dir/0.1.2/copy_dir/), however it has an awkward API and didn't seem to work properly (it would overflow the stack anytime I tried to use it).~~

Turns out the underlying cause is that git2 keeps an handle to one of the files in the repository struct, and just dropping it before trying to rename makes it succeed. I have force pushed over the old commit, since there wasn't anything of value in it.


