### PR TITLE
Fix copy mode on Wayland

### DIFF
--- a/window/src/os/wayland/pointer.rs
+++ b/window/src/os/wayland/pointer.rs
@@ -141,10 +141,8 @@ impl PendingMouse {
     pub fn queue(&mut self, evt: PointerEvent) -> bool {
         match evt {
             PointerEvent::Enter { serial, .. } => {
-                self.copy_and_paste
-                    .lock()
-                    .unwrap()
-                    .update_last_serial(serial);
+                let conn = WaylandConnection::get().unwrap().wayland();
+                *conn.last_serial.borrow_mut() = serial;
                 self.in_window = true;
                 false
             }
@@ -169,10 +167,8 @@ impl PendingMouse {
                 serial,
                 ..
             } => {
-                self.copy_and_paste
-                    .lock()
-                    .unwrap()
-                    .update_last_serial(serial);
+                let conn = WaylandConnection::get().unwrap().wayland();
+                *conn.last_serial.borrow_mut() = serial;
                 fn linux_button(b: u32) -> Option<MousePress> {
                     // See BTN_LEFT and friends in <linux/input-event-codes.h>
                     match b {

--- a/window/src/os/wayland/window.rs
+++ b/window/src/os/wayland/window.rs
@@ -1176,8 +1176,8 @@ impl WaylandWindowInner {
 
     fn request_drag_move(&self) {
         if let Some(window) = self.window.as_ref() {
-            let serial = self.copy_and_paste.lock().unwrap().last_serial;
             let conn = Connection::get().unwrap().wayland();
+            let serial = *conn.last_serial.borrow();
             window.start_interactive_move(&conn.pointer.borrow().seat, serial);
         }
     }


### PR DESCRIPTION
On Wayland, copy mode often doesn't actually update the clipboard. Specifically, it only works one time after a pointer enter or pointer button event, then doesn't work again until the next event.

This is because the Wayland protocol serial number in CopyAndPaste::last_serial is only updated by pointer enter and pointer button events. So, subsequent copies using only the keyboard reuse the same serial number and get ignored. last_serial used to be updated for keyboard events, too, but that was (accidentally?) dropped in commit 0a00ffe98b11546c5fdecca8a77dd72cc609db9c.

Commit 0a00ffe98b11546c5fdecca8a77dd72cc609db9c also added another last_serial to WaylandConnection which is updated for keyboard events but isn't used anywhere as far as I can tell.

So, to fix this bug, let's get rid of CopyAndPaste::last_serial and replace it with WaylandConnection::last_serial, which is now updated for pointer and keyboard events.

closes: #3843