### PR TITLE
wayland: update SCTK to fix startup on newer compositors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4843,9 +4843,9 @@ checksum = "f67ad224767faa3c7d8b6d91985b78e70a1324408abcb1cfcc2be4c06bc06043"
 
 [[package]]
 name = "smithay-client-toolkit"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f307c47d32d2715eb2e0ece5589057820e0e5e70d07c247d1063e844e107f454"
+checksum = "870427e30b8f2cbe64bf43ec4b86e88fe39b0a84b3f15efd9c9c2d020bc86eb9"
 dependencies = [
  "bitflags 1.3.2",
  "dlib",

--- a/window/Cargo.toml
+++ b/window/Cargo.toml
@@ -75,7 +75,7 @@ xcb = {version="1.2", features=["render", "randr", "dri2", "xkb", "xlib_xcb", "p
 xkbcommon = { version = "0.5.0", features = ["x11", "wayland"] }
 mio = {version="0.8", features=["os-ext"]}
 libc = "0.2"
-smithay-client-toolkit = {version = "0.16", default-features=false, optional=true}
+smithay-client-toolkit = {version = "0.16.1", default-features=false, optional=true}
 wayland-protocols = {version="0.29", optional=true}
 wayland-client = {version="0.29", optional=true}
 wayland-egl = {version="0.29", optional=true}


### PR DESCRIPTION
Fixes #3996.

With this change, wezterm is now able to start in Wayland mode on Plasma 6.