### PR TITLE
docs: update Arch install location

### DIFF
--- a/docs/install/linux.md
+++ b/docs/install/linux.md
@@ -146,9 +146,9 @@ $ zypper install wezterm
 
 ## Arch Linux
 
-WezTerm is available in the [Community repository](https://archlinux.org/packages/community/x86_64/wezterm/).
+WezTerm is available in the [Extra repository](https://archlinux.org/packages/extra/x86_64/wezterm/).
 
-The version available in the community repository may lag behind the latest wezterm release, so you may
+The version available in the extra repository may lag behind the latest wezterm release, so you may
 wish to use one of these AUR options:
 
 |What                 |Where|


### PR DESCRIPTION
Arch Linux had a [git migration](https://archlinux.org/news/git-migration-announcement/) in May of this year. During that, the `[community]` repository was merged into `[extra]`. The old link was dead, so I updated it to the new location.