### PR TITLE
Plugin package path

### DIFF
--- a/config/src/lua.rs
+++ b/config/src/lua.rs
@@ -226,13 +226,14 @@ pub fn make_lua_context(config_file: &Path) -> anyhow::Result<Lua> {
             array.insert(0, format!("{}/?.lua", path.display()));
             array.insert(1, format!("{}/?/init.lua", path.display()));
         }
-
+        
+        prefix_path(&mut path_array, &crate::DATA_DIR.join("plugins"));
         prefix_path(&mut path_array, &crate::HOME_DIR.join(".wezterm"));
         for dir in crate::CONFIG_DIRS.iter() {
             prefix_path(&mut path_array, dir);
         }
         path_array.insert(
-            2,
+            4,
             format!("{}/plugins/?/plugin/init.lua", crate::DATA_DIR.display()),
         );
 

--- a/config/src/lua.rs
+++ b/config/src/lua.rs
@@ -226,7 +226,7 @@ pub fn make_lua_context(config_file: &Path) -> anyhow::Result<Lua> {
             array.insert(0, format!("{}/?.lua", path.display()));
             array.insert(1, format!("{}/?/init.lua", path.display()));
         }
-        
+
         prefix_path(&mut path_array, &crate::HOME_DIR.join(".wezterm"));
         prefix_path(&mut path_array, &crate::DATA_DIR.join("plugins"));
         for dir in crate::CONFIG_DIRS.iter() {

--- a/config/src/lua.rs
+++ b/config/src/lua.rs
@@ -227,13 +227,13 @@ pub fn make_lua_context(config_file: &Path) -> anyhow::Result<Lua> {
             array.insert(1, format!("{}/?/init.lua", path.display()));
         }
         
-        prefix_path(&mut path_array, &crate::DATA_DIR.join("plugins"));
         prefix_path(&mut path_array, &crate::HOME_DIR.join(".wezterm"));
+        prefix_path(&mut path_array, &crate::DATA_DIR.join("plugins"));
         for dir in crate::CONFIG_DIRS.iter() {
             prefix_path(&mut path_array, dir);
         }
         path_array.insert(
-            4,
+            2,
             format!("{}/plugins/?/plugin/init.lua", crate::DATA_DIR.display()),
         );
 


### PR DESCRIPTION
Related to #4150

Allows for wezterm plugins to require separate scripts besides `plugin/init.lua` in the repository. 

An example plugin is available: [oscarcederberg/plugin-package-path.wezterm](https://github.com/oscarcederberg/plugin-package-path.wezterm/tree/main).\
With this change, including the plugin will run the following scripts:\
`<PLUGIN_DIR>/plugin/init.lua -> <PLUGIN_DIR>/other_module/init.lua -> <PLUGIN_DIR>/other_module/other_script.lua`.

Adds `<DATA_DIR>/?/.init.lua` and `<DATA_DIR>/?.lua` as searchable package paths. The package path is now in this order on a laptop running Linux (logged by calling `wezterm.log_info(package.path)`, formatted for readability):
```
<HOME_DIR>/.config/wezterm/?.lua;
<HOME_DIR>/.config/wezterm/?/init.lua;
<HOME_DIR>/.local/share/wezterm/plugins/?/plugin/init.lua;
<HOME_DIR>/.local/share/wezterm/plugins/?.lua;             <-- Inserted
<HOME_DIR>/.local/share/wezterm/plugins/?/init.lua;        <-- Inserted
<HOME_DIR>/.wezterm/?.lua;
<HOME_DIR>/.wezterm/?/init.lua;
/usr/local/share/lua/5.4/?.lua;
/usr/local/share/lua/5.4/?/init.lua;
/usr/local/lib/lua/5.4/?.lua;
/usr/local/lib/lua/5.4/?/init.lua;
./?.lua;./?/init.lua
```

I didn't find myself anywhere appropriate to document this change in the code. I also tried running all tests, but my laptop doesn't seem to be able to handle them and freezes unfortunately.

Kind regards! :smiley: 