### PR TITLE
feat: handle horizontal mousewheel events

### DIFF
--- a/mux/src/termwiztermtab.rs
+++ b/mux/src/termwiztermtab.rs
@@ -232,6 +232,8 @@ impl Pane for TermWizTerminalPane {
             MouseButton::Right => Buttons::RIGHT,
             MouseButton::WheelUp(_) => Buttons::VERT_WHEEL | Buttons::WHEEL_POSITIVE,
             MouseButton::WheelDown(_) => Buttons::VERT_WHEEL,
+            MouseButton::WheelLeft(_) => Buttons::HORZ_WHEEL | Buttons::WHEEL_POSITIVE,
+            MouseButton::WheelRight(_) => Buttons::HORZ_WHEEL,
             MouseButton::None => Buttons::NONE,
         };
 

--- a/term/src/input.rs
+++ b/term/src/input.rs
@@ -20,6 +20,8 @@ pub enum MouseButton {
     Right,
     WheelUp(usize),
     WheelDown(usize),
+    WheelLeft(usize),
+    WheelRight(usize),
     None,
 }
 

--- a/term/src/terminalstate/mouse.rs
+++ b/term/src/terminalstate/mouse.rs
@@ -56,6 +56,8 @@ impl TerminalState {
             MouseButton::Right => 2,
             MouseButton::WheelUp(_) => 64,
             MouseButton::WheelDown(_) => 65,
+            MouseButton::WheelLeft(_) => 66,
+            MouseButton::WheelRight(_) => 67,
         };
 
         if event.modifiers.contains(KeyModifiers::SHIFT) {
@@ -123,6 +125,8 @@ impl TerminalState {
                     match event.button {
                         MouseButton::WheelDown(_) => KeyCode::DownArrow,
                         MouseButton::WheelUp(_) => KeyCode::UpArrow,
+                        MouseButton::WheelLeft(_) => KeyCode::LeftArrow,
+                        MouseButton::WheelRight(_) => KeyCode::RightArrow,
                         _ => bail!("unexpected mouse event"),
                     },
                     KeyModifiers::default(),
@@ -328,12 +332,11 @@ impl TerminalState {
         match event {
             MouseEvent {
                 kind: MouseEventKind::Press,
-                button: MouseButton::WheelUp(_),
-                ..
-            }
-            | MouseEvent {
-                kind: MouseEventKind::Press,
-                button: MouseButton::WheelDown(_),
+                button:
+                    MouseButton::WheelUp(_)
+                    | MouseButton::WheelDown(_)
+                    | MouseButton::WheelLeft(_)
+                    | MouseButton::WheelRight(_),
                 ..
             } => self.mouse_wheel(event),
             MouseEvent {

--- a/wezterm-client/src/pane/mousestate.rs
+++ b/wezterm-client/src/pane/mousestate.rs
@@ -48,6 +48,14 @@ impl MouseState {
                         last.button = MouseButton::WheelDown(a + b);
                         return;
                     }
+                    (MouseButton::WheelLeft(a), MouseButton::WheelLeft(b)) => {
+                        last.button = MouseButton::WheelLeft(a + b);
+                        return;
+                    }
+                    (MouseButton::WheelRight(a), MouseButton::WheelRight(b)) => {
+                        last.button = MouseButton::WheelRight(a + b);
+                        return;
+                    }
                     _ => {}
                 }
             }

--- a/wezterm-gui/src/termwindow/mouseevent.rs
+++ b/wezterm-gui/src/termwindow/mouseevent.rs
@@ -888,7 +888,17 @@ impl super::TermWindow {
                     button: MouseButton::WheelDown(-amount as usize),
                 },
             }),
-            WMEK::HorzWheel(_) => None,
+            WMEK::HorzWheel(amount) => Some(match *amount {
+                0 => return,
+                1.. => MouseEventTrigger::Down {
+                    streak: 1,
+                    button: MouseButton::WheelLeft(*amount as usize),
+                },
+                _ => MouseEventTrigger::Down {
+                    streak: 1,
+                    button: MouseButton::WheelRight(-amount as usize),
+                },
+            }),
         };
 
         if allow_action {
@@ -921,17 +931,26 @@ impl super::TermWindow {
                     MouseEventTrigger::Down {
                         ref mut streak,
                         button:
-                            MouseButton::WheelUp(ref mut delta) | MouseButton::WheelDown(ref mut delta),
+                            MouseButton::WheelUp(ref mut delta)
+                            | MouseButton::WheelDown(ref mut delta)
+                            | MouseButton::WheelLeft(ref mut delta)
+                            | MouseButton::WheelRight(ref mut delta),
                     }
                     | MouseEventTrigger::Up {
                         ref mut streak,
                         button:
-                            MouseButton::WheelUp(ref mut delta) | MouseButton::WheelDown(ref mut delta),
+                            MouseButton::WheelUp(ref mut delta)
+                            | MouseButton::WheelDown(ref mut delta)
+                            | MouseButton::WheelLeft(ref mut delta)
+                            | MouseButton::WheelRight(ref mut delta),
                     }
                     | MouseEventTrigger::Drag {
                         ref mut streak,
                         button:
-                            MouseButton::WheelUp(ref mut delta) | MouseButton::WheelDown(ref mut delta),
+                            MouseButton::WheelUp(ref mut delta)
+                            | MouseButton::WheelDown(ref mut delta)
+                            | MouseButton::WheelLeft(ref mut delta)
+                            | MouseButton::WheelRight(ref mut delta),
                     } => {
                         *streak = 1;
                         *delta = 1;
@@ -982,7 +1001,13 @@ impl super::TermWindow {
                         TMB::WheelDown((-amount) as usize)
                     }
                 }
-                WMEK::HorzWheel(_) => TMB::None,
+                WMEK::HorzWheel(amount) => {
+                    if amount > 0 {
+                        TMB::WheelLeft(amount as usize)
+                    } else {
+                        TMB::WheelRight((-amount) as usize)
+                    }
+                }
             },
             x: column,
             y: row,


### PR DESCRIPTION
My apologies as this is a rough PR and I'll admit that I'm not sure I fully understand 100% of the code I touched. I don't *think* this is breaking anything though, and it enables horizontal scrolling as far as I've tested (it works in neovim).

There's a `TODO` left about the values in `mouse_report_button_number` as I really had no idea what to put there, so I simply incremented the other values. It seems to work but I don't know if that's correct, and I couldn't find any reference anywhere about this.