### PR TITLE
Fix Gnome window buttons DPI scaling

### DIFF
--- a/wezterm-gui/src/termwindow/render/fancy_tab_bar.rs
+++ b/wezterm-gui/src/termwindow/render/fancy_tab_bar.rs
@@ -288,6 +288,7 @@ impl crate::TermWindow {
                     &font,
                     &metrics,
                     &self.config,
+                    tab_bar_height,
                 ),
             }
         };


### PR DESCRIPTION
Fixed Gnome window buttons not scaling properly on high DPI displays. Instead of a fixed size, Gnome window button size will now be calculated from top bar height instead. Since the height of the top is adjusted whenever the DPI changes, window buttons are now scaled properly.