### PR TITLE
Fix mouse scroll on hovered but unfocused pane

### DIFF
--- a/wezterm-gui/src/termwindow/mod.rs
+++ b/wezterm-gui/src/termwindow/mod.rs
@@ -2360,22 +2360,18 @@ impl TermWindow {
         Ok(())
     }
 
-    fn scroll_by_current_event_wheel_delta(&mut self) -> anyhow::Result<()> {
+    fn scroll_by_current_event_wheel_delta(&mut self, pane: &Arc<dyn Pane>) -> anyhow::Result<()> {
         if let Some(event) = &self.current_mouse_event {
             let amount = match event.kind {
                 MouseEventKind::VertWheel(amount) => -amount,
                 _ => return Ok(()),
             };
-            self.scroll_by_line(amount.into())?;
+            self.scroll_by_line(amount.into(), pane)?;
         }
         Ok(())
     }
 
-    fn scroll_by_line(&mut self, amount: isize) -> anyhow::Result<()> {
-        let pane = match self.get_active_pane_or_overlay() {
-            Some(pane) => pane,
-            None => return Ok(()),
-        };
+    fn scroll_by_line(&mut self, amount: isize, pane: &Arc<dyn Pane>) -> anyhow::Result<()> {
         let dims = pane.get_dimensions();
         let position = self
             .get_viewport(pane.pane_id())
@@ -2583,8 +2579,8 @@ impl TermWindow {
             MoveTab(n) => self.move_tab(*n)?,
             MoveTabRelative(n) => self.move_tab_relative(*n)?,
             ScrollByPage(n) => self.scroll_by_page(**n)?,
-            ScrollByLine(n) => self.scroll_by_line(*n)?,
-            ScrollByCurrentEventWheelDelta => self.scroll_by_current_event_wheel_delta()?,
+            ScrollByLine(n) => self.scroll_by_line(*n, pane)?,
+            ScrollByCurrentEventWheelDelta => self.scroll_by_current_event_wheel_delta(pane)?,
             ScrollToPrompt(n) => self.scroll_to_prompt(*n)?,
             ScrollToTop => self.scroll_to_top(pane),
             ScrollToBottom => self.scroll_to_bottom(pane),


### PR DESCRIPTION
Closes #2373

Scrolling a non-focused pane with the mouse wheel wasn't working. It turns out we are detecting the hovered pane, and `perform_key_assignment` does have the hovered pane, but it just wasn't passing this information in to `scroll_by_current_event_wheel_delta`. This resulted in `scroll_by_line` repeating the operation to get the current pane, and this doesn't have the hovering logic.

The fix is to pass the pane along in the call to `scroll_by_current_event_wheel_delta`, and it's subsequent call to `scroll_by_line`