### PR TITLE
ci: Use sccache-action instead of rust-cache

### DIFF
--- a/.github/workflows/gen_centos8.yml
+++ b/.github/workflows/gen_centos8.yml
@@ -26,6 +26,10 @@ jobs:
   build:
     runs-on: "ubuntu-latest"
     container: "quay.io/centos/centos:stream8"
+    env:
+      CARGO_INCREMENTAL: "0"
+      SCCACHE_GHA_ENABLED: "true"
+      RUSTC_WRAPPER: "sccache"
 
     steps:
       - name: "Install config manager"
@@ -55,10 +59,20 @@ jobs:
           submodules: "recursive"
       - name: "Install Rust"
         uses: dtolnay/rust-toolchain@stable
-      - name: "Cache cargo"
-        uses: Swatinem/rust-cache@v2
+      - name: "Compile with sccache"
+        uses: mozilla-actions/sccache-action@v0.0.3
+      - name: "Cache Rust Dependencies"
+        uses: actions/cache@v3
+        id: cache-cargo-vendor
         with:
-          key: "centos8-None-2-${{ runner.os }}-cargo"
+          path: |
+            vendor
+            .cargo/config
+          key: "cargo-deps-${{ hashFiles('**/Cargo.lock') }}"
+      - name: "Vendor dependecies"
+        if: steps.cache-cargo-vendor.outputs.cache-hit != 'true'
+        shell: bash
+        run: "cargo vendor --locked --versioned-dirs >> .cargo/config"
       - name: "Install System Deps"
         shell: bash
         run: "env CI=yes PATH=$PATH ./get-deps"

--- a/.github/workflows/gen_centos8_continuous.yml
+++ b/.github/workflows/gen_centos8_continuous.yml
@@ -30,6 +30,9 @@ jobs:
     container: "quay.io/centos/centos:stream8"
     env:
       BUILD_REASON: "Schedule"
+      CARGO_INCREMENTAL: "0"
+      SCCACHE_GHA_ENABLED: "true"
+      RUSTC_WRAPPER: "sccache"
 
     steps:
       - name: "Install config manager"
@@ -59,10 +62,20 @@ jobs:
           submodules: "recursive"
       - name: "Install Rust"
         uses: dtolnay/rust-toolchain@stable
-      - name: "Cache cargo"
-        uses: Swatinem/rust-cache@v2
+      - name: "Compile with sccache"
+        uses: mozilla-actions/sccache-action@v0.0.3
+      - name: "Cache Rust Dependencies"
+        uses: actions/cache@v3
+        id: cache-cargo-vendor
         with:
-          key: "centos8-None-2-${{ runner.os }}-cargo"
+          path: |
+            vendor
+            .cargo/config
+          key: "cargo-deps-${{ hashFiles('**/Cargo.lock') }}"
+      - name: "Vendor dependecies"
+        if: steps.cache-cargo-vendor.outputs.cache-hit != 'true'
+        shell: bash
+        run: "cargo vendor --locked --versioned-dirs >> .cargo/config"
       - name: "Install System Deps"
         shell: bash
         run: "env CI=yes PATH=$PATH ./get-deps"

--- a/.github/workflows/gen_centos8_tag.yml
+++ b/.github/workflows/gen_centos8_tag.yml
@@ -9,6 +9,10 @@ jobs:
   build:
     runs-on: "ubuntu-latest"
     container: "quay.io/centos/centos:stream8"
+    env:
+      CARGO_INCREMENTAL: "0"
+      SCCACHE_GHA_ENABLED: "true"
+      RUSTC_WRAPPER: "sccache"
 
     steps:
       - name: "Install config manager"
@@ -38,10 +42,20 @@ jobs:
           submodules: "recursive"
       - name: "Install Rust"
         uses: dtolnay/rust-toolchain@stable
-      - name: "Cache cargo"
-        uses: Swatinem/rust-cache@v2
+      - name: "Compile with sccache"
+        uses: mozilla-actions/sccache-action@v0.0.3
+      - name: "Cache Rust Dependencies"
+        uses: actions/cache@v3
+        id: cache-cargo-vendor
         with:
-          key: "centos8-None-2-${{ runner.os }}-cargo"
+          path: |
+            vendor
+            .cargo/config
+          key: "cargo-deps-${{ hashFiles('**/Cargo.lock') }}"
+      - name: "Vendor dependecies"
+        if: steps.cache-cargo-vendor.outputs.cache-hit != 'true'
+        shell: bash
+        run: "cargo vendor --locked --versioned-dirs >> .cargo/config"
       - name: "Install System Deps"
         shell: bash
         run: "env CI=yes PATH=$PATH ./get-deps"

--- a/.github/workflows/gen_centos9.yml
+++ b/.github/workflows/gen_centos9.yml
@@ -26,6 +26,10 @@ jobs:
   build:
     runs-on: "ubuntu-latest"
     container: "quay.io/centos/centos:stream9"
+    env:
+      CARGO_INCREMENTAL: "0"
+      SCCACHE_GHA_ENABLED: "true"
+      RUSTC_WRAPPER: "sccache"
 
     steps:
       - name: "Install config manager"
@@ -55,10 +59,20 @@ jobs:
           submodules: "recursive"
       - name: "Install Rust"
         uses: dtolnay/rust-toolchain@stable
-      - name: "Cache cargo"
-        uses: Swatinem/rust-cache@v2
+      - name: "Compile with sccache"
+        uses: mozilla-actions/sccache-action@v0.0.3
+      - name: "Cache Rust Dependencies"
+        uses: actions/cache@v3
+        id: cache-cargo-vendor
         with:
-          key: "centos9-None-2-${{ runner.os }}-cargo"
+          path: |
+            vendor
+            .cargo/config
+          key: "cargo-deps-${{ hashFiles('**/Cargo.lock') }}"
+      - name: "Vendor dependecies"
+        if: steps.cache-cargo-vendor.outputs.cache-hit != 'true'
+        shell: bash
+        run: "cargo vendor --locked --versioned-dirs >> .cargo/config"
       - name: "Install System Deps"
         shell: bash
         run: "env CI=yes PATH=$PATH ./get-deps"

--- a/.github/workflows/gen_centos9_continuous.yml
+++ b/.github/workflows/gen_centos9_continuous.yml
@@ -30,6 +30,9 @@ jobs:
     container: "quay.io/centos/centos:stream9"
     env:
       BUILD_REASON: "Schedule"
+      CARGO_INCREMENTAL: "0"
+      SCCACHE_GHA_ENABLED: "true"
+      RUSTC_WRAPPER: "sccache"
 
     steps:
       - name: "Install config manager"
@@ -59,10 +62,20 @@ jobs:
           submodules: "recursive"
       - name: "Install Rust"
         uses: dtolnay/rust-toolchain@stable
