### PR TITLE
fix: clarify the docs for default `font_size`

### DIFF
--- a/docs/config/lua/config/font_size.md
+++ b/docs/config/lua/config/font_size.md
@@ -11,6 +11,3 @@ You may use fractional point sizes, such as `13.3`, to fine tune the size.
 The default font size is `10.0` points.
 
 {{since('20210314-114017-04b7cedd')}}
-
-The default font size is now `12.0` points.
-


### PR DESCRIPTION
Not quite sure but this has confused me a couple times.
So I think we should clean this up, I am not sure if just removing it is enough but let me know what else it should be refactored to.