### PR TITLE
x11: Use modifiers from X event if none were detected by XKB

### DIFF
--- a/window/src/os/wayland/window.rs
+++ b/window/src/os/wayland/window.rs
@@ -467,12 +467,12 @@ impl WaylandWindowInner {
             } => {
                 mapper.update_modifier_state(mods_depressed, mods_latched, mods_locked, group);
 
-                let mods = mapper.get_key_modifiers();
+                let mods = mapper.get_key_modifiers(None);
                 let leds = mapper.get_led_status();
 
                 let changed = (mods != self.modifiers) || (leds != self.leds);
 
-                self.modifiers = mapper.get_key_modifiers();
+                self.modifiers = mapper.get_key_modifiers(None);
                 self.leds = mapper.get_led_status();
 
                 if changed {


### PR DESCRIPTION
This is a working tentative at fixing text expansion/injection done by Espanso by default, where XKB doesn't seem to detect the pressed modifiers `Ctrl+Shift` before pressing `v`.

ref: https://github.com/wez/wezterm/issues/3840#issuecomment-1677974127 (and following comments)

(( So with this patch, XKB's state is not updated and the key event' modifiers are kind of transient: only existing for this event. ))

Edit: waiting for your input on https://github.com/wez/wezterm/issues/3840#issuecomment-1680087150 