### PR TITLE
Added spawn_command_as_user to allow user impersonation when spawning processes into the Pty

### DIFF
--- a/pty/src/lib.rs
+++ b/pty/src/lib.rs
@@ -163,6 +163,13 @@ impl_downcast!(ChildKiller);
 pub trait SlavePty {
     /// Spawns the command specified by the provided CommandBuilder
     fn spawn_command(&self, cmd: CommandBuilder) -> Result<Box<dyn Child + Send + Sync>, Error>;
+    /// Spawns a command in the security context of the primary token passed as the h_token parameter
+    #[cfg(windows)]
+    fn spawn_command_as_user(
+        &self,
+        cmd: CommandBuilder,
+        h_token: &winapi::um::winnt::HANDLE,
+    ) -> Result<Box<dyn Child + Send + Sync>, Error>;
 }
 
 /// Represents the exit status of a child process.

--- a/pty/src/serial.rs
+++ b/pty/src/serial.rs
@@ -116,6 +116,17 @@ impl SlavePty for Slave {
             port: Arc::clone(&self.port),
         }))
     }
+        /// Spawns a command in the security context of the primary token
+    #[cfg(windows)]
+    fn spawn_command_as_user(&self, cmd: CommandBuilder, h_token: &winapi::um::winnt::HANDLE) -> anyhow::Result<Box<dyn Child + Send + Sync>> {
+        ensure!(
+            cmd.is_default_prog(),
+            "can only use default prog commands with serial tty implementations"
+        );
+        Ok(Box::new(SerialChild {
+            port: Arc::clone(&self.port),
+        }))
+    }
 }
 
 /// There isn't really a child process on the end of the serial connection,

--- a/pty/src/win/conpty.rs
+++ b/pty/src/win/conpty.rs
@@ -114,4 +114,13 @@ impl SlavePty for ConPtySlavePty {
         let child = inner.con.spawn_command(cmd)?;
         Ok(Box::new(child))
     }
+    fn spawn_command_as_user(
+            &self,
+            cmd: CommandBuilder,
+            h_token: &winapi::um::winnt::HANDLE,
+        ) -> Result<Box<dyn Child + Send + Sync>, Error> {
+            let inner = self.inner.lock().unwrap();
+            let child = inner.con.spawn_command_as_user(cmd, h_token.clone())?;
+            Ok(Box::new(child))
+    }
 }


### PR DESCRIPTION
Recently, I came across a scenario where I needed to be able to spawn processes into the Pty under different security contexts/user accounts using portable_pty.

I've added the method spawn_command_as_user to allow for user impersonation using the CreateProcessAsUser. Either a primary or impersonation token can be supplied parameter. CreateProcessAsUser requires both SeIncreaseQuotaPrivilege and SeAssignPrimaryTokenPrivileges user rights to be enabled on the calling process.