### PR TITLE
Add zoom-pane subcommand

### DIFF
--- a/mux/src/tab.rs
+++ b/mux/src/tab.rs
@@ -745,6 +745,10 @@ impl Tab {
             .lock()
             .split_and_insert(pane_index, request, pane)
     }
+
+    pub fn get_zoomed_pane(&self) -> Option<Arc<dyn Pane>> {
+        self.inner.lock().get_zoomed_pane()
+    }
 }
 
 impl TabInner {
@@ -2050,6 +2054,10 @@ impl TabInner {
         } else {
             pane_index
         })
+    }
+
+    fn get_zoomed_pane(&self) -> Option<Arc<dyn Pane>> {
+        self.zoomed.clone()
     }
 }
 

--- a/wezterm-mux-server-impl/src/sessionhandler.rs
+++ b/wezterm-mux-server-impl/src/sessionhandler.rs
@@ -532,10 +532,23 @@ impl SessionHandler {
                             let tab = mux
                                 .get_tab(containing_tab_id)
                                 .ok_or_else(|| anyhow!("no such tab {}", containing_tab_id))?;
-                            tab.set_zoomed(false);
-                            if zoomed {
-                                tab.set_active_pane(&pane);
-                                tab.set_zoomed(zoomed);
+                            match tab.get_zoomed_pane() {
+                                Some(p) => {
+                                    let is_zoomed = p.pane_id() == pane_id;
+                                    if is_zoomed != zoomed {
+                                        tab.set_zoomed(false);
+                                        if zoomed {
+                                            tab.set_active_pane(&pane);
+                                            tab.set_zoomed(zoomed);
+                                        }
+                                    }
+                                }
+                                None => {
+                                    if zoomed {
+                                        tab.set_active_pane(&pane);
+                                        tab.set_zoomed(zoomed);
+                                    }
+                                }
                             }
                             Ok(Pdu::UnitResponse(UnitResponse {}))
                         },

--- a/wezterm-mux-server-impl/src/sessionhandler.rs
+++ b/wezterm-mux-server-impl/src/sessionhandler.rs
@@ -532,8 +532,11 @@ impl SessionHandler {
                             let tab = mux
                                 .get_tab(containing_tab_id)
                                 .ok_or_else(|| anyhow!("no such tab {}", containing_tab_id))?;
-                            tab.set_active_pane(&pane);
-                            tab.set_zoomed(zoomed);
+                            tab.set_zoomed(false);
+                            if zoomed {
+                                tab.set_active_pane(&pane);
+                                tab.set_zoomed(zoomed);
+                            }
                             Ok(Pdu::UnitResponse(UnitResponse {}))
                         },
                         send_response,
@@ -1021,7 +1024,7 @@ async fn split_pane(split: SplitPane, client_id: Option<Arc<ClientId>>) -> anyho
 
     Ok::<Pdu, anyhow::Error>(Pdu::SpawnResponse(SpawnResponse {
         pane_id: pane.pane_id(),
-        tab_id: tab_id,
+        tab_id,
         window_id,
         size,
     }))

--- a/wezterm/src/cli/mod.rs
+++ b/wezterm/src/cli/mod.rs
@@ -22,6 +22,7 @@ mod set_window_title;
 mod spawn_command;
 mod split_pane;
 mod tls_creds;
+mod zoom_pane;
 
 #[derive(Debug, Parser, Clone, Copy)]
 enum CliOutputFormatKind {
@@ -159,6 +160,10 @@ Outputs the pane-id for the newly created pane on success"
     /// Rename a workspace
     #[command(name = "rename-workspace", rename_all = "kebab")]
     RenameWorkspace(rename_workspace::RenameWorkspace),
+
+    /// Zoom, unzoom, or toggle zoom state
+    #[command(name = "zoom-pane", rename_all = "kebab")]
+    ZoomPane(zoom_pane::ZoomPane),
 }
 
 async fn run_cli_async(opts: &crate::Opt, cli: CliCommand) -> anyhow::Result<()> {
@@ -194,6 +199,7 @@ async fn run_cli_async(opts: &crate::Opt, cli: CliCommand) -> anyhow::Result<()>
         CliSubCommand::SetTabTitle(cmd) => cmd.run(client).await,
         CliSubCommand::SetWindowTitle(cmd) => cmd.run(client).await,
         CliSubCommand::RenameWorkspace(cmd) => cmd.run(client).await,
+        CliSubCommand::ZoomPane(cmd) => cmd.run(client).await,
     }
 }
 

