### PR TITLE
Add move_pane_id parameter to pane:split lua api

### DIFF
--- a/lua-api-crates/mux/src/pane.rs
+++ b/lua-api-crates/mux/src/pane.rs
@@ -424,6 +424,8 @@ struct SplitPane {
     top_level: bool,
     #[dynamic(default = "default_split_size")]
     size: f32,
+    #[dynamic(default)]
+    move_pane_id: Option<usize>,
 }
 impl_lua_conversion_dynamic!(SplitPane);
 
@@ -433,10 +435,14 @@ fn default_split_size() -> f32 {
 
 impl SplitPane {
     async fn run(&self, pane: &MuxPane) -> mlua::Result<MuxPane> {
-        let (command, command_dir) = self.cmd_builder.to_command_builder();
-        let source = SplitSource::Spawn {
-            command,
-            command_dir,
+        let source = if let Some(move_pane_id) = self.move_pane_id {
+            SplitSource::MovePane(move_pane_id)
+        } else {
+            let (command, command_dir) = self.cmd_builder.to_command_builder();
+            SplitSource::Spawn {
+                command,
+                command_dir,
+            }
         };
 
         let size = if self.size == 0.0 {


### PR DESCRIPTION
I took a stab at adding https://github.com/wez/wezterm/issues/4216 myself. It wasn't too hard, it also works as I expected. 

example config, `CTRL+a` will move pane id 0 to the split.

```lua
local wezterm = require('wezterm')
config = {}
config.keys = {
    { 
      key = "a", 
      mods = 'CTRL', 
      action = wezterm.action_callback(function(window, pane) 
            pane:split { move_pane_id = 0 }
        end), 
    }
}

return config
```