### PR TITLE
Add `wezterm.to_string` function

### DIFF
--- a/docs/config/lua/wezterm/to_string.md
+++ b/docs/config/lua/wezterm/to_string.md
@@ -1,0 +1,24 @@
+---
+title: wezterm.to_string
+tags:
+ - utility
+---
+# `wezterm.to_string(arg)`
+
+{{since('nightly')}}
+
+This function returns a string representation of any Lua value. In particular
+this can be used to get a string representation of a table or userdata.
+
+```lua
+local wezterm = require 'wezterm'
+assert(wezterm.to_string { 1, 2 } == [=[[
+    1,
+    2,
+]]=])
+assert(wezterm.to_string { a = 1, b = 2 } == [[{
+    "a": 1,
+    "b": 2,
+}]])
+```
+

--- a/lua-api-crates/logging/src/lib.rs
+++ b/lua-api-crates/logging/src/lib.rs
@@ -30,6 +30,14 @@ pub fn register(lua: &Lua) -> anyhow::Result<()> {
         })?,
     )?;
 
+    wezterm_mod.set(
+        "to_string",
+        lua.create_function(|_, arg: Value| {
+            let res = ValuePrinter(arg);
+            Ok(format!("{:#?}", res).to_string())
+        })?,
+    )?;
+
     lua.globals().set(
         "print",
         lua.create_function(|_, args: Variadic<Value>| {


### PR DESCRIPTION
Here is a draft of a `wezterm.to_string` function. I think it makes sense to keep it so that it only accepts on `Value`, but I can change it so it can accept multiple values if you prefer?

Also, for now I just use the `ValuePrinter` directly, so we don't need to be as careful with strings as in `printerhelper`, but I can use `printerhelper` if you prefer. 