### PR TITLE
Expose pen attribute on terminal info

### DIFF
--- a/term/src/terminalstate/mod.rs
+++ b/term/src/terminalstate/mod.rs
@@ -929,6 +929,11 @@ impl TerminalState {
         }
     }
 
+    /// Returns the current cell attributes of the screen
+    pub fn pen(&self) -> CellAttributes {
+        self.pen.clone()
+    }
+
     pub fn user_vars(&self) -> &HashMap<String, String> {
         &self.user_vars
     }


### PR DESCRIPTION
Resolves https://github.com/wez/wezterm/issues/4230 by exposing `pen` on `TerminalState`