### PR TITLE
Fixes tabbar identation when placed at the bottom of the window

### DIFF
--- a/wezterm-gui/src/tabbar.rs
+++ b/wezterm-gui/src/tabbar.rs
@@ -372,6 +372,7 @@ impl TabBarState {
         if use_integrated_title_buttons
             && config.integrated_title_button_style == IntegratedTitleButtonStyle::MacOsNative
             && config.use_fancy_tab_bar == false
+            && config.tab_bar_at_bottom == false
         {
             for _ in 0..10 as usize {
                 line.insert_cell(0, black_cell.clone(), title_width, SEQ_ZERO);


### PR DESCRIPTION
Fixes issue #4495 where title bar is indented instead of being fully left aligned.

**Before:**
<img width="561" alt="Screenshot 2023-10-29 at 5 12 02 PM" src="https://github.com/wez/wezterm/assets/93291476/e8292211-a32f-4b1e-bcb7-76d5a78c7339">


**After:**
<img width="561" alt="Screenshot 2023-10-29 at 5 10 42 PM" src="https://github.com/wez/wezterm/assets/93291476/512de6d0-dc43-43d7-a0e9-043d91c06854">
