### PR TITLE
Add shell completion for homebrew installation

### DIFF
--- a/ci/deploy.sh
+++ b/ci/deploy.sh
@@ -34,6 +34,7 @@ case $OSTYPE in
     mkdir -p $zipdir/WezTerm.app/Contents/MacOS
     mkdir -p $zipdir/WezTerm.app/Contents/Resources
     cp -r assets/shell-integration/* $zipdir/WezTerm.app/Contents/Resources
+    cp -r assets/shell-completion $zipdir/WezTerm.app/Contents/Resources
 
     for bin in wezterm wezterm-mux-server wezterm-gui strip-ansi-escapes ; do
       # If the user ran a simple `cargo build --release`, then we want to allow


### PR DESCRIPTION
This pull request aims to enable automatic shell completion during the Homebrew installation process, similar to [this reference](https://github.com/Homebrew/homebrew-cask/blob/eea987403640a663166ce93ecf03401840d90886/Casks/a/alacritty.rb#L17-L22). To achieve this, the pull request includes changes to incorporate shell completion scripts within the WezTerm.app.

related: https://github.com/wez/homebrew-wezterm/issues/7

Note:
Upon successful merging and release of this pull request, it will be necessary to add the following code to the Homebrew Formula:

```ruby
  binary "WezTerm.app/Contents/Resources/shell-completion/zsh",
         target: "#{HOMEBREW_PREFIX}/share/zsh/site-functions/_wezterm"
  binary "WezTerm.app/Contents/Resources/shell-completion/bash",
         target: "#{HOMEBREW_PREFIX}/etc/bash_completion.d/wezterm"
  binary "WezTerm.app/Contents/Resources/shell-completion/fish",
         target: "#{HOMEBREW_PREFIX}/share/fish/vendor_completions.d/wezterm.fish"
```