### PR TITLE
docs: fix building without wayland command

### DIFF
--- a/docs/install/source.md
+++ b/docs/install/source.md
@@ -49,7 +49,7 @@ If your distribution has X11 but not Wayland, then you can build WezTerm without
 Wayland support by changing the `build` invocation:
 
 ```console
-$ cargo build --release --no-default-features vendored-fonts
+$ cargo build --release --no-default-features --features vendored-fonts
 ```
 
 Building without X11 is not supported.


### PR DESCRIPTION
The command provided to build from source without Wayland support is malformed:

```console
$ cargo build --release --no-default-features vendored-fonts
error: unexpected argument 'vendored-fonts' found
```

I think the intent was to disable default features and add the `vendored-fonts` feature, so I added the `--features` flag.