### PR TITLE
Doc update: Source install's cargo build option

### DIFF
--- a/docs/install/source.md
+++ b/docs/install/source.md
@@ -49,7 +49,7 @@ If your distribution has X11 but not Wayland, then you can build WezTerm without
 Wayland support by changing the `build` invocation:
 
 ```console
-$ cargo build --release --no-default-features vendored-fonts
+$ cargo build --release --no-default-features --features distro-defaults,vendored-fonts
 ```
 
 Building without X11 is not supported.


### PR DESCRIPTION
This is documentation/blog update. 
Updated installation for source/UNIX update. 

Syncing with `README-DISTRO-MAINTAINER.md` .