### PR TITLE
basename, dirname and canonical_path addition.

### DIFF
--- a/docs/config/lua/wezterm/basename.md
+++ b/docs/config/lua/wezterm/basename.md
@@ -24,7 +24,7 @@ from Rust's [`std::path::PathBuf`](https://doc.rust-lang.org/nightly/std/path/st
 local wezterm = require 'wezterm'
 local basename = wezterm.basename
 
-wezterm.log_info('baz.txt' == basename '/foo/bar/baz.txt')
+assert('baz.txt' == basename '/foo/bar/baz.txt')
 ```
 
 See also [dirname](dirname.md).

--- a/docs/config/lua/wezterm/basename.md
+++ b/docs/config/lua/wezterm/basename.md
@@ -24,7 +24,7 @@ from Rust's [`std::path::PathBuf`](https://doc.rust-lang.org/nightly/std/path/st
 local wezterm = require 'wezterm'
 local basename = wezterm.basename
 
-wezterm.log_info( 'baz.txt = ' .. basename '/foo/bar/baz.txt' )
+wezterm.log_info('baz.txt = ' .. basename '/foo/bar/baz.txt')
 ```
 
 See also [dirname](dirname.md).

--- a/docs/config/lua/wezterm/basename.md
+++ b/docs/config/lua/wezterm/basename.md
@@ -24,7 +24,7 @@ from Rust's [`std::path::PathBuf`](https://doc.rust-lang.org/nightly/std/path/st
 local wezterm = require 'wezterm'
 local basename = wezterm.basename
 
-wezterm.log_info('baz.txt = ' .. basename '/foo/bar/baz.txt')
+wezterm.log_info('baz.txt' == basename '/foo/bar/baz.txt')
 ```
 
 See also [dirname](dirname.md).

--- a/docs/config/lua/wezterm/basename.md
+++ b/docs/config/lua/wezterm/basename.md
@@ -1,0 +1,30 @@
+---
+title: wezterm.basename
+tags:
+ - utility
+ - filesystem
+---
+# `wezterm.basename(path)`
+
+{{since('nightly')}}
+
+This function returns a string containing the basename of the given path.
+The function does not check whether the given path actually exists.
+Due to limitations in the lua bindings, all of the paths
+must be able to be represented as UTF-8 or this function will generate an
+error.
+
+Note: This function is similar to the shell command basename, but it behaves
+slightly different in some edge case. E.g. `wezterm.basename 'foo.txt/.//'`
+returns `'foo.txt` since trailing `/`s are ignored and so is one `.`.
+But `wezterm.basename 'foo.txt/..'` returns `'..'`. This behaviour comes
+from Rust's [`std::path::PathBuf`](https://doc.rust-lang.org/nightly/std/path/struct.PathBuf.html#method.file_name).
+
+```lua
+local wezterm = require 'wezterm'
+local basename = wezterm.basename
+
+wezterm.log_info( 'baz.txt = ' .. basename '/foo/bar/baz.txt' )
+```
+
+See also [dirname](dirname.md).

--- a/docs/config/lua/wezterm/canonical_path.md
+++ b/docs/config/lua/wezterm/canonical_path.md
@@ -1,0 +1,37 @@
+---
+title: wezterm.canonical_path
+tags:
+ - utility
+ - filesystem
+---
+# `wezterm.canonical_path(path)`
+
+{{since('nightly')}}
+
+This function returns a string with the canonical form of a path if it exists.
+The returned path is in absolute form with all intermediate components normalized
+and symbolic links resolved.
+Due to limitations in the lua bindings, all of the paths
+must be able to be represented as UTF-8 or this function will generate an
+error.
+
+The function can for example be used get the correct absolute path for a path
+in a different format.
+```lua
+local wezterm = require 'wezterm'
+local canonical_path = wezterm.canonical_path
+
+wezterm.log_error( wezterm.home_dir .. ' = ' canonical_path( wezterm.home_dir .. "/.") )
+```
+
+Another common use case is to find the absolute path of a symlink. E.g., Dropbox is usually
+symlinked to `$HOME/Dropbox` on macOS, but is located at `$HOME/Library/CloudStorage/Dropbox`.
+```lua
+local wezterm = require 'wezterm'
+local canonical_path = wezterm.canonical_path
+local home_dir = wezterm.home_dir
+
+wezterm.log_error( home_dir .. '/Library/CloudStorage/Dropbox' .. ' = ' .. canonical_path( home_dir .. "/Dropbox") )
+```
+
+See also [glob](glob.md).

