### PR TITLE
x11: fix resize increments

### DIFF
--- a/window/src/os/x11/window.rs
+++ b/window/src/os/x11/window.rs
@@ -1558,8 +1558,8 @@ impl XWindowInner {
         self.conn().send_request_no_reply(&xcb::x::ChangeProperty {
             mode: PropMode::Replace,
             window: self.window_id,
-            property: xcb::x::ATOM_WM_SIZE_HINTS,
-            r#type: xcb::x::ATOM_CARDINAL,
+            property: xcb::x::ATOM_WM_NORMAL_HINTS,
+            r#type: xcb::x::ATOM_WM_SIZE_HINTS,
             data,
         })?;
 


### PR DESCRIPTION
Set atom with property (type) `WM_NORMAL_HINTS (WM_SIZE_HINTS)` instead of `WM_SIZE_HINTS (CARDINAL)`.

The `use_resize_increments` feature didn't work at all for me prior.