### PR TITLE
Fixes #4035: Make hyperlink rule match links that contain emojis

### DIFF
--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -1622,7 +1622,7 @@ pub fn default_hyperlink_rules() -> Vec<hyperlink::Rule> {
         hyperlink::Rule::with_highlight(r"<(\w+://\S+)>", "$1", 1).unwrap(),
         // Then handle URLs not wrapped in brackets
         // and include terminating ), / or - characters, if any
-        hyperlink::Rule::new(r"\b\w+://\S+[)/a-zA-Z0-9-]+", "$0").unwrap(),
+        hyperlink::Rule::new(r"\b\w+://\S+[)/a-zA-Z0-9-]+?(?=[\s]|$)", "$0").unwrap(),
         // implicit mailto link
         hyperlink::Rule::new(r"\b\w+@[\w-]+(\.[\w-]+)+\b", "mailto:$0").unwrap(),
     ]


### PR DESCRIPTION
The other hyperlink rules (for links in brackets, etc.) have a lot of redundancy and actually use a simpler version of the link detection regex.

I haven’t updated those as making the regular expressions consistent should ideally be a separate issue and pull request.