### PR TITLE
Fix sftp::FilePermissions::is_readonly to properly report readonly status

### DIFF
--- a/wezterm-ssh/src/sftp/types.rs
+++ b/wezterm-ssh/src/sftp/types.rs
@@ -91,8 +91,9 @@ pub struct FilePermissions {
 }
 
 impl FilePermissions {
+    /// Returns true if all write permissions (owner, group, other) are false.
     pub fn is_readonly(self) -> bool {
-        !(self.owner_read || self.group_read || self.other_read)
+        !(self.owner_write || self.group_write || self.other_write)
     }
 
     /// Create from a unix mode bitset


### PR DESCRIPTION
@wez I must have been asleep when I wrote this function because it's checking the wrong flags. We want it to see if any of the write permissions are set. If they are, then this is not readonly, otherwise it is. This is how the [std lib does it for Unix platforms](https://github.com/rust-lang/rust/blob/1a5f8bce74ee432f7cc3aa131bc3d6920e06de10/library/std/src/sys/unix/fs.rs#L570).