### PR TITLE
Detect true color set by max_colors

### DIFF
--- a/termwiz/src/caps/mod.rs
+++ b/termwiz/src/caps/mod.rs
@@ -219,7 +219,9 @@ impl Capabilities {
                         if has_true_color {
                             ColorLevel::TrueColor
                         } else if let Some(cap::MaxColors(n)) = db.get::<cap::MaxColors>() {
-                            if n >= 256 {
+                            if n >= 16777216 {
+                                ColorLevel::TrueColor
+                            } else if n >= 256 {
                                 ColorLevel::TwoFiftySix
                             } else {
                                 ColorLevel::Sixteen


### PR DESCRIPTION
Terminals like `xterm-direct` has max_colors set to 16M. They should be treated as supporting true colors.

Related: #4528