### PR TITLE
docs: fix minor variable name mismatch in the docs

### DIFF
--- a/docs/config/lua/config/integrated_title_buttons.md
+++ b/docs/config/lua/config/integrated_title_buttons.md
@@ -2,7 +2,7 @@
 tags:
   - appearance
 ---
-# `integrated_title_button_style = BUTTONS`
+# `integrated_title_buttons = BUTTONS`
 
 {{since('20230408-112425-69ae8472')}}
 


### PR DESCRIPTION
The integrated_title_buttons page incorrectly referred to integrated_title_button_style.