-      - name: "Cache cargo"
-        uses: Swatinem/rust-cache@v2
+      - name: "Compile with sccache"
+        uses: mozilla-actions/sccache-action@v0.0.3
+      - name: "Cache Rust Dependencies"
+        uses: actions/cache@v3
+        id: cache-cargo-vendor
         with:
-          key: "centos9-None-2-${{ runner.os }}-cargo"
+          path: |
+            vendor
+            .cargo/config
+          key: "cargo-deps-${{ hashFiles('**/Cargo.lock') }}"
+      - name: "Vendor dependecies"
+        if: steps.cache-cargo-vendor.outputs.cache-hit != 'true'
+        shell: bash
+        run: "cargo vendor --locked --versioned-dirs >> .cargo/config"
       - name: "Install System Deps"
         shell: bash
         run: "env CI=yes PATH=$PATH ./get-deps"

--- a/.github/workflows/gen_centos9_tag.yml
+++ b/.github/workflows/gen_centos9_tag.yml
@@ -9,6 +9,10 @@ jobs:
   build:
     runs-on: "ubuntu-latest"
     container: "quay.io/centos/centos:stream9"
+    env:
+      CARGO_INCREMENTAL: "0"
+      SCCACHE_GHA_ENABLED: "true"
+      RUSTC_WRAPPER: "sccache"
 
     steps:
       - name: "Install config manager"
@@ -38,10 +42,20 @@ jobs:
           submodules: "recursive"
       - name: "Install Rust"
         uses: dtolnay/rust-toolchain@stable
-      - name: "Cache cargo"
-        uses: Swatinem/rust-cache@v2
+      - name: "Compile with sccache"
+        uses: mozilla-actions/sccache-action@v0.0.3
+      - name: "Cache Rust Dependencies"
+        uses: actions/cache@v3
+        id: cache-cargo-vendor
         with:
-          key: "centos9-None-2-${{ runner.os }}-cargo"
+          path: |
+            vendor
+            .cargo/config
+          key: "cargo-deps-${{ hashFiles('**/Cargo.lock') }}"
+      - name: "Vendor dependecies"
+        if: steps.cache-cargo-vendor.outputs.cache-hit != 'true'
+        shell: bash
+        run: "cargo vendor --locked --versioned-dirs >> .cargo/config"
       - name: "Install System Deps"
         shell: bash
         run: "env CI=yes PATH=$PATH ./get-deps"

--- a/.github/workflows/gen_debian10.3.yml
+++ b/.github/workflows/gen_debian10.3.yml
@@ -26,6 +26,10 @@ jobs:
   build:
     runs-on: "ubuntu-latest"
     container: "debian:10.3"
+    env:
+      CARGO_INCREMENTAL: "0"
+      SCCACHE_GHA_ENABLED: "true"
+      RUSTC_WRAPPER: "sccache"
 
     steps:
       - name: "set APT to non-interactive"
@@ -58,10 +62,20 @@ jobs:
           submodules: "recursive"
       - name: "Install Rust"
         uses: dtolnay/rust-toolchain@stable
-      - name: "Cache cargo"
-        uses: Swatinem/rust-cache@v2
+      - name: "Compile with sccache"
+        uses: mozilla-actions/sccache-action@v0.0.3
+      - name: "Cache Rust Dependencies"
+        uses: actions/cache@v3
+        id: cache-cargo-vendor
         with:
-          key: "debian10.3-None-2-${{ runner.os }}-cargo"
+          path: |
+            vendor
+            .cargo/config
+          key: "cargo-deps-${{ hashFiles('**/Cargo.lock') }}"
+      - name: "Vendor dependecies"
+        if: steps.cache-cargo-vendor.outputs.cache-hit != 'true'
+        shell: bash
+        run: "cargo vendor --locked --versioned-dirs >> .cargo/config"
       - name: "Install System Deps"
         shell: bash
         run: "env CI=yes PATH=$PATH ./get-deps"

--- a/.github/workflows/gen_debian10.3_continuous.yml
+++ b/.github/workflows/gen_debian10.3_continuous.yml
@@ -30,6 +30,9 @@ jobs:
     container: "debian:10.3"
     env:
       BUILD_REASON: "Schedule"
+      CARGO_INCREMENTAL: "0"
+      SCCACHE_GHA_ENABLED: "true"
+      RUSTC_WRAPPER: "sccache"
 
     steps:
       - name: "set APT to non-interactive"
@@ -62,10 +65,20 @@ jobs:
           submodules: "recursive"
       - name: "Install Rust"
         uses: dtolnay/rust-toolchain@stable
-      - name: "Cache cargo"
-        uses: Swatinem/rust-cache@v2
+      - name: "Compile with sccache"
+        uses: mozilla-actions/sccache-action@v0.0.3
+      - name: "Cache Rust Dependencies"
+        uses: actions/cache@v3
+        id: cache-cargo-vendor
         with:
-          key: "debian10.3-None-2-${{ runner.os }}-cargo"
+          path: |
+            vendor
+            .cargo/config
+          key: "cargo-deps-${{ hashFiles('**/Cargo.lock') }}"
+      - name: "Vendor dependecies"
+        if: steps.cache-cargo-vendor.outputs.cache-hit != 'true'
+        shell: bash
+        run: "cargo vendor --locked --versioned-dirs >> .cargo/config"
       - name: "Install System Deps"
         shell: bash
         run: "env CI=yes PATH=$PATH ./get-deps"

--- a/.github/workflows/gen_debian10.3_tag.yml
+++ b/.github/workflows/gen_debian10.3_tag.yml
@@ -9,6 +9,10 @@ jobs:
   build:
     runs-on: "ubuntu-latest"
     container: "debian:10.3"
+    env:
+      CARGO_INCREMENTAL: "0"
+      SCCACHE_GHA_ENABLED: "true"
+      RUSTC_WRAPPER: "sccache"
 
     steps:
       - name: "set APT to non-interactive"
@@ -41,10 +45,20 @@ jobs:
           submodules: "recursive"
       - name: "Install Rust"
         uses: dtolnay/rust-toolchain@stable
-      - name: "Cache cargo"
-        uses: Swatinem/rust-cache@v2
+      - name: "Compile with sccache"
+        uses: mozilla-actions/sccache-action@v0.0.3
+      - name: "Cache Rust Dependencies"
+        uses: actions/cache@v3
+        id: cache-cargo-vendor
         with:
-          key: "debian10.3-None-2-${{ runner.os }}-cargo"
+          path: |
+            vendor
+            .cargo/config
+          key: "cargo-deps-${{ hashFiles('**/Cargo.lock') }}"
+      - name: "Vendor dependecies"
+        if: steps.cache-cargo-vendor.outputs.cache-hit != 'true'
+        shell: bash
+        run: "cargo vendor --locked --versioned-dirs >> .cargo/config"
       - name: "Install System Deps"
         shell: bash
         run: "env CI=yes PATH=$PATH ./get-deps"

