### PR TITLE
Fix pane focus rapidly switching back and forth

### DIFF
--- a/lua-api-crates/mux/src/pane.rs
+++ b/lua-api-crates/mux/src/pane.rs
@@ -1,6 +1,7 @@
 use super::*;
 use luahelper::{dynamic_to_lua_value, from_lua, to_lua};
 use mlua::Value;
+use mux::tab::NotifyMux;
 use std::cmp::Ordering;
 use std::sync::Arc;
 use termwiz::cell::SemanticType;
@@ -400,7 +401,7 @@ impl UserData for MuxPane {
             let tab = mux
                 .get_tab(tab_id)
                 .ok_or_else(|| mlua::Error::external(format!("tab {tab_id} not found")))?;
-            tab.set_active_pane(&pane);
+            tab.set_active_pane(&pane, NotifyMux::Yes);
             Ok(())
         });
 

--- a/mux/src/lib.rs
+++ b/mux/src/lib.rs
@@ -1,6 +1,6 @@
 use crate::client::{ClientId, ClientInfo};
 use crate::pane::{Pane, PaneId};
-use crate::tab::{SplitRequest, Tab, TabId};
+use crate::tab::{NotifyMux, SplitRequest, Tab, TabId};
 use crate::window::{Window, WindowId};
 use anyhow::{anyhow, Context, Error};
 use config::keyassignment::SpawnTabDomain;
@@ -542,7 +542,7 @@ impl Mux {
             .get_tab(tab_id)
             .ok_or_else(|| anyhow::anyhow!("tab {tab_id} not found"))?;
 
-        tab.set_active_pane(&pane);
+        tab.set_active_pane(&pane, NotifyMux::No);
 
         Ok(())
     }

--- a/wezterm-mux-server-impl/src/sessionhandler.rs
+++ b/wezterm-mux-server-impl/src/sessionhandler.rs
@@ -6,7 +6,7 @@ use mux::client::ClientId;
 use mux::domain::SplitSource;
 use mux::pane::{Pane, PaneId};
 use mux::renderable::{RenderableDimensions, StableCursorPosition};
-use mux::tab::TabId;
+use mux::tab::{NotifyMux, TabId};
 use mux::{Mux, MuxNotification};
 use promise::spawn::spawn_into_main_thread;
 use std::collections::HashMap;
@@ -332,10 +332,9 @@ impl SessionHandler {
                             let tab = mux
                                 .get_tab(tab_id)
                                 .ok_or_else(|| anyhow::anyhow!("tab {tab_id} not found"))?;
-                            tab.set_active_pane(&pane);
+                            tab.set_active_pane(&pane, NotifyMux::No);
 
                             mux.record_focus_for_current_identity(pane_id);
-                            mux.notify(mux::MuxNotification::PaneFocused(pane_id));
 
                             Ok(Pdu::UnitResponse(UnitResponse {}))
                         },
@@ -538,14 +537,14 @@ impl SessionHandler {
                                     if is_zoomed != zoomed {
                                         tab.set_zoomed(false);
                                         if zoomed {
-                                            tab.set_active_pane(&pane);
+                                            tab.set_active_pane(&pane, NotifyMux::Yes);
                                             tab.set_zoomed(zoomed);
                                         }
                                     }
                                 }
                                 None => {
                                     if zoomed {
-                                        tab.set_active_pane(&pane);
+                                        tab.set_active_pane(&pane, NotifyMux::Yes);
                                         tab.set_zoomed(zoomed);
                                     }
                                 }


### PR DESCRIPTION
Switching panes multiple times too quickly sometimes causes the focus to get stuck rapidly switching back and forth between two panes by itself. This happens both locally and on an SSH domain. The root cause is similar in both cases.

In the local case, GuiFrontend handles a MuxNotification::PaneFocused event by calling Mux::focus_pane_and_containing_tab, which calls through Tab::set_active_pane -> TabInner::set_active_pane -> TabInner::advise_focus_change. TabInner::advise_focus_change then calls Mux::notify with a new MuxNotification::PaneFocused event, which is a redundant notification focusing the same pane again.

This is normally harmless other than a small amount of wasted work; TabInner::set_active_pane notices that the focused pane didn't change and doesn't generate yet another event.

However, if another real focus change is queued between the original focus change and the redundant one, we get into trouble. For example, if the user switches to pane 0 and then immediately to pane 1, the event queue contains [PaneFocused(0), PaneFocused(1)]. When the first event is handled, pane 0 is focused, and a redundant notification is generated, so the event queue contains [PaneFocused(1), PaneFocused(0)]. Then after the next event is handled, pane 1 is focused, and we add another redundant notification, so the event queue contains [PaneFocused(0), PaneFocused(1)]. Repeat ad nauseam.

Fix this by not generating the notification from
TabInner::advise_focus_change when it would be redundant, which we indicate with a new boolean parameter.

The mux server case is very similar, except that Pdu::SetFocusedPane in SessionHandler is the vector for the bug.

This bug appears to have been introduced by commit f71bce1727bbf1c384ca63a650a2aadec5afe841. I verified that `wezterm cli activate-pane-direction` still works over SSH after this fix.

closes: #4390
closes: #4693