### PR TITLE
get-deps: support installing docs dependencies on debian

### DIFF
--- a/get-deps
+++ b/get-deps
@@ -1,18 +1,23 @@
 #!/bin/sh
 
-case $1 in
-  --testing)
-    TESTING=0
-  ;;
-  '')
-    TESTING=1
-  ;;
-  *)
-    echo 'get-deps:'
-    echo '  --testing    include dependencies required for tests'
-    exit 1
-  ;;
-esac
+TESTING=0
+DOCS=0
+for arg in "$@"; do
+    case $arg in
+      --testing)
+        TESTING=1
+      ;;
+      --docs)
+        DOCS=1
+      ;;
+      *)
+        echo 'get-deps:'
+        echo '  --docs       include dependencies required for testing docs'
+        echo '  --testing    include dependencies required for tests'
+        exit 1
+      ;;
+    esac
+done
 
 NOTFOUND=0
 
@@ -21,7 +26,11 @@ test_cmd() {
 }
 
 test_flag() {
-  test $TESTING -eq 0
+  test $TESTING -eq 1
+}
+
+docs_flag() {
+  test $DOCS -eq 1
 }
 
 if test -z "$SUDO"; then
@@ -163,6 +172,9 @@ debian_deps() {
 
   if test_flag; then
     $APT install -y 'openssh-server'
+  fi
+  if docs_flag; then
+    $APT install -y 'python3-pip mkdocs'
   fi
 }
 


### PR DESCRIPTION
The python3-pip and mkdocs packages are required to run the ci/build-docs.sh script.