--- a/.github/workflows/gen_debian11.yml
+++ b/.github/workflows/gen_debian11.yml
@@ -26,6 +26,10 @@ jobs:
   build:
     runs-on: "ubuntu-latest"
     container: "debian:11"
+    env:
+      CARGO_INCREMENTAL: "0"
+      SCCACHE_GHA_ENABLED: "true"
+      RUSTC_WRAPPER: "sccache"
 
     steps:
       - name: "set APT to non-interactive"
@@ -58,10 +62,20 @@ jobs:
           submodules: "recursive"
       - name: "Install Rust"
         uses: dtolnay/rust-toolchain@stable
-      - name: "Cache cargo"
-        uses: Swatinem/rust-cache@v2
+      - name: "Compile with sccache"
+        uses: mozilla-actions/sccache-action@v0.0.3
+      - name: "Cache Rust Dependencies"
+        uses: actions/cache@v3
+        id: cache-cargo-vendor
         with:
-          key: "debian11-None-2-${{ runner.os }}-cargo"
+          path: |
+            vendor
+            .cargo/config
+          key: "cargo-deps-${{ hashFiles('**/Cargo.lock') }}"
+      - name: "Vendor dependecies"
+        if: steps.cache-cargo-vendor.outputs.cache-hit != 'true'
+        shell: bash
+        run: "cargo vendor --locked --versioned-dirs >> .cargo/config"
       - name: "Install System Deps"
         shell: bash
         run: "env CI=yes PATH=$PATH ./get-deps"

--- a/.github/workflows/gen_debian11_continuous.yml
+++ b/.github/workflows/gen_debian11_continuous.yml
@@ -30,6 +30,9 @@ jobs:
     container: "debian:11"
     env:
       BUILD_REASON: "Schedule"
+      CARGO_INCREMENTAL: "0"
+      SCCACHE_GHA_ENABLED: "true"
+      RUSTC_WRAPPER: "sccache"
 
     steps:
       - name: "set APT to non-interactive"
@@ -62,10 +65,20 @@ jobs:
           submodules: "recursive"
       - name: "Install Rust"
         uses: dtolnay/rust-toolchain@stable
-      - name: "Cache cargo"
-        uses: Swatinem/rust-cache@v2
+      - name: "Compile with sccache"
+        uses: mozilla-actions/sccache-action@v0.0.3
+      - name: "Cache Rust Dependencies"
+        uses: actions/cache@v3
+        id: cache-cargo-vendor
         with:
-          key: "debian11-None-2-${{ runner.os }}-cargo"
+          path: |
+            vendor
+            .cargo/config
+          key: "cargo-deps-${{ hashFiles('**/Cargo.lock') }}"
+      - name: "Vendor dependecies"
+        if: steps.cache-cargo-vendor.outputs.cache-hit != 'true'
+        shell: bash
+        run: "cargo vendor --locked --versioned-dirs >> .cargo/config"
       - name: "Install System Deps"
         shell: bash
         run: "env CI=yes PATH=$PATH ./get-deps"

--- a/.github/workflows/gen_debian11_tag.yml
+++ b/.github/workflows/gen_debian11_tag.yml
@@ -9,6 +9,10 @@ jobs:
   build:
     runs-on: "ubuntu-latest"
     container: "debian:11"
+    env:
+      CARGO_INCREMENTAL: "0"
+      SCCACHE_GHA_ENABLED: "true"
+      RUSTC_WRAPPER: "sccache"
 
     steps:
       - name: "set APT to non-interactive"
@@ -41,10 +45,20 @@ jobs:
           submodules: "recursive"
       - name: "Install Rust"
         uses: dtolnay/rust-toolchain@stable
-      - name: "Cache cargo"
-        uses: Swatinem/rust-cache@v2
+      - name: "Compile with sccache"
+        uses: mozilla-actions/sccache-action@v0.0.3
+      - name: "Cache Rust Dependencies"
+        uses: actions/cache@v3
+        id: cache-cargo-vendor
         with:
-          key: "debian11-None-2-${{ runner.os }}-cargo"
+          path: |
+            vendor
+            .cargo/config
+          key: "cargo-deps-${{ hashFiles('**/Cargo.lock') }}"
+      - name: "Vendor dependecies"
+        if: steps.cache-cargo-vendor.outputs.cache-hit != 'true'
+        shell: bash
+        run: "cargo vendor --locked --versioned-dirs >> .cargo/config"
       - name: "Install System Deps"
         shell: bash
         run: "env CI=yes PATH=$PATH ./get-deps"

--- a/.github/workflows/gen_debian12.yml
+++ b/.github/workflows/gen_debian12.yml
@@ -26,6 +26,10 @@ jobs:
   build:
     runs-on: "ubuntu-latest"
     container: "debian:12"
+    env:
+      CARGO_INCREMENTAL: "0"
+      SCCACHE_GHA_ENABLED: "true"
+      RUSTC_WRAPPER: "sccache"
 
     steps:
       - name: "set APT to non-interactive"
@@ -58,10 +62,20 @@ jobs:
           submodules: "recursive"
       - name: "Install Rust"
         uses: dtolnay/rust-toolchain@stable
-      - name: "Cache cargo"
-        uses: Swatinem/rust-cache@v2
+      - name: "Compile with sccache"
+        uses: mozilla-actions/sccache-action@v0.0.3
+      - name: "Cache Rust Dependencies"
+        uses: actions/cache@v3
+        id: cache-cargo-vendor
         with:
-          key: "debian12-None-2-${{ runner.os }}-cargo"
+          path: |
+            vendor
+            .cargo/config
+          key: "cargo-deps-${{ hashFiles('**/Cargo.lock') }}"
+      - name: "Vendor dependecies"
+        if: steps.cache-cargo-vendor.outputs.cache-hit != 'true'
+        shell: bash
+        run: "cargo vendor --locked --versioned-dirs >> .cargo/config"
       - name: "Install System Deps"
         shell: bash
         run: "env CI=yes PATH=$PATH ./get-deps"

--- a/.github/workflows/gen_debian12_continuous.yml
+++ b/.github/workflows/gen_debian12_continuous.yml
@@ -30,6 +30,9 @@ jobs:
     container: "debian:12"
     env:
       BUILD_REASON: "Schedule"
+      CARGO_INCREMENTAL: "0"
+      SCCACHE_GHA_ENABLED: "true"
+      RUSTC_WRAPPER: "sccache"
 
     steps:
       - name: "set APT to non-interactive"
@@ -62,10 +65,20 @@ jobs:
           submodules: "recursive"
       - name: "Install Rust"
         uses: dtolnay/rust-toolchain@stable
-      - name: "Cache cargo"
-        uses: Swatinem/rust-cache@v2
+      - name: "Compile with sccache"
+        uses: mozilla-actions/sccache-action@v0.0.3
+      - name: "Cache Rust Dependencies"
+        uses: actions/cache@v3
+        id: cache-cargo-vendor
         with:
-          key: "debian12-None-2-${{ runner.os }}-cargo"
+          path: |
+            vendor
+            .cargo/config
+          key: "cargo-deps-${{ hashFiles('**/Cargo.lock') }}"
+      - name: "Vendor dependecies"
+        if: steps.cache-cargo-vendor.outputs.cache-hit != 'true'
+        shell: bash
+        run: "cargo vendor --locked --versioned-dirs >> .cargo/config"
       - name: "Install System Deps"
         shell: bash
         run: "env CI=yes PATH=$PATH ./get-deps"

--- a/.github/workflows/gen_debian12_tag.yml
+++ b/.github/workflows/gen_debian12_tag.yml
@@ -9,6 +9,10 @@ jobs:
   build:
     runs-on: "ubuntu-latest"
     container: "debian:12"
+    env:
+      CARGO_INCREMENTAL: "0"
+      SCCACHE_GHA_ENABLED: "true"
+      RUSTC_WRAPPER: "sccache"
 
     steps:
       - name: "set APT to non-interactive"
@@ -41,10 +45,20 @@ jobs:
           submodules: "recursive"
       - name: "Install Rust"
         uses: dtolnay/rust-toolchain@stable
-      - name: "Cache cargo"
-        uses: Swatinem/rust-cache@v2
+      - name: "Compile with sccache"
+        uses: mozilla-actions/sccache-action@v0.0.3
+      - name: "Cache Rust Dependencies"
+        uses: actions/cache@v3
+        id: cache-cargo-vendor
         with:
-          key: "debian12-None-2-${{ runner.os }}-cargo"
+          path: |
+            vendor
+            .cargo/config
+          key: "cargo-deps-${{ hashFiles('**/Cargo.lock') }}"
+      - name: "Vendor dependecies"
+        if: steps.cache-cargo-vendor.outputs.cache-hit != 'true'
+        shell: bash
+        run: "cargo vendor --locked --versioned-dirs >> .cargo/config"
       - name: "Install System Deps"
         shell: bash
         run: "env CI=yes PATH=$PATH ./get-deps"

--- a/.github/workflows/gen_fedora37.yml
+++ b/.github/workflows/gen_fedora37.yml
@@ -26,6 +26,10 @@ jobs:
   build:
     runs-on: "ubuntu-latest"
     container: "fedora:37"
+    env:
+      CARGO_INCREMENTAL: "0"
+      SCCACHE_GHA_ENABLED: "true"
+      RUSTC_WRAPPER: "sccache"
 
     steps:
       - name: "Install config manager"
@@ -52,10 +56,20 @@ jobs:
           submodules: "recursive"
       - name: "Install Rust"
         uses: dtolnay/rust-toolchain@stable
-      - name: "Cache cargo"
-        uses: Swatinem/rust-cache@v2
+      - name: "Compile with sccache"
+        uses: mozilla-actions/sccache-action@v0.0.3
+      - name: "Cache Rust Dependencies"
+        uses: actions/cache@v3
+        id: cache-cargo-vendor
         with:
-          key: "fedora37-None-2-${{ runner.os }}-cargo"
+          path: |
+            vendor
+            .cargo/config
+          key: "cargo-deps-${{ hashFiles('**/Cargo.lock') }}"
+      - name: "Vendor dependecies"
+        if: steps.cache-cargo-vendor.outputs.cache-hit != 'true'
+        shell: bash
+        run: "cargo vendor --locked --versioned-dirs >> .cargo/config"
       - name: "Install System Deps"
         shell: bash
         run: "env CI=yes PATH=$PATH ./get-deps"

--- a/.github/workflows/gen_fedora37_continuous.yml
+++ b/.github/workflows/gen_fedora37_continuous.yml
@@ -30,6 +30,9 @@ jobs:
     container: "fedora:37"
     env:
       BUILD_REASON: "Schedule"
+      CARGO_INCREMENTAL: "0"
+      SCCACHE_GHA_ENABLED: "true"
+      RUSTC_WRAPPER: "sccache"
 
     steps:
       - name: "Install config manager"
@@ -56,10 +59,20 @@ jobs:
           submodules: "recursive"
       - name: "Install Rust"
         uses: dtolnay/rust-toolchain@stable
-      - name: "Cache cargo"
-        uses: Swatinem/rust-cache@v2
+      - name: "Compile with sccache"
+        uses: mozilla-actions/sccache-action@v0.0.3
+      - name: "Cache Rust Dependencies"
+        uses: actions/cache@v3
+        id: cache-cargo-vendor
         with:
-          key: "fedora37-None-2-${{ runner.os }}-cargo"
+          path: |
+            vendor
+            .cargo/config
+          key: "cargo-deps-${{ hashFiles('**/Cargo.lock') }}"
+      - name: "Vendor dependecies"
+        if: steps.cache-cargo-vendor.outputs.cache-hit != 'true'
+        shell: bash
+        run: "cargo vendor --locked --versioned-dirs >> .cargo/config"
       - name: "Install System Deps"
         shell: bash
         run: "env CI=yes PATH=$PATH ./get-deps"

--- a/.github/workflows/gen_fedora37_tag.yml
+++ b/.github/workflows/gen_fedora37_tag.yml
@@ -9,6 +9,10 @@ jobs:
   build:
     runs-on: "ubuntu-latest"
     container: "fedora:37"
+    env:
+      CARGO_INCREMENTAL: "0"
+      SCCACHE_GHA_ENABLED: "true"
+      RUSTC_WRAPPER: "sccache"
 
     steps:
       - name: "Install config manager"
@@ -35,10 +39,20 @@ jobs:
           submodules: "recursive"
       - name: "Install Rust"
         uses: dtolnay/rust-toolchain@stable
-      - name: "Cache cargo"
-        uses: Swatinem/rust-cache@v2
+      - name: "Compile with sccache"
+        uses: mozilla-actions/sccache-action@v0.0.3
+      - name: "Cache Rust Dependencies"
+        uses: actions/cache@v3
+        id: cache-cargo-vendor
         with:
-          key: "fedora37-None-2-${{ runner.os }}-cargo"
+          path: |
+            vendor
+            .cargo/config
+          key: "cargo-deps-${{ hashFiles('**/Cargo.lock') }}"
+      - name: "Vendor dependecies"
+        if: steps.cache-cargo-vendor.outputs.cache-hit != 'true'
+        shell: bash
+        run: "cargo vendor --locked --versioned-dirs >> .cargo/config"
       - name: "Install System Deps"
         shell: bash
         run: "env CI=yes PATH=$PATH ./get-deps"

--- a/.github/workflows/gen_fedora38.yml
+++ b/.github/workflows/gen_fedora38.yml
@@ -26,6 +26,10 @@ jobs:
   build:
     runs-on: "ubuntu-latest"
     container: "fedora:38"