--- a/docs/config/lua/wezterm/canonical_path.md
+++ b/docs/config/lua/wezterm/canonical_path.md
@@ -21,17 +21,25 @@ in a different format.
 local wezterm = require 'wezterm'
 local canonical_path = wezterm.canonical_path
 
-wezterm.log_error( wezterm.home_dir .. ' = ' canonical_path( wezterm.home_dir .. "/.") )
+wezterm.log_error(
+  wezterm.home_dir .. ' = ' .. canonical_path(wezterm.home_dir .. '/.')
+)
 ```
 
 Another common use case is to find the absolute path of a symlink. E.g., Dropbox is usually
 symlinked to `$HOME/Dropbox` on macOS, but is located at `$HOME/Library/CloudStorage/Dropbox`.
 ```lua
+-- macOS only:
 local wezterm = require 'wezterm'
 local canonical_path = wezterm.canonical_path
 local home_dir = wezterm.home_dir
 
-wezterm.log_error( home_dir .. '/Library/CloudStorage/Dropbox' .. ' = ' .. canonical_path( home_dir .. "/Dropbox") )
+wezterm.log_error(
+  home_dir
+    .. '/Library/CloudStorage/Dropbox'
+    .. ' = '
+    .. canonical_path(home_dir .. '/Dropbox')
+)
 ```
 
 See also [glob](glob.md).

--- a/docs/config/lua/wezterm/canonical_path.md
+++ b/docs/config/lua/wezterm/canonical_path.md
@@ -22,7 +22,7 @@ local wezterm = require 'wezterm'
 local canonical_path = wezterm.canonical_path
 
 wezterm.log_error(
-  wezterm.home_dir .. ' = ' .. canonical_path(wezterm.home_dir .. '/.')
+  wezterm.home_dir == canonical_path(wezterm.home_dir .. '/.')
 )
 ```
 
@@ -35,10 +35,8 @@ local canonical_path = wezterm.canonical_path
 local home_dir = wezterm.home_dir
 
 wezterm.log_error(
-  home_dir
-    .. '/Library/CloudStorage/Dropbox'
-    .. ' = '
-    .. canonical_path(home_dir .. '/Dropbox')
+  home_dir .. '/Library/CloudStorage/Dropbox'
+    == canonical_path(home_dir .. '/Dropbox')
 )
 ```
 

--- a/docs/config/lua/wezterm/canonical_path.md
+++ b/docs/config/lua/wezterm/canonical_path.md
@@ -15,13 +15,15 @@ Due to limitations in the lua bindings, all of the paths
 must be able to be represented as UTF-8 or this function will generate an
 error.
 
+Note: This function is similar to the shell commands realpath and readlink.
+
 The function can for example be used get the correct absolute path for a path
 in a different format.
 ```lua
 local wezterm = require 'wezterm'
 local canonical_path = wezterm.canonical_path
 