--- a/wezterm/src/cli/zoom_pane.rs
+++ b/wezterm/src/cli/zoom_pane.rs
@@ -1,0 +1,109 @@
+use crate::cli::resolve_pane_id;
+use anyhow::{anyhow, Result};
+use clap::Parser;
+use codec::SetPaneZoomed;
+use mux::pane::PaneId;
+use std::collections::HashMap;
+use wezterm_client::client::Client;
+
+#[derive(Debug, Parser, Clone)]
+pub struct ZoomPane {
+    /// Specify the target pane.
+    /// The default is to use the current pane based on the
+    /// environment variable WEZTERM_PANE.
+    #[arg(long)]
+    pane_id: Option<PaneId>,
+
+    /// Zooms the pane if it wasn't already zoomed
+    #[arg(long, default_value = "true", conflicts_with_all=&["unzoom", "toggle"])]
+    zoom: bool,
+
+    /// Unzooms the pane if it was zoomed
+    #[arg(long, conflicts_with_all=&["zoom", "toggle"])]
+    unzoom: bool,
+
+    /// Toggles the zoom state of the pane
+    #[arg(long, conflicts_with_all=&["zoom", "unzoom"])]
+    toggle: bool,
+}
+
+impl ZoomPane {
+    pub async fn run(&self, client: Client) -> Result<()> {
+        let panes = client.list_panes().await?;
+
+        let mut pane_id_to_tab_id = HashMap::new();
+        let mut tab_id_to_active_zoomed_pane_id = HashMap::new();
+
+        for tabroot in panes.tabs {
+            let mut cursor = tabroot.into_tree().cursor();
+
+            loop {
+                if let Some(entry) = cursor.leaf_mut() {
+                    pane_id_to_tab_id.insert(entry.pane_id, entry.tab_id);
+                    if entry.is_active_pane && entry.is_zoomed_pane {
+                        tab_id_to_active_zoomed_pane_id.insert(entry.tab_id, entry.pane_id);
+                    }
+                }
+                match cursor.preorder_next() {
+                    Ok(c) => cursor = c,
+                    Err(_) => break,
+                }
+            }
+        }
+
+        let pane_id = resolve_pane_id(&client, self.pane_id).await?;
+        let containing_tab_id = pane_id_to_tab_id
+            .get(&pane_id)
+            .copied()
+            .ok_or_else(|| anyhow!("unable to resolve current tab"))?;
+
+        if self.zoom {
+            client
+                .set_zoomed(SetPaneZoomed {
+                    containing_tab_id,
+                    pane_id,
+                    zoomed: true,
+                })
+                .await?;
+        }
+
+        if self.unzoom {
+            client
+                .set_zoomed(SetPaneZoomed {
+                    containing_tab_id,
+                    pane_id,
+                    zoomed: false,
+                })
+                .await?;
+        }
+
+        if self.toggle {
+            if tab_id_to_active_zoomed_pane_id.contains_key(&containing_tab_id) {
+                let target_pane = tab_id_to_active_zoomed_pane_id
+            .get(&containing_tab_id)
+            .copied()
+            .ok_or_else(|| {
+                anyhow!("could not determine which pane should be active for tab {containing_tab_id}")
+            })?;
+                if target_pane == pane_id {
+                    client
+                        .set_zoomed(SetPaneZoomed {
+                            containing_tab_id,
+                            pane_id,
+                            zoomed: false,
+                        })
+                        .await?;
+                }
+            } else {
+                client
+                    .set_zoomed(SetPaneZoomed {
+                        containing_tab_id,
+                        pane_id,
+                        zoomed: true,
+                    })
+                    .await?;
+            }
+        }
+        Ok(())
+    }
+}


### PR DESCRIPTION
Hi,

I'm currently working on integrating Helix with WezTerm to perform [interactive global search](https://github.com/helix-editor/helix/issues/196).

The mechanism I'm implementing involves sending a command to the bottom pane when a key is presseed:

```sh
case "$1" in
  "fzf")
    split_pane_down
    echo "hx-fzf.sh \$(rg --line-number --column --no-heading --smart-case . | fzf --delimiter : --preview 'bat --style=full --color=always --highlight-line {2} {1}' --preview-window '~3,+{2}+3/2' | awk '{ print \$1 }' | cut -d: -f1,2,3)" | $send_to_bottom_pane
    ;;
```

Once a selection is made, the file will be opened by Helix in the top pane. Now I want to hide the bottom pane but looks like WezTerm [does not support](https://github.com/wez/wezterm/discussions/3779) this functionality.

While I'm aware that it's possible to bind a key to [toggle the zoom state](https://wezfurlong.org/wezterm/config/lua/keyassignment/TogglePaneZoomState.html) of the top pane, this requires an additional key press. Furthermore, I'm looking to avoid the option of [killing](https://wezfurlong.org/wezterm/cli/cli/kill-pane.html) the bottom pane.

Thus, this PR has been initiated to introduce a CLI-based method for toggling the zoom state of the current pane.