### PR TITLE
fix: Proper block cursor shape

### DIFF
--- a/wezterm-gui/src/customglyph.rs
+++ b/wezterm-gui/src/customglyph.rs
@@ -262,7 +262,7 @@ impl PolyStyle {
                 let mut stroke = Stroke::default();
                 stroke.width = width;
                 if self == PolyStyle::OutlineHeavy {
-                    stroke.width *= 3.6; // NOTE: Changing this makes block cursor unproportinal at different font sizes
+                    stroke.width *= 3.1; // NOTE: Changing this makes block cursor unproportinal at different font sizes
                 } else if self == PolyStyle::OutlineThin {
                     stroke.width = 1.2;
                 }

--- a/wezterm-gui/src/customglyph.rs
+++ b/wezterm-gui/src/customglyph.rs
@@ -262,7 +262,7 @@ impl PolyStyle {
                 let mut stroke = Stroke::default();
                 stroke.width = width;
                 if self == PolyStyle::OutlineHeavy {
-                    stroke.width *= 3.0; // NOTE: Using 2.0, the difference is almost invisible
+                    stroke.width *= 3.6; // NOTE: Changing this makes block cursor unproportinal at different font sizes
                 } else if self == PolyStyle::OutlineThin {
                     stroke.width = 1.2;
                 }


### PR DESCRIPTION
Fixes https://github.com/wez/wezterm/issues/4231

Before:
![before](https://github.com/wez/wezterm/assets/39203616/2c53c7c0-81e4-4e6a-b592-d28fc23164b6)
After:
![after](https://github.com/wez/wezterm/assets/39203616/a2bfb849-a853-47cd-8b0b-7cd380c3e486)