-wezterm.log_error(
+assert(
   wezterm.home_dir == canonical_path(wezterm.home_dir .. '/.')
 )
 ```
@@ -34,7 +36,7 @@ local wezterm = require 'wezterm'
 local canonical_path = wezterm.canonical_path
 local home_dir = wezterm.home_dir
 
-wezterm.log_error(
+assert(
   home_dir .. '/Library/CloudStorage/Dropbox'
     == canonical_path(home_dir .. '/Dropbox')
 )

--- a/docs/config/lua/wezterm/dirname.md
+++ b/docs/config/lua/wezterm/dirname.md
@@ -21,7 +21,7 @@ behave slightly different in some edge case.
 local wezterm = require 'wezterm'
 local dirname = wezterm.dirname
 
-wezterm.log_error('/foo/bar = ' .. dirname '/foo/bar/baz.txt')
+wezterm.log_error('/foo/bar' == dirname '/foo/bar/baz.txt')
 ```
 
 If you want only the directory name and not the full path, you can use
@@ -31,7 +31,7 @@ local wezterm = require 'wezterm'
 local basename = wezterm.basename
 local dirname = wezterm.dirname
 
-wezterm.log_error('bar = ' .. basename(dirname '/foo/bar/baz.txt'))
+wezterm.log_error('bar' == basename(dirname '/foo/bar/baz.txt'))
 ```
 
 See also [basename](basename.md).

--- a/docs/config/lua/wezterm/dirname.md
+++ b/docs/config/lua/wezterm/dirname.md
@@ -1,0 +1,37 @@
+---
+title: wezterm.dirname
+tags:
+ - utility
+ - filesystem
+---
+# `wezterm.dirname(path)`
+
+{{since('nightly')}}
+
+This function returns a string containing the dirname of the given path.
+The function does not check whether the given path actually exists.
+Due to limitations in the lua bindings, all of the paths
+must be able to be represented as UTF-8 or this function will generate an
+error.
+
+Note: This function is similar to the shell command dirname, but it might
+behave slightly different in some edge case.
+
+```lua
+local wezterm = require 'wezterm'
+local dirname = wezterm.dirname
+
+wezterm.log_error( '/foo/bar = ' .. dirname '/foo/bar/baz.txt' )
+```
+
+If you want only the directory name and not the full path, you can use
+`basename` and `dirname` together. E.g.:
+```lua
+local wezterm = require 'wezterm'
+local basename = wezterm.basename
+local dirname = wezterm.dirname
+
+wezterm.log_error( 'bar = ' .. basename(dirname '/foo/bar/baz.txt') )
+```
+
+See also [basename](basename.md).

--- a/docs/config/lua/wezterm/dirname.md
+++ b/docs/config/lua/wezterm/dirname.md
@@ -21,7 +21,7 @@ behave slightly different in some edge case.
 local wezterm = require 'wezterm'
 local dirname = wezterm.dirname
 
-wezterm.log_error( '/foo/bar = ' .. dirname '/foo/bar/baz.txt' )
+wezterm.log_error('/foo/bar = ' .. dirname '/foo/bar/baz.txt')
 ```
 
 If you want only the directory name and not the full path, you can use
@@ -31,7 +31,7 @@ local wezterm = require 'wezterm'
 local basename = wezterm.basename
 local dirname = wezterm.dirname
 
-wezterm.log_error( 'bar = ' .. basename(dirname '/foo/bar/baz.txt') )
+wezterm.log_error('bar = ' .. basename(dirname '/foo/bar/baz.txt'))
 ```
 
 See also [basename](basename.md).

--- a/docs/config/lua/wezterm/dirname.md
+++ b/docs/config/lua/wezterm/dirname.md
@@ -31,7 +31,7 @@ local wezterm = require 'wezterm'
 local basename = wezterm.basename
 local dirname = wezterm.dirname
 
-wezterm.log_error('bar' == basename(dirname '/foo/bar/baz.txt'))
+assert('bar' == basename(dirname '/foo/bar/baz.txt'))
 ```
 
 See also [basename](basename.md).

--- a/lua-api-crates/filesystem/src/lib.rs
+++ b/lua-api-crates/filesystem/src/lib.rs
@@ -35,14 +35,14 @@ async fn read_dir<'lua>(_: &'lua Lua, path: String) -> mlua::Result<Vec<String>>
 
 // similar (but not equal) to the shell command basename
 async fn basename<'lua>(_: &'lua Lua, path: String) -> mlua::Result<String> {
-    let path = Path::new(&path);
-    if let Some(basename) = path.file_name() {
+    let path_rs = Path::new(&path);
+    if let Some(basename) = path_rs.file_name() {
         if let Some(utf8) = basename.to_str() {
             Ok(utf8.to_string())
         } else {
             return Err(mlua::Error::external(anyhow!(
                 "path entry {} is not representable as utf8",
-                path.display()
+                path_rs.display()
             )));
         }
     } else {

--- a/lua-api-crates/filesystem/src/lib.rs
+++ b/lua-api-crates/filesystem/src/lib.rs
@@ -55,34 +55,34 @@ async fn basename<'lua>(_: &'lua Lua, path: String) -> mlua::Result<String> {
 // return the path without its final component if there is one
 // similar to the shell command dirname
 async fn dirname<'lua>(_: &'lua Lua, path: String) -> mlua::Result<String> {
-    let path = Path::new(&path);
-    if let Some(parent_path) = path.parent() {
+    let path_rs = Path::new(&path);
+    if let Some(parent_path) = path_rs.parent() {
         if let Some(utf8) = parent_path.to_str() {
             Ok(utf8.to_string())
         } else {
             return Err(mlua::Error::external(anyhow!(
                 "path entry {} is not representable as utf8",
-                path.display()
+                path_rs.display()
             )));
         }
     } else {
         // parent returns None if the path terminates in a root or prefix
-        Ok("".to_string())
+        Ok(path)
     }
 }
 
 // if path exists return the canonical form of the path with all
 // intermediate components normalized and symbolic links resolved
 async fn canonical_path<'lua>(_: &'lua Lua, path: String) -> mlua::Result<String> {
-    let path = smol::fs::canonicalize(&path)
+    let path_rs = smol::fs::canonicalize(&path)
         .await
-        .map_err(|err| format!(mlua::Error::external("canonical_path('{path}'): {err:#}")))?;
-    if let Some(utf8) = &path.to_str() {
+        .map_err(|err| mlua::Error::external(format!("canonical_path('{path}'): {err:#}")))?;
+    if let Some(utf8) = &path_rs.to_str() {
         Ok(utf8.to_string())
     } else {
         return Err(mlua::Error::external(anyhow!(
             "path entry {} is not representable as utf8",
-            path.display()
+            path_rs.display()
         )));
     }
 }

--- a/lua-api-crates/filesystem/src/lib.rs
+++ b/lua-api-crates/filesystem/src/lib.rs
@@ -42,7 +42,7 @@ async fn basename<'lua>(_: &'lua Lua, path: String) -> mlua::Result<String> {
         } else {
             return Err(mlua::Error::external(anyhow!(
                 "path entry {} is not representable as utf8",
-                path_rs.display()
+                &path
             )));
         }
     } else {
@@ -62,7 +62,7 @@ async fn dirname<'lua>(_: &'lua Lua, path: String) -> mlua::Result<String> {
         } else {
             return Err(mlua::Error::external(anyhow!(
                 "path entry {} is not representable as utf8",
-                path_rs.display()
+                &path
             )));
         }
     } else {
@@ -82,7 +82,7 @@ async fn canonical_path<'lua>(_: &'lua Lua, path: String) -> mlua::Result<String
     } else {
         return Err(mlua::Error::external(anyhow!(
             "path entry {} is not representable as utf8",
-            path_rs.display()
+            &path
         )));
     }
 }

