### PR TITLE
EnumVariant/Enum<T>: Data race allowed on T

### DIFF
--- a/luahelper/src/enumctor.rs
+++ b/luahelper/src/enumctor.rs
@@ -14,7 +14,7 @@ struct EnumVariant<T> {
 
 // Safety: <T> is used only in PhantomData so it doesn't actually
 // need to be Send.
-unsafe impl<T> Send for EnumVariant<T> {}
+unsafe impl<T: Send> Send for EnumVariant<T> {}
 
 impl<T> EnumVariant<T>
 where
@@ -99,7 +99,7 @@ pub struct Enum<T> {
 
 // Safety: <T> is used only in PhantomData so it doesn't actually
 // need to be Send.
-unsafe impl<T> Send for Enum<T> {}
+unsafe impl<T: Send> Send for Enum<T> {}
 
 impl<T> Enum<T> {
     pub fn new() -> Self {


### PR DESCRIPTION
Hi,
I found a memory-safety/soundness issue in this crate while scanning Rust code for potential vulnerabilities. This PR contains a fix for the issue.

# Issue Description
`EnumVariant<T>` unconditionally implements Sync. This allows users to create data races on `T: !Sync`. Such data races can lead to undefined behavior.
https://github.com/wez/wezterm/blob/a7c6ea8c1ed93396bd2c3d6cd0e99119a2c8bdd9/luahelper/src/enumctor.rs#L17

same 
https://github.com/wez/wezterm/blob/a7c6ea8c1ed93396bd2c3d6cd0e99119a2c8bdd9/luahelper/src/enumctor.rs#L102