### PR TITLE
Fix example comment about switching zero for Fira fonts

### DIFF
--- a/docs/config/font-shaping.md
+++ b/docs/config/font-shaping.md
@@ -46,7 +46,7 @@ it lists available stylistic sets here:
 and you can set them in wezterm:
 
 ```lua
--- Use this for a zero with a dot rather than a line through it
+-- Use this for a zero with a line through it rather than a dot
 -- when using the Fira Code font
 config.harfbuzz_features = { 'zero' }
 ```


### PR DESCRIPTION
I noticed that the comment about switching the form of the digit zero for Fira Mono and Fira Code is reversed from the actual behavior: the default is with the dot, not the line.