--- a/lua-api-crates/filesystem/src/lib.rs
+++ b/lua-api-crates/filesystem/src/lib.rs
@@ -64,9 +64,9 @@ async fn dirname<'lua>(_: &'lua Lua, path: String) -> mlua::Result<String> {
             Ok(utf8.to_string())
         } else {
             return Err(mlua::Error::external(anyhow!(
-                    "path entry {} is not representable as utf8",
-                    path.display()
-        )));
+                "path entry {} is not representable as utf8",
+                path.display()
+            )));
         }
     } else {
         // parent returns None if the path terminates in a root or prefix

--- a/lua-api-crates/filesystem/src/lib.rs
+++ b/lua-api-crates/filesystem/src/lib.rs
@@ -7,8 +7,8 @@ use std::path::Path;
 pub fn register(lua: &Lua) -> anyhow::Result<()> {
     let wezterm_mod = get_or_create_module(lua, "wezterm")?;
     wezterm_mod.set("read_dir", lua.create_async_function(read_dir)?)?;
-    wezterm_mod.set("basename", lua.create_async_function(basename)?)?;
-    wezterm_mod.set("dirname", lua.create_async_function(dirname)?)?;
+    wezterm_mod.set("basename", lua.create_function(basename)?)?;
+    wezterm_mod.set("dirname", lua.create_function(dirname)?)?;
     wezterm_mod.set("canonical_path", lua.create_async_function(canonical_path)?)?;
     wezterm_mod.set("glob", lua.create_async_function(glob)?)?;
     Ok(())
@@ -53,7 +53,7 @@ fn basename<'lua>(_: &'lua Lua, path: String) -> mlua::Result<String> {
 
 // return the path without its final component if there is one
 // similar to the shell command dirname
-async fn dirname<'lua>(_: &'lua Lua, path: String) -> mlua::Result<String> {
+fn dirname<'lua>(_: &'lua Lua, path: String) -> mlua::Result<String> {
     let path_rs = Path::new(&path);
     if let Some(parent_path) = path_rs.parent() {
         if let Some(utf8) = parent_path.to_str() {
@@ -79,8 +79,7 @@ async fn canonical_path<'lua>(_: &'lua Lua, path: String) -> mlua::Result<String
         Ok(utf8.to_string())
     } else {
         return Err(mlua::Error::external(anyhow!(
-            "path entry {} is not representable as utf8",
-            &path
+            "path entry {path} is not representable as utf8"
         )));
     }
 }

--- a/lua-api-crates/filesystem/src/lib.rs
+++ b/lua-api-crates/filesystem/src/lib.rs
@@ -34,15 +34,14 @@ async fn read_dir<'lua>(_: &'lua Lua, path: String) -> mlua::Result<Vec<String>>
 }
 
 // similar (but not equal) to the shell command basename