+    env:
+      CARGO_INCREMENTAL: "0"
+      SCCACHE_GHA_ENABLED: "true"
+      RUSTC_WRAPPER: "sccache"
 
     steps:
       - name: "Install config manager"
@@ -52,10 +56,20 @@ jobs:
           submodules: "recursive"
       - name: "Install Rust"
         uses: dtolnay/rust-toolchain@stable
-      - name: "Cache cargo"
-        uses: Swatinem/rust-cache@v2
+      - name: "Compile with sccache"
+        uses: mozilla-actions/sccache-action@v0.0.3
+      - name: "Cache Rust Dependencies"
+        uses: actions/cache@v3
+        id: cache-cargo-vendor
         with:
-          key: "fedora38-None-2-${{ runner.os }}-cargo"
+          path: |
+            vendor
+            .cargo/config
+          key: "cargo-deps-${{ hashFiles('**/Cargo.lock') }}"
+      - name: "Vendor dependecies"
+        if: steps.cache-cargo-vendor.outputs.cache-hit != 'true'
+        shell: bash
+        run: "cargo vendor --locked --versioned-dirs >> .cargo/config"
       - name: "Install System Deps"
         shell: bash
         run: "env CI=yes PATH=$PATH ./get-deps"

--- a/.github/workflows/gen_fedora38_continuous.yml
+++ b/.github/workflows/gen_fedora38_continuous.yml
@@ -30,6 +30,9 @@ jobs:
     container: "fedora:38"
     env:
       BUILD_REASON: "Schedule"
+      CARGO_INCREMENTAL: "0"
+      SCCACHE_GHA_ENABLED: "true"
+      RUSTC_WRAPPER: "sccache"
 
     steps:
       - name: "Install config manager"
@@ -56,10 +59,20 @@ jobs:
           submodules: "recursive"
       - name: "Install Rust"
         uses: dtolnay/rust-toolchain@stable
-      - name: "Cache cargo"
-        uses: Swatinem/rust-cache@v2
+      - name: "Compile with sccache"
+        uses: mozilla-actions/sccache-action@v0.0.3
+      - name: "Cache Rust Dependencies"
+        uses: actions/cache@v3
+        id: cache-cargo-vendor
         with:
-          key: "fedora38-None-2-${{ runner.os }}-cargo"
+          path: |
+            vendor
+            .cargo/config
+          key: "cargo-deps-${{ hashFiles('**/Cargo.lock') }}"
+      - name: "Vendor dependecies"
+        if: steps.cache-cargo-vendor.outputs.cache-hit != 'true'
+        shell: bash
+        run: "cargo vendor --locked --versioned-dirs >> .cargo/config"
       - name: "Install System Deps"
         shell: bash
         run: "env CI=yes PATH=$PATH ./get-deps"

--- a/.github/workflows/gen_fedora38_tag.yml
+++ b/.github/workflows/gen_fedora38_tag.yml
@@ -9,6 +9,10 @@ jobs:
   build:
     runs-on: "ubuntu-latest"
     container: "fedora:38"
+    env:
+      CARGO_INCREMENTAL: "0"
+      SCCACHE_GHA_ENABLED: "true"
+      RUSTC_WRAPPER: "sccache"
 
     steps:
       - name: "Install config manager"
@@ -35,10 +39,20 @@ jobs:
           submodules: "recursive"
       - name: "Install Rust"
         uses: dtolnay/rust-toolchain@stable
-      - name: "Cache cargo"
-        uses: Swatinem/rust-cache@v2
+      - name: "Compile with sccache"
+        uses: mozilla-actions/sccache-action@v0.0.3
+      - name: "Cache Rust Dependencies"
+        uses: actions/cache@v3
+        id: cache-cargo-vendor
         with:
-          key: "fedora38-None-2-${{ runner.os }}-cargo"
+          path: |
+            vendor
+            .cargo/config
+          key: "cargo-deps-${{ hashFiles('**/Cargo.lock') }}"
+      - name: "Vendor dependecies"
+        if: steps.cache-cargo-vendor.outputs.cache-hit != 'true'
+        shell: bash
+        run: "cargo vendor --locked --versioned-dirs >> .cargo/config"
       - name: "Install System Deps"
         shell: bash
         run: "env CI=yes PATH=$PATH ./get-deps"

--- a/.github/workflows/gen_fedora39.yml
+++ b/.github/workflows/gen_fedora39.yml
@@ -26,6 +26,10 @@ jobs:
   build:
     runs-on: "ubuntu-latest"
     container: "fedora:39"
+    env:
+      CARGO_INCREMENTAL: "0"
+      SCCACHE_GHA_ENABLED: "true"
+      RUSTC_WRAPPER: "sccache"
 
     steps:
       - name: "Install config manager"
@@ -52,10 +56,20 @@ jobs:
           submodules: "recursive"
       - name: "Install Rust"
         uses: dtolnay/rust-toolchain@stable
-      - name: "Cache cargo"
-        uses: Swatinem/rust-cache@v2
+      - name: "Compile with sccache"
+        uses: mozilla-actions/sccache-action@v0.0.3
+      - name: "Cache Rust Dependencies"
+        uses: actions/cache@v3
+        id: cache-cargo-vendor
         with:
-          key: "fedora39-None-2-${{ runner.os }}-cargo"
+          path: |
+            vendor
+            .cargo/config
+          key: "cargo-deps-${{ hashFiles('**/Cargo.lock') }}"
+      - name: "Vendor dependecies"
+        if: steps.cache-cargo-vendor.outputs.cache-hit != 'true'
+        shell: bash
+        run: "cargo vendor --locked --versioned-dirs >> .cargo/config"
       - name: "Install System Deps"
         shell: bash
         run: "env CI=yes PATH=$PATH ./get-deps"

--- a/.github/workflows/gen_fedora39_continuous.yml
+++ b/.github/workflows/gen_fedora39_continuous.yml
@@ -30,6 +30,9 @@ jobs:
     container: "fedora:39"
     env:
       BUILD_REASON: "Schedule"
+      CARGO_INCREMENTAL: "0"
+      SCCACHE_GHA_ENABLED: "true"
+      RUSTC_WRAPPER: "sccache"
 
     steps:
       - name: "Install config manager"
@@ -56,10 +59,20 @@ jobs:
           submodules: "recursive"
       - name: "Install Rust"
         uses: dtolnay/rust-toolchain@stable
-      - name: "Cache cargo"
-        uses: Swatinem/rust-cache@v2
+      - name: "Compile with sccache"
+        uses: mozilla-actions/sccache-action@v0.0.3
+      - name: "Cache Rust Dependencies"
+        uses: actions/cache@v3
+        id: cache-cargo-vendor
         with:
-          key: "fedora39-None-2-${{ runner.os }}-cargo"
+          path: |
+            vendor
+            .cargo/config
+          key: "cargo-deps-${{ hashFiles('**/Cargo.lock') }}"
+      - name: "Vendor dependecies"
+        if: steps.cache-cargo-vendor.outputs.cache-hit != 'true'
+        shell: bash
+        run: "cargo vendor --locked --versioned-dirs >> .cargo/config"
       - name: "Install System Deps"
         shell: bash
         run: "env CI=yes PATH=$PATH ./get-deps"

--- a/.github/workflows/gen_fedora39_tag.yml
+++ b/.github/workflows/gen_fedora39_tag.yml
@@ -9,6 +9,10 @@ jobs:
   build:
     runs-on: "ubuntu-latest"
     container: "fedora:39"
+    env:
+      CARGO_INCREMENTAL: "0"
+      SCCACHE_GHA_ENABLED: "true"
+      RUSTC_WRAPPER: "sccache"
 
     steps:
       - name: "Install config manager"
@@ -35,10 +39,20 @@ jobs:
           submodules: "recursive"
       - name: "Install Rust"
         uses: dtolnay/rust-toolchain@stable
-      - name: "Cache cargo"
-        uses: Swatinem/rust-cache@v2
+      - name: "Compile with sccache"
+        uses: mozilla-actions/sccache-action@v0.0.3
+      - name: "Cache Rust Dependencies"
+        uses: actions/cache@v3
+        id: cache-cargo-vendor
         with:
-          key: "fedora39-None-2-${{ runner.os }}-cargo"
+          path: |
+            vendor
+            .cargo/config
+          key: "cargo-deps-${{ hashFiles('**/Cargo.lock') }}"
+      - name: "Vendor dependecies"
+        if: steps.cache-cargo-vendor.outputs.cache-hit != 'true'
+        shell: bash
+        run: "cargo vendor --locked --versioned-dirs >> .cargo/config"
       - name: "Install System Deps"
         shell: bash
         run: "env CI=yes PATH=$PATH ./get-deps"

--- a/.github/workflows/gen_macos.yml
+++ b/.github/workflows/gen_macos.yml
@@ -22,6 +22,9 @@ jobs:
     runs-on: "macos-11"
     
     env:
+      CARGO_INCREMENTAL: "0"
+      SCCACHE_GHA_ENABLED: "true"
+      RUSTC_WRAPPER: "sccache"
       MACOSX_DEPLOYMENT_TARGET: "10.9"
 
     steps:
@@ -34,6 +37,20 @@ jobs:
       - name: "Install Rust (ARM)"
         shell: bash
         run: "rustup target add aarch64-apple-darwin"
+      - name: "Compile with sccache"
+        uses: mozilla-actions/sccache-action@v0.0.3
+      - name: "Cache Rust Dependencies"
+        uses: actions/cache@v3
+        id: cache-cargo-vendor
+        with:
+          path: |
+            vendor
+            .cargo/config
+          key: "cargo-deps-${{ hashFiles('**/Cargo.lock') }}"
+      - name: "Vendor dependecies"
+        if: steps.cache-cargo-vendor.outputs.cache-hit != 'true'
+        shell: bash
+        run: "cargo vendor --locked --versioned-dirs >> .cargo/config"
       - name: "Install System Deps"
         shell: bash
         run: "env CI=yes PATH=$PATH ./get-deps"

--- a/.github/workflows/gen_macos_continuous.yml
+++ b/.github/workflows/gen_macos_continuous.yml
@@ -25,6 +25,9 @@ jobs:
     
     env:
       BUILD_REASON: "Schedule"
+      CARGO_INCREMENTAL: "0"
+      SCCACHE_GHA_ENABLED: "true"
+      RUSTC_WRAPPER: "sccache"
       MACOSX_DEPLOYMENT_TARGET: "10.9"
 
     steps:
@@ -37,6 +40,20 @@ jobs:
       - name: "Install Rust (ARM)"
         shell: bash
         run: "rustup target add aarch64-apple-darwin"
+      - name: "Compile with sccache"
+        uses: mozilla-actions/sccache-action@v0.0.3
+      - name: "Cache Rust Dependencies"
+        uses: actions/cache@v3
+        id: cache-cargo-vendor
+        with:
+          path: |
+            vendor
+            .cargo/config
+          key: "cargo-deps-${{ hashFiles('**/Cargo.lock') }}"
+      - name: "Vendor dependecies"
+        if: steps.cache-cargo-vendor.outputs.cache-hit != 'true'
+        shell: bash
+        run: "cargo vendor --locked --versioned-dirs >> .cargo/config"
       - name: "Install System Deps"
         shell: bash
         run: "env CI=yes PATH=$PATH ./get-deps"

--- a/.github/workflows/gen_macos_tag.yml
+++ b/.github/workflows/gen_macos_tag.yml
@@ -10,6 +10,9 @@ jobs:
     runs-on: "macos-11"
     
     env:
+      CARGO_INCREMENTAL: "0"
+      SCCACHE_GHA_ENABLED: "true"
+      RUSTC_WRAPPER: "sccache"
       MACOSX_DEPLOYMENT_TARGET: "10.9"
 
     steps:
@@ -22,6 +25,20 @@ jobs:
       - name: "Install Rust (ARM)"
         shell: bash
         run: "rustup target add aarch64-apple-darwin"
+      - name: "Compile with sccache"
+        uses: mozilla-actions/sccache-action@v0.0.3
+      - name: "Cache Rust Dependencies"
+        uses: actions/cache@v3
+        id: cache-cargo-vendor
+        with:
+          path: |
+            vendor
+            .cargo/config
+          key: "cargo-deps-${{ hashFiles('**/Cargo.lock') }}"
+      - name: "Vendor dependecies"
+        if: steps.cache-cargo-vendor.outputs.cache-hit != 'true'
+        shell: bash
+        run: "cargo vendor --locked --versioned-dirs >> .cargo/config"
       - name: "Install System Deps"
         shell: bash
         run: "env CI=yes PATH=$PATH ./get-deps"
@@ -63,7 +80,7 @@ jobs:
         shell: bash
         run: "cp wezterm.rb homebrew-wezterm/Casks/wezterm.rb"
       - name: "Commit homebrew tap changes"
-        uses: stefanzweifel/git-auto-commit-action@v5
+        uses: stefanzweifel/git-auto-commit-action@v4
         with:
           commit_message: "Automated update to match latest tag"
           repository: "homebrew-wezterm"

--- a/.github/workflows/gen_ubuntu20.04.yml
+++ b/.github/workflows/gen_ubuntu20.04.yml
@@ -31,6 +31,10 @@ jobs:
     container:
       image: "ubuntu:20.04"
       options: --privileged
+    env:
+      CARGO_INCREMENTAL: "0"
+      SCCACHE_GHA_ENABLED: "true"
+      RUSTC_WRAPPER: "sccache"
 
     steps:
       - name: "set APT to non-interactive"
