### PR TITLE
Add support for stretching tab bar to fill width of tab bar

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -7,3 +7,7 @@ ar = "x86_64-w64-mingw32-gcc-ar"
 # enabled for the target, so let's turn that on here.
 [target.x86_64-pc-windows-msvc]
 rustflags = "-C target-feature=+crt-static"
+
+[aarch64-unknown-linux-gnu]
+rustflags = ["-C", "linker-plugin-lto", "-C", "link-arg=-fuse-ld=lld"]
+

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7373,3 +7373,8 @@ dependencies = [
  "quote",
  "syn 2.0.68",
 ]
+
+[[patch.unused]]
+name = "xcb"
+version = "1.2.1"
+source = "git+https://github.com/rust-x-bindings/rust-xcb?rev=dbdaa01c178c6fbe68bd51b7ad44c08172181083#dbdaa01c178c6fbe68bd51b7ad44c08172181083"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,8 +29,6 @@ codegen-units = 1
 #split-debuginfo = "unpacked"
 
 [patch.crates-io]
-xcb = { git = "https://github.com/rust-x-bindings/rust-xcb", rev = "dbdaa01c178c6fbe68bd51b7ad44c08172181083" } # waiting on a release with https://github.com/rust-x-bindings/rust-xcb/pull/230
-
 # We use our own vendored cairo, which has minimal deps and should just
 # build via cargo.
 cairo-sys-rs = { path = "deps/cairo", version = "0.18.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,13 +15,13 @@ members = [
   "wezterm-uds",
 ]
 resolver = "2"
-exclude = [
-  "termwiz/codegen"
-]
+exclude = ["termwiz/codegen"]
 
 [profile.release]
 opt-level = 3
 # debug = 2
+lto = "fat"
+codegen-units = 1
 
 [profile.dev]
 # https://jakedeichert.com/blog/reducing-rust-incremental-compilation-times-on-macos-by-70-percent/
@@ -29,6 +29,8 @@ opt-level = 3
 #split-debuginfo = "unpacked"
 
 [patch.crates-io]
+xcb = { git = "https://github.com/rust-x-bindings/rust-xcb", rev = "dbdaa01c178c6fbe68bd51b7ad44c08172181083" } # waiting on a release with https://github.com/rust-x-bindings/rust-xcb/pull/230
+
 # We use our own vendored cairo, which has minimal deps and should just
 # build via cargo.
-cairo-sys-rs = {path="deps/cairo", version="0.18.0"}
+cairo-sys-rs = { path = "deps/cairo", version = "0.18.0" }

--- a/assets/macos/WezTerm.app/Contents/Info.plist
+++ b/assets/macos/WezTerm.app/Contents/Info.plist
@@ -60,6 +60,8 @@
 	<string>An application launched via WezTerm would like to access your Downloads folder.</string>
 	<key>NSSystemAdministrationUsageDescription</key>
 	<string>An application launched via WezTerm requires elevated permission.</string>
+	<key>NSBluetoothAlwaysUsageDescription</key>
+		<string>An application launched via WeZterm would like to access Bluetooth adapter.</string>
 	<key>CFBundleDocumentTypes</key>
 	<array>
 		<dict>

