### PR TITLE
Make RIS also clear the alternate screen

### DIFF
--- a/term/src/terminalstate/performer.rs
+++ b/term/src/terminalstate/performer.rs
@@ -700,6 +700,8 @@ impl<'a> Performer<'a> {
                 self.accumulating_title.take();
 
                 self.screen.full_reset();
+                self.screen.activate_alt_screen(seqno);
+                self.erase_in_display(EraseInDisplay::EraseDisplay);
                 self.screen.activate_primary_screen(seqno);
                 self.erase_in_display(EraseInDisplay::EraseScrollback);
                 self.erase_in_display(EraseInDisplay::EraseDisplay);


### PR DESCRIPTION
xterm clears the alternate screen on RIS since #383. VTE and konsole already did that.

From esctest:
RISTests.test_RIS_ExitAltScreen