-async fn basename<'lua>(_: &'lua Lua, path: String) -> mlua::Result<String> {
+fn basename<'lua>(_: &'lua Lua, path: String) -> mlua::Result<String> {
     let path_rs = Path::new(&path);
     if let Some(basename) = path_rs.file_name() {
         if let Some(utf8) = basename.to_str() {
             Ok(utf8.to_string())
         } else {
             return Err(mlua::Error::external(anyhow!(
-                "path entry {} is not representable as utf8",
-                &path
+                "path entry {path} is not representable as utf8"
             )));
         }
     } else {
@@ -61,8 +60,7 @@ async fn dirname<'lua>(_: &'lua Lua, path: String) -> mlua::Result<String> {
             Ok(utf8.to_string())
         } else {
             return Err(mlua::Error::external(anyhow!(
-                "path entry {} is not representable as utf8",
-                &path
+                "path entry {path} is not representable as utf8"
             )));
         }
     } else {


### PR DESCRIPTION
This might solve #4248 and is a step towards adding more (rust) functionality as requested in #4328. 

I will add to the documentation later (this is just a first draft). 

Note that basename and dirname behave slightly different than the usual commands right now. For something like "/foo/bar/baz.rs" they behave the same, but if the path ends with "/." (e.g. "foo/bar/.") there is a difference. This doesn't seem important to me, but I can change it, if someone else thinks this difference is important. (This comes from the behavior of the rust functions file_name and parent.)