--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -474,6 +474,10 @@ pub struct Config {
     #[dynamic(default)]
     pub tab_and_split_indices_are_zero_based: bool,
 
+    /// Specifies to fill the width of the window with the tab bar
+    #[dynamic(default)]
+    pub tab_bar_fill: bool,
+
     /// Specifies the maximum width that a tab can have in the
     /// tab bar.  Defaults to 16 glyphs in width.
     #[dynamic(default = "default_tab_max_width")]

--- a/docs/config/appearance.md
+++ b/docs/config/appearance.md
@@ -277,6 +277,8 @@ details.
   bar at the bottom of the window instead of the top
 * [tab_max_width](lua/config/tab_max_width.md) sets the maximum width, measured in cells,
   of a given tab when using retro tab mode.
+* [tab_bar_fill](lua/config/tab_bar_fill.md) sets the fancy tab bar to fill
+  the width of the title bar.
 
 #### Native (Fancy) Tab Bar appearance
 

--- a/docs/config/lua/config/tab_bar_title_fill.md
+++ b/docs/config/lua/config/tab_bar_title_fill.md
@@ -1,0 +1,15 @@
+---
+tags:
+  - tab_bar
+---
+# `tab_bar_fill`
+
+Specifies that the fancy tab bar should allow tab titles
+to take up the entire width of the tab bar.
+In this mode, maximum tab width is ignored.
+
+Defaults to false.
+
+```lua
+config.tab_bar_fill = true
+```

--- a/wezterm-gui/src/tabbar.rs
+++ b/wezterm-gui/src/tabbar.rs
@@ -323,11 +323,11 @@ impl TabBarState {
         // are symbols representing minimize, maximize and close.
 
         let mut active_tab_no = 0;
-
+        let tab_info_len = tab_info.len().max(1);
         let config_tab_max_width = if config.tab_bar_fill {
             // We have no layout, so this is a rough estimate
             // The tab bar consists of the tab titles, the new tab button, and some padding
-            title_width.saturating_sub(new_tab.len() + 2 + tab_info.len()) / (tab_info.len())
+            title_width.saturating_sub(new_tab.len() + 2 + tab_info_len) / (tab_info_len)
         } else {
             config.tab_max_width
         };

--- a/window/src/os/wayland/copy_and_paste.rs
+++ b/window/src/os/wayland/copy_and_paste.rs
@@ -102,9 +102,12 @@ impl CopyAndPaste {
 impl WaylandState {
     pub(super) fn resolve_copy_and_paste(&mut self) -> Option<Arc<Mutex<CopyAndPaste>>> {
         let active_surface_id = self.active_surface_id.borrow();
-        let active_surface_id = active_surface_id.as_ref().unwrap();
-        if let Some(pending) = self.surface_to_pending.get(&active_surface_id) {
-            Some(Arc::clone(&pending.lock().unwrap().copy_and_paste))
+        if let Some(active_surface_id) = active_surface_id.as_ref() {
+            if let Some(pending) = self.surface_to_pending.get(&active_surface_id) {
+                Some(Arc::clone(&pending.lock().unwrap().copy_and_paste))
+            } else {
+                None
+            }
         } else {
             None
         }

--- a/window/src/os/wayland/keyboard.rs
+++ b/window/src/os/wayland/keyboard.rs
@@ -90,7 +90,7 @@ impl Dispatch<WlKeyboard, KeyboardData> for WaylandState {
                             }
 
                             Err(err) => {
-                                log::error!("Error processing keymap change: {:#}", err);
+                                log::error!("{}", err);
                             }
                         }
                     }


### PR DESCRIPTION
This PR is meant to resolve issue #1914

It implements support for filling letting tabs expand to fill the title bar.

At least, about as well as was obvious to me how to do :)

The main issues with the current implementation are:



1. ~~When computing layout, most people would expect (IMHO) the real tabs to take up all available space except for the width of the left and right status items.
   Unfortunately, it was not obvious to me how to do this without computing layout twice.~~

~~This is exacerbated by the fact that we give the max width to all of the computation functions, and they often try to do reasonable truncation (see #2).~~

~~Additionally, as far as the window is current, a right status item always exists (AFAICT), so the max title fill of a single tab is really half the space.~~

~~The best i think makes sense at the moment (not implemented), unless i'm missing something, would be to add options for max width of left/right status items,
and use them to account for the items without wasting a full tab width on them.~~

~~If there is a way to compute the layout of the right/left status items first, you could get it exactly right.~~

(This was fixed later)

2. The max width to give to the format-tab-title function is computed twice, and we give a max_width.
   On the second pass, the (previous to this patch) semantic was to pass in first_pass_title_len.min(max_tab_width)
   The problem is that this semantic is, IMHO, broken.

Lots of format-tab-title functions truncate, especially if they involve the current working directory.
They then also leave a little space at the end.
Or left truncate and then right truncate.

So something like

```lua
  if tab.active_pane.current_working_dir then
  local path_string = tab.active_pane.current_working_dir.path
  local current_width = wezterm.column_width(title_with_icon)
  local working_dir_width = wezterm.column_width(path_string)
  title_with_icon = title_with_icon .. ":" .. wezterm.truncate_left(path_string, max_width - current_width - 10)
  end
  if wezterm.truncate_right(title_with_icon, max_width - 6) ~= title_with_icon then
      title = " " .. wezterm.truncate_right(title_with_icon, max_width - 8) .. " .."
  else
      title = " " .. title_with_icon .. " "
  end
```

When the title runs over during the first pass, we will return a title that is smaller than it needs to be (the - 8).
The second pass will now hand us _the old title width_ instead of the actual max amount we could expand to, because that's the min of (first_pass_title_len, max_tab_width)
We will now truncate even further, despite having plenty of space left in our tab title.

I have changed this second pass to instead use max(title_len, max_tab_width). This will allow functions like the above to work.

Looking at github, most functions act like the above.
On top of this, if you don't do this, there is no way to truncate to anything <= max_width without it giving you a smaller size during pass 2.
This change seemed the better option.