@@ -63,10 +67,20 @@ jobs:
           submodules: "recursive"
       - name: "Install Rust"
         uses: dtolnay/rust-toolchain@stable
-      - name: "Cache cargo"
-        uses: Swatinem/rust-cache@v2
+      - name: "Compile with sccache"
+        uses: mozilla-actions/sccache-action@v0.0.3
+      - name: "Cache Rust Dependencies"
+        uses: actions/cache@v3
+        id: cache-cargo-vendor
         with:
-          key: "ubuntu20.04-None-2-${{ runner.os }}-cargo"
+          path: |
+            vendor
+            .cargo/config
+          key: "cargo-deps-${{ hashFiles('**/Cargo.lock') }}"
+      - name: "Vendor dependecies"
+        if: steps.cache-cargo-vendor.outputs.cache-hit != 'true'
+        shell: bash
+        run: "cargo vendor --locked --versioned-dirs >> .cargo/config"
       - name: "Install System Deps"
         shell: bash
         run: "env CI=yes PATH=$PATH ./get-deps"

--- a/.github/workflows/gen_ubuntu20.04_continuous.yml
+++ b/.github/workflows/gen_ubuntu20.04_continuous.yml
@@ -35,6 +35,9 @@ jobs:
       options: --privileged
     env:
       BUILD_REASON: "Schedule"
+      CARGO_INCREMENTAL: "0"
+      SCCACHE_GHA_ENABLED: "true"
+      RUSTC_WRAPPER: "sccache"
 
     steps:
       - name: "set APT to non-interactive"
@@ -67,10 +70,20 @@ jobs:
           submodules: "recursive"
       - name: "Install Rust"
         uses: dtolnay/rust-toolchain@stable
-      - name: "Cache cargo"
-        uses: Swatinem/rust-cache@v2
+      - name: "Compile with sccache"
+        uses: mozilla-actions/sccache-action@v0.0.3
+      - name: "Cache Rust Dependencies"
+        uses: actions/cache@v3
+        id: cache-cargo-vendor
         with:
-          key: "ubuntu20.04-None-2-${{ runner.os }}-cargo"
+          path: |
+            vendor
+            .cargo/config
+          key: "cargo-deps-${{ hashFiles('**/Cargo.lock') }}"
+      - name: "Vendor dependecies"
+        if: steps.cache-cargo-vendor.outputs.cache-hit != 'true'
+        shell: bash
+        run: "cargo vendor --locked --versioned-dirs >> .cargo/config"
       - name: "Install System Deps"
         shell: bash
         run: "env CI=yes PATH=$PATH ./get-deps"

--- a/.github/workflows/gen_ubuntu20.04_tag.yml
+++ b/.github/workflows/gen_ubuntu20.04_tag.yml
@@ -11,6 +11,10 @@ jobs:
     container:
       image: "ubuntu:20.04"
       options: --privileged
+    env:
+      CARGO_INCREMENTAL: "0"
+      SCCACHE_GHA_ENABLED: "true"
+      RUSTC_WRAPPER: "sccache"
 
     steps:
       - name: "set APT to non-interactive"
@@ -43,10 +47,20 @@ jobs:
           submodules: "recursive"
       - name: "Install Rust"
         uses: dtolnay/rust-toolchain@stable
-      - name: "Cache cargo"
-        uses: Swatinem/rust-cache@v2
+      - name: "Compile with sccache"
+        uses: mozilla-actions/sccache-action@v0.0.3
+      - name: "Cache Rust Dependencies"
+        uses: actions/cache@v3
+        id: cache-cargo-vendor
         with:
-          key: "ubuntu20.04-None-2-${{ runner.os }}-cargo"
+          path: |
+            vendor
+            .cargo/config
+          key: "cargo-deps-${{ hashFiles('**/Cargo.lock') }}"
+      - name: "Vendor dependecies"
+        if: steps.cache-cargo-vendor.outputs.cache-hit != 'true'
+        shell: bash
+        run: "cargo vendor --locked --versioned-dirs >> .cargo/config"
       - name: "Install System Deps"
         shell: bash
         run: "env CI=yes PATH=$PATH ./get-deps"
@@ -93,7 +107,7 @@ jobs:
         shell: bash
         run: "cp wezterm-linuxbrew.rb linuxbrew-wezterm/Formula/wezterm.rb"
       - name: "Commit linuxbrew tap changes"
-        uses: stefanzweifel/git-auto-commit-action@v5
+        uses: stefanzweifel/git-auto-commit-action@v4
         with:
           commit_message: "Automated update to match latest tag"
           repository: "linuxbrew-wezterm"

--- a/.github/workflows/gen_ubuntu22.04.yml
+++ b/.github/workflows/gen_ubuntu22.04.yml
@@ -26,6 +26,10 @@ jobs:
   build:
     runs-on: "ubuntu-latest"
     container: "ubuntu:22.04"
+    env:
+      CARGO_INCREMENTAL: "0"
+      SCCACHE_GHA_ENABLED: "true"
+      RUSTC_WRAPPER: "sccache"
 
     steps:
       - name: "set APT to non-interactive"
@@ -58,10 +62,20 @@ jobs:
           submodules: "recursive"
       - name: "Install Rust"
         uses: dtolnay/rust-toolchain@stable
-      - name: "Cache cargo"
-        uses: Swatinem/rust-cache@v2
+      - name: "Compile with sccache"
+        uses: mozilla-actions/sccache-action@v0.0.3
+      - name: "Cache Rust Dependencies"
+        uses: actions/cache@v3
+        id: cache-cargo-vendor
         with:
-          key: "ubuntu22.04-None-2-${{ runner.os }}-cargo"
+          path: |
+            vendor
+            .cargo/config
+          key: "cargo-deps-${{ hashFiles('**/Cargo.lock') }}"
+      - name: "Vendor dependecies"
+        if: steps.cache-cargo-vendor.outputs.cache-hit != 'true'
+        shell: bash
+        run: "cargo vendor --locked --versioned-dirs >> .cargo/config"
       - name: "Install System Deps"
         shell: bash
         run: "env CI=yes PATH=$PATH ./get-deps"

--- a/.github/workflows/gen_ubuntu22.04_continuous.yml
+++ b/.github/workflows/gen_ubuntu22.04_continuous.yml
@@ -30,6 +30,9 @@ jobs:
     container: "ubuntu:22.04"
     env:
       BUILD_REASON: "Schedule"
+      CARGO_INCREMENTAL: "0"
+      SCCACHE_GHA_ENABLED: "true"
+      RUSTC_WRAPPER: "sccache"
 
     steps:
       - name: "set APT to non-interactive"
@@ -62,10 +65,20 @@ jobs:
           submodules: "recursive"
       - name: "Install Rust"
         uses: dtolnay/rust-toolchain@stable
