### PR TITLE
ssh: apply HostKeyAlgorithms in ssh config

### DIFF
--- a/wezterm-ssh/src/sessioninner.rs
+++ b/wezterm-ssh/src/sessioninner.rs
@@ -201,6 +201,9 @@ impl SessionInner {
         if let Some(bind_addr) = self.config.get("bindaddress") {
             sess.set_option(libssh_rs::SshOption::BindAddress(bind_addr.to_string()))?;
         }
+        if let Some(host_key) = self.config.get("hostkeyalgorithms") {
+            sess.set_option(libssh_rs::SshOption::HostKeys(host_key.to_string()))?;
+        }
 
         let sock =
             self.connect_to_host(&hostname, port, verbose, self.config.get("proxycommand"))?;


### PR DESCRIPTION
Some ssh servers may only support certain key algorithms, so wezterm needs to use HostKeyAlgorithms in the ssh configuration file for the cryptographic handshake.