### PR TITLE
Adds config option for command palette rows

### DIFF
--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -148,9 +148,7 @@ pub struct Config {
     #[dynamic(default = "default_command_palette_font_size")]
     pub command_palette_font_size: f64,
 
-    #[dynamic(default = "default_command_palette_rows")]
-    pub command_palette_rows: usize,
-
+    pub command_palette_rows: Option<usize>,
     #[dynamic(default = "default_command_palette_fg_color")]
     pub command_palette_fg_color: RgbaColor,
 
@@ -1571,10 +1569,6 @@ fn default_char_select_bg_color() -> RgbaColor {
 
 fn default_command_palette_font_size() -> f64 {
     14.0
-}
-
-fn default_command_palette_rows() -> usize {
-    0
 }
 
 fn default_command_palette_fg_color() -> RgbaColor {

--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -148,6 +148,9 @@ pub struct Config {
     #[dynamic(default = "default_command_palette_font_size")]
     pub command_palette_font_size: f64,
 
+    #[dynamic(default = "default_command_palette_rows")]
+    pub command_palette_rows: usize,
+
     #[dynamic(default = "default_command_palette_fg_color")]
     pub command_palette_fg_color: RgbaColor,
 
@@ -1568,6 +1571,10 @@ fn default_char_select_bg_color() -> RgbaColor {
 
 fn default_command_palette_font_size() -> f64 {
     14.0
+}
+
+fn default_command_palette_rows() -> usize {
+    0
 }
 
 fn default_command_palette_fg_color() -> RgbaColor {

--- a/docs/config/lua/config/command_palette_rows.md
+++ b/docs/config/lua/config/command_palette_rows.md
@@ -5,7 +5,8 @@ tags:
 ---
 # `command_palette_rows = 14`
 
+{{since('nightly')}}
 
 Specifies the number of rows displayed by the command palette.
 [ActivateCommandPalette](../keyassignment/ActivateCommandPalette.md).
-
+If unset or `nil`, a default value based on the terminal display will be used.

--- a/docs/config/lua/config/command_palette_rows.md
+++ b/docs/config/lua/config/command_palette_rows.md
@@ -1,0 +1,11 @@
+---
+tags:
+  - appearance
+  - command_palette
+---
+# `command_palette_rows = 14`
+
+
+Specifies the number of rows displayed by the command palette.
+[ActivateCommandPalette](../keyassignment/ActivateCommandPalette.md).
+

--- a/wezterm-gui/src/termwindow/palette.rs
+++ b/wezterm-gui/src/termwindow/palette.rs
@@ -664,9 +664,14 @@ impl Modal for CommandPalette {
             .expect("to resolve char selection font");
         let metrics = RenderMetrics::with_font_metrics(&font.metrics());
 
-        let max_rows_on_screen = ((term_window.dimensions.pixel_height * 8 / 10)
+        let mut max_rows_on_screen = ((term_window.dimensions.pixel_height * 8 / 10)
             / metrics.cell_size.height as usize)
             - 2;
+        if 0 < term_window.config.command_palette_rows
+            && term_window.config.command_palette_rows < max_rows_on_screen
+        {
+            max_rows_on_screen = term_window.config.command_palette_rows;
+        }
         *self.max_rows_on_screen.borrow_mut() = max_rows_on_screen;
 
         let rebuild_matches = results

--- a/wezterm-gui/src/termwindow/palette.rs
+++ b/wezterm-gui/src/termwindow/palette.rs
@@ -667,10 +667,8 @@ impl Modal for CommandPalette {
         let mut max_rows_on_screen = ((term_window.dimensions.pixel_height * 8 / 10)
             / metrics.cell_size.height as usize)
             - 2;
-        if 0 < term_window.config.command_palette_rows
-            && term_window.config.command_palette_rows < max_rows_on_screen
-        {
-            max_rows_on_screen = term_window.config.command_palette_rows;
+        if let Some(size) = term_window.config.command_palette_rows {
+            max_rows_on_screen = max_rows_on_screen.min(size);
         }
         *self.max_rows_on_screen.borrow_mut() = max_rows_on_screen;
 


### PR DESCRIPTION
Command palette defaulted to showing rows based on terminal rows, this allows configuration of the number of rows displayed by the command palette.