### PR TITLE
Scroll viewport to bottom after erase scrollback

### DIFF
--- a/wezterm-gui/src/frontend.rs
+++ b/wezterm-gui/src/frontend.rs
@@ -95,6 +95,7 @@ impl GuiFrontEnd {
                 MuxNotification::WindowInvalidated(_) => {}
                 MuxNotification::PaneOutput(_) => {}
                 MuxNotification::PaneAdded(_) => {}
+                MuxNotification::EraseScrollback(_) => {}
                 MuxNotification::Alert {
                     pane_id: _,
                     alert:

--- a/wezterm-gui/src/termwindow/mod.rs
+++ b/wezterm-gui/src/termwindow/mod.rs
@@ -1200,6 +1200,13 @@ impl TermWindow {
                 MuxNotification::PaneOutput(pane_id) => {
                     self.mux_pane_output_event(pane_id);
                 }
+                MuxNotification::EraseScrollback(pane_id) => {
+                    let mux = Mux::get();
+                    let pane = mux
+                        .get_pane(pane_id)
+                        .ok_or_else(|| anyhow!("pane id {} is not valid", pane_id))?;
+                    self.scroll_to_bottom(&pane)
+                }
                 MuxNotification::WindowInvalidated(_) => {
                     window.invalidate();
                 }
@@ -1400,6 +1407,7 @@ impl TermWindow {
                     return true;
                 }
             }
+            MuxNotification::EraseScrollback(_pane_id) => {}
             MuxNotification::Alert {
                 alert: Alert::ToastNotification { .. } | Alert::PaletteChanged { .. },
                 ..

--- a/wezterm-mux-server-impl/src/dispatch.rs
+++ b/wezterm-mux-server-impl/src/dispatch.rs
@@ -109,6 +109,7 @@ where
             Ok(Item::Notif(MuxNotification::PaneOutput(pane_id))) => {
                 handler.schedule_pane_push(pane_id);
             }
+            Ok(Item::Notif(MuxNotification::EraseScrollback(_pane_id))) => {}
             Ok(Item::Notif(MuxNotification::PaneAdded(_pane_id))) => {}
             Ok(Item::Notif(MuxNotification::PaneRemoved(pane_id))) => {
                 Pdu::PaneRemoved(codec::PaneRemoved { pane_id })


### PR DESCRIPTION
This PR addresses an issue identified while remotely controlling a Wezterm pane from Neovim, notably when the user manually scrolls up causing the cursor to go out of view, and then sends some remote commands. The sequence of actions leading to the problem is as follows:

This fixes a problem I noticed when remotely controlling a Wezterm pane from Neovim:
1. Be remotely controlling a wezterm pane
2. Manually scroll up in that pane so the cursor is no longer visible
3. Send the escape code to clear the scrollback buffer (`clear; printf "\e[3J"`) followed by something that will generate long output, such as running some unit testing.

Observed Behavior: After the scrollback buffer is cleared, the screen refreshes, making the cursor visible again. However, as the tests begin to run and generate lengthy output, the cursor moves out of view, and the lines remain scrolled to the top.

Expected Behavior: Given that clearing the scrollback buffer brings the cursor back into view, it would be logical for the viewport to continue scrolling along with any new output, keeping the cursor visible.

It is important to note that this issue only occurs when step 2 is included. Omitting this step will result in the original code behaving as expected.

Alternatively, here is a way to reproduce this from a single pane:
```lua
config.keys = {
  {
    mods = 'CMD',
    key = 'd',
    action = wezterm.action.Multiple {
      wezterm.action.SendString('clear; printf "\\e[3J"\n'),
      wezterm.action.SendString('ls\n'),
    },
  },
}
```

CMD+d will reproduce the problem (again, only if the user has manually scrolled up before hitting CMD+d)

This PR is the first Rust code I've written, and I'm also not very familiar with the Wezterm source. I welcome and encourage any feedback or meticulous reviews 😄 