-      - name: "Cache cargo"
-        uses: Swatinem/rust-cache@v2
+      - name: "Compile with sccache"
+        uses: mozilla-actions/sccache-action@v0.0.3
+      - name: "Cache Rust Dependencies"
+        uses: actions/cache@v3
+        id: cache-cargo-vendor
         with:
-          key: "ubuntu22.04-None-2-${{ runner.os }}-cargo"
+          path: |
+            vendor
+            .cargo/config
+          key: "cargo-deps-${{ hashFiles('**/Cargo.lock') }}"
+      - name: "Vendor dependecies"
+        if: steps.cache-cargo-vendor.outputs.cache-hit != 'true'
+        shell: bash
+        run: "cargo vendor --locked --versioned-dirs >> .cargo/config"
       - name: "Install System Deps"
         shell: bash
         run: "env CI=yes PATH=$PATH ./get-deps"

--- a/.github/workflows/gen_ubuntu22.04_tag.yml
+++ b/.github/workflows/gen_ubuntu22.04_tag.yml
@@ -9,6 +9,10 @@ jobs:
   build:
     runs-on: "ubuntu-latest"
     container: "ubuntu:22.04"
+    env:
+      CARGO_INCREMENTAL: "0"
+      SCCACHE_GHA_ENABLED: "true"
+      RUSTC_WRAPPER: "sccache"
 
     steps:
       - name: "set APT to non-interactive"
@@ -41,10 +45,20 @@ jobs:
           submodules: "recursive"
       - name: "Install Rust"
         uses: dtolnay/rust-toolchain@stable
-      - name: "Cache cargo"
-        uses: Swatinem/rust-cache@v2
+      - name: "Compile with sccache"
+        uses: mozilla-actions/sccache-action@v0.0.3
+      - name: "Cache Rust Dependencies"
+        uses: actions/cache@v3
+        id: cache-cargo-vendor
         with:
-          key: "ubuntu22.04-None-2-${{ runner.os }}-cargo"
+          path: |
+            vendor
+            .cargo/config
+          key: "cargo-deps-${{ hashFiles('**/Cargo.lock') }}"
+      - name: "Vendor dependecies"
+        if: steps.cache-cargo-vendor.outputs.cache-hit != 'true'
+        shell: bash
+        run: "cargo vendor --locked --versioned-dirs >> .cargo/config"
       - name: "Install System Deps"
         shell: bash
         run: "env CI=yes PATH=$PATH ./get-deps"

--- a/.github/workflows/gen_windows.yml
+++ b/.github/workflows/gen_windows.yml
@@ -19,6 +19,10 @@ jobs:
   build:
     runs-on: "windows-latest"
     
+    env:
+      CARGO_INCREMENTAL: "0"
+      SCCACHE_GHA_ENABLED: "true"
+      RUSTC_WRAPPER: "sccache"
 
     steps:
       - name: "checkout repo"
@@ -29,10 +33,20 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           target: "x86_64-pc-windows-msvc"
-      - name: "Cache cargo"
-        uses: Swatinem/rust-cache@v2
+      - name: "Compile with sccache"
+        uses: mozilla-actions/sccache-action@v0.0.3
+      - name: "Cache Rust Dependencies"
+        uses: actions/cache@v3
+        id: cache-cargo-vendor
         with:
-          key: "windows-x86_64-pc-windows-msvc-2-${{ runner.os }}-cargo"
+          path: |
+            vendor
+            .cargo/config
+          key: "cargo-deps-${{ hashFiles('**/Cargo.lock') }}"
+      - name: "Vendor dependecies"
+        if: steps.cache-cargo-vendor.outputs.cache-hit != 'true'
+        shell: bash
+        run: "cargo vendor --locked --versioned-dirs >> .cargo/config"
       - name: "Build (Release mode)"
         shell: cmd
         run: |

--- a/.github/workflows/gen_windows_continuous.yml
+++ b/.github/workflows/gen_windows_continuous.yml
@@ -23,6 +23,9 @@ jobs:
     
     env:
       BUILD_REASON: "Schedule"
+      CARGO_INCREMENTAL: "0"
+      SCCACHE_GHA_ENABLED: "true"
+      RUSTC_WRAPPER: "sccache"
 
     steps:
       - name: "checkout repo"
@@ -33,10 +36,20 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           target: "x86_64-pc-windows-msvc"
-      - name: "Cache cargo"
-        uses: Swatinem/rust-cache@v2
+      - name: "Compile with sccache"
+        uses: mozilla-actions/sccache-action@v0.0.3
+      - name: "Cache Rust Dependencies"
+        uses: actions/cache@v3
+        id: cache-cargo-vendor
         with:
-          key: "windows-x86_64-pc-windows-msvc-2-${{ runner.os }}-cargo"
+          path: |
+            vendor
+            .cargo/config
+          key: "cargo-deps-${{ hashFiles('**/Cargo.lock') }}"
+      - name: "Vendor dependecies"
+        if: steps.cache-cargo-vendor.outputs.cache-hit != 'true'
+        shell: bash
+        run: "cargo vendor --locked --versioned-dirs >> .cargo/config"
       - name: "Build (Release mode)"
         shell: cmd
         run: |

--- a/.github/workflows/gen_windows_tag.yml
+++ b/.github/workflows/gen_windows_tag.yml
@@ -9,6 +9,10 @@ jobs:
   build:
     runs-on: "windows-latest"
     
+    env:
+      CARGO_INCREMENTAL: "0"
+      SCCACHE_GHA_ENABLED: "true"
+      RUSTC_WRAPPER: "sccache"
 
     steps:
       - name: "checkout repo"
@@ -19,10 +23,20 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           target: "x86_64-pc-windows-msvc"
-      - name: "Cache cargo"
-        uses: Swatinem/rust-cache@v2
+      - name: "Compile with sccache"
+        uses: mozilla-actions/sccache-action@v0.0.3
+      - name: "Cache Rust Dependencies"
+        uses: actions/cache@v3
+        id: cache-cargo-vendor
         with:
-          key: "windows-x86_64-pc-windows-msvc-2-${{ runner.os }}-cargo"
+          path: |
+            vendor
+            .cargo/config
+          key: "cargo-deps-${{ hashFiles('**/Cargo.lock') }}"
+      - name: "Vendor dependecies"
+        if: steps.cache-cargo-vendor.outputs.cache-hit != 'true'
+        shell: bash
+        run: "cargo vendor --locked --versioned-dirs >> .cargo/config"
       - name: "Build (Release mode)"
         shell: cmd
         run: |


### PR DESCRIPTION
It reduced ci times for fluke from 9min to 1min in MacOS (see [this issue](https://github.com/hapsoc/fluke/issues/118)) so I thought it would be worth a try here too.

`sccache` does not have a configurable `key` for the cache so it might not work at all for us.