### PR TITLE
x11: improve use_resize_increment behavior

### DIFF
--- a/wezterm-gui/src/main.rs
+++ b/wezterm-gui/src/main.rs
@@ -43,6 +43,7 @@ mod markdown;
 mod overlay;
 mod quad;
 mod renderstate;
+mod resize_increment_calculator;
 mod scripting;
 mod scrollbar;
 mod selection;

--- a/wezterm-gui/src/resize_increment_calculator.rs
+++ b/wezterm-gui/src/resize_increment_calculator.rs
@@ -1,0 +1,29 @@
+use ::window::parameters::Border;
+use ::window::ResizeIncrement;
+
+pub struct ResizeIncrementCalculator {
+    pub x: u16,
+    pub y: u16,
+    pub padding_left: usize,
+    pub padding_top: usize,
+    pub padding_right: usize,
+    pub padding_bottom: usize,
+    pub border: Border,
+    pub tab_bar_height: usize,
+}
+
+impl Into<ResizeIncrement> for ResizeIncrementCalculator {
+    fn into(self) -> ResizeIncrement {
+        ResizeIncrement {
+            x: self.x,
+            y: self.y,
+            base_width: (self.padding_left
+                + self.padding_right
+                + (self.border.left + self.border.right).get()) as u16,
+            base_height: (self.padding_top
+                + self.padding_bottom
+                + (self.border.top + self.border.bottom).get()
+                + self.tab_bar_height) as u16,
+        }
+    }
+}

--- a/wezterm-gui/src/termwindow/mod.rs
+++ b/wezterm-gui/src/termwindow/mod.rs
@@ -9,6 +9,7 @@ use crate::overlay::{
     start_overlay, start_overlay_pane, CopyModeParams, CopyOverlay, LauncherArgs, LauncherFlags,
     QuickSelectOverlay,
 };
+use crate::resize_increment_calculator::ResizeIncrementCalculator;
 use crate::scripting::guiwin::GuiWin;
 use crate::scrollbar::*;
 use crate::selection::Selection;
@@ -842,10 +843,19 @@ impl TermWindow {
             };
             myself.config_subscription.replace(config_subscription);
             if config.use_resize_increments {
-                window.set_resize_increments(ResizeIncrement {
-                    x: myself.render_metrics.cell_size.width as u16,
-                    y: myself.render_metrics.cell_size.height as u16,
-                });
+                window.set_resize_increments(
+                    ResizeIncrementCalculator {
+                        x: myself.render_metrics.cell_size.width as u16,
+                        y: myself.render_metrics.cell_size.height as u16,
+                        padding_left: padding_left,
+                        padding_top: padding_top,
+                        padding_right: padding_right,
+                        padding_bottom: padding_bottom,
+                        border: border,
+                        tab_bar_height: tab_bar_height,
+                    }
+                    .into(),
+                );
             }
 
             if let Some(gl) = gl {

--- a/wezterm-gui/src/termwindow/mod.rs
+++ b/wezterm-gui/src/termwindow/mod.rs
@@ -842,10 +842,10 @@ impl TermWindow {
             };
             myself.config_subscription.replace(config_subscription);
             if config.use_resize_increments {
-                window.set_resize_increments(
-                    myself.render_metrics.cell_size.width as u16,
-                    myself.render_metrics.cell_size.height as u16,
-                );
+                window.set_resize_increments(ResizeIncrement {
+                    x: myself.render_metrics.cell_size.width as u16,
+                    y: myself.render_metrics.cell_size.height as u16,
+                });
             }
 
             if let Some(gl) = gl {

--- a/wezterm-gui/src/termwindow/mod.rs
+++ b/wezterm-gui/src/termwindow/mod.rs
@@ -1708,7 +1708,7 @@ impl TermWindow {
 
         if let Some(window) = self.window.as_ref().map(|w| w.clone()) {
             self.load_os_parameters();
-            self.apply_scale_change(&dimensions, self.fonts.get_font_scale(), &window);
+            self.apply_scale_change(&dimensions, self.fonts.get_font_scale());
             self.apply_dimensions(&dimensions, None, &window);
             window.config_did_change(&config);
             window.invalidate();

--- a/wezterm-gui/src/termwindow/resize.rs
+++ b/wezterm-gui/src/termwindow/resize.rs
@@ -1,5 +1,5 @@
 use crate::utilsprites::RenderMetrics;
-use ::window::{Dimensions, Window, WindowOps, WindowState};
+use ::window::{Dimensions, ResizeIncrement, Window, WindowOps, WindowState};
 use config::{ConfigHandle, DimensionContext};
 use mux::Mux;
 use std::rc::Rc;
@@ -101,18 +101,14 @@ impl super::TermWindow {
             }
         }
 
-        window.set_resize_increments(
-            if self.config.use_resize_increments {
-                self.render_metrics.cell_size.width as u16
-            } else {
-                1
-            },
-            if self.config.use_resize_increments {
-                self.render_metrics.cell_size.height as u16
-            } else {
-                1
-            },
-        );
+        window.set_resize_increments(if self.config.use_resize_increments {
+            ResizeIncrement {
+                x: self.render_metrics.cell_size.width as u16,
+                y: self.render_metrics.cell_size.height as u16,
+            }
+        } else {
+            ResizeIncrement::disabled()
+        });
 
         if let Err(err) = self.recreate_texture_atlas(None) {
             log::error!("recreate_texture_atlas: {:#}", err);

--- a/window/src/lib.rs
+++ b/window/src/lib.rs
@@ -364,11 +364,18 @@ pub struct ResolvedGeometry {
 pub struct ResizeIncrement {
     pub x: u16,
     pub y: u16,
+    pub base_width: u16,
+    pub base_height: u16,
 }
 
 impl ResizeIncrement {
     /// Use this as a readable shorthand for disabling the feature
     pub fn disabled() -> Self {
-        Self { x: 1, y: 1 }
+        Self {
+            x: 1,
+            y: 1,
+            base_width: 0,
+            base_height: 0,
+        }
     }
 }

--- a/window/src/lib.rs
+++ b/window/src/lib.rs
@@ -330,7 +330,7 @@ pub trait WindowOps {
     /// the x and y values specified.
     /// This may not be supported or respected by the desktop
     /// environment.
-    fn set_resize_increments(&self, _x: u16, _y: u16) {}
+    fn set_resize_increments(&self, _incr: ResizeIncrement) {}
 
     fn get_os_parameters(
         &self,
@@ -358,4 +358,17 @@ pub struct ResolvedGeometry {
     pub y: Option<i32>,
     pub width: usize,
     pub height: usize,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct ResizeIncrement {
+    pub x: u16,
+    pub y: u16,
+}
+
+impl ResizeIncrement {
+    /// Use this as a readable shorthand for disabling the feature
+    pub fn disabled() -> Self {
+        Self { x: 1, y: 1 }
+    }
 }

--- a/window/src/os/macos/window.rs
+++ b/window/src/os/macos/window.rs
@@ -1257,9 +1257,15 @@ impl WindowInner {
     }
 
     fn set_resize_increments(&self, incr: ResizeIncrement) {
+        let min_width = incr.base_width + incr.x;
+        let min_height = incr.base_height + incr.y;
         unsafe {
             self.window
                 .setResizeIncrements_(NSSize::new(incr.x.into(), incr.y.into()));
+            let () = msg_send![
+                *self.window,
+                setContentMinSize: NSSize::new(min_width.into(), min_height.into())
+            ];
         }
     }
 

--- a/window/src/os/macos/window.rs
+++ b/window/src/os/macos/window.rs
@@ -10,8 +10,8 @@ use crate::parameters::{Border, Parameters, TitleBar};
 use crate::{
     Clipboard, Connection, DeadKeyStatus, Dimensions, Handled, KeyCode, KeyEvent, Modifiers,
     MouseButtons, MouseCursor, MouseEvent, MouseEventKind, MousePress, Point, RawKeyEvent, Rect,
-    RequestedWindowGeometry, ResolvedGeometry, ScreenPoint, Size, ULength, WindowDecorations,
-    WindowEvent, WindowEventSender, WindowOps, WindowState,
+    RequestedWindowGeometry, ResizeIncrement, ResolvedGeometry, ScreenPoint, Size, ULength,
+    WindowDecorations, WindowEvent, WindowEventSender, WindowOps, WindowState,
 };
 use anyhow::{anyhow, bail, ensure};
 use async_trait::async_trait;
@@ -827,9 +827,9 @@ impl WindowOps for Window {
         });
     }
 
-    fn set_resize_increments(&self, x: u16, y: u16) {
+    fn set_resize_increments(&self, incr: ResizeIncrement) {
         Connection::with_window_inner(self.id, move |inner| {
-            inner.set_resize_increments(x, y);
+            inner.set_resize_increments(incr);
             Ok(())
         });
     }
@@ -1256,10 +1256,10 @@ impl WindowInner {
         }
     }
 
-    fn set_resize_increments(&self, x: u16, y: u16) {
+    fn set_resize_increments(&self, incr: ResizeIncrement) {
         unsafe {
             self.window
-                .setResizeIncrements_(NSSize::new(x.into(), y.into()));
+                .setResizeIncrements_(NSSize::new(incr.x.into(), incr.y.into()));
         }
     }
 

--- a/window/src/os/wayland/window.rs
+++ b/window/src/os/wayland/window.rs
@@ -23,6 +23,7 @@ use raw_window_handle::{
 use smithay_client_toolkit as toolkit;
 use std::any::Any;
 use std::cell::RefCell;
+use std::cmp::max;
 use std::convert::TryInto;
 use std::io::Read;
 use std::os::unix::io::AsRawFd;
@@ -669,8 +670,16 @@ impl WaylandWindowInner {
 
                 if self.window_state.can_resize() {
                     if let Some(incr) = self.resize_increments {
-                        let desired_pixel_width = pixel_width - (pixel_width % incr.x as i32);
-                        let desired_pixel_height = pixel_height - (pixel_height % incr.y as i32);
+                        let min_width = incr.base_width + incr.x;
+                        let min_height = incr.base_height + incr.y;
+                        let desired_pixel_width = max(
+                            pixel_width - (pixel_width % incr.x as i32),
+                            min_width as i32,
+                        );
+                        let desired_pixel_height = max(
+                            pixel_height - (pixel_height % incr.y as i32),
+                            min_height as i32,
+                        );
                         w = self.pixels_to_surface(desired_pixel_width) as u32;
                         h = self.pixels_to_surface(desired_pixel_height) as u32;
                         pixel_width = self.surface_to_pixels(w.try_into().unwrap());

--- a/window/src/os/x11/window.rs
+++ b/window/src/os/x11/window.rs
@@ -4,9 +4,9 @@ use crate::connection::ConnectionOps;
 use crate::os::{xkeysyms, Connection, Window};
 use crate::{
     Appearance, Clipboard, DeadKeyStatus, Dimensions, MouseButtons, MouseCursor, MouseEvent,
-    MouseEventKind, MousePress, Point, Rect, RequestedWindowGeometry, ResolvedGeometry,
-    ScreenPoint, ScreenRect, WindowDecorations, WindowEvent, WindowEventSender, WindowOps,
-    WindowState,
+    MouseEventKind, MousePress, Point, Rect, RequestedWindowGeometry, ResizeIncrement,
+    ResolvedGeometry, ScreenPoint, ScreenRect, WindowDecorations, WindowEvent, WindowEventSender,
+    WindowOps, WindowState,
 };
 use anyhow::{anyhow, Context as _};
 use async_trait::async_trait;
@@ -1529,7 +1529,7 @@ impl XWindowInner {
             });
     }
 
-    fn set_resize_increments(&mut self, x: u16, y: u16) -> anyhow::Result<()> {
+    fn set_resize_increments(&mut self, incr: ResizeIncrement) -> anyhow::Result<()> {
         use xcb_util::*;
         let hints = xcb_size_hints_t {
             flags: XCB_ICCCM_SIZE_HINT_P_RESIZE_INC,
@@ -1541,8 +1541,8 @@ impl XWindowInner {
             min_height: 0,
             max_width: 0,
             max_height: 0,
-            width_inc: x.into(),
-            height_inc: y.into(),
+            width_inc: incr.x.into(),
+            height_inc: incr.y.into(),
             min_aspect_num: 0,
             min_aspect_den: 0,
             max_aspect_num: 0,
@@ -1753,9 +1753,9 @@ impl WindowOps for XWindow {
         });
     }
 
-    fn set_resize_increments(&self, x: u16, y: u16) {
+    fn set_resize_increments(&self, incr: ResizeIncrement) {
         XConnection::with_window_inner(self.0, move |inner| {
-            if let Err(err) = inner.set_resize_increments(x, y) {
+            if let Err(err) = inner.set_resize_increments(incr) {
                 log::error!("set_resize_increments failed: {:#}", err);
             }
             Ok(())

--- a/window/src/os/x11/window.rs
+++ b/window/src/os/x11/window.rs
@@ -1532,13 +1532,15 @@ impl XWindowInner {
     fn set_resize_increments(&mut self, incr: ResizeIncrement) -> anyhow::Result<()> {
         use xcb_util::*;
         let hints = xcb_size_hints_t {
-            flags: XCB_ICCCM_SIZE_HINT_P_RESIZE_INC | XCB_ICCCM_SIZE_HINT_BASE_SIZE,
+            flags: XCB_ICCCM_SIZE_HINT_P_MIN_SIZE
+                | XCB_ICCCM_SIZE_HINT_P_RESIZE_INC
+                | XCB_ICCCM_SIZE_HINT_BASE_SIZE,
             x: 0,
             y: 0,
             width: 0,
             height: 0,
-            min_width: 0,
-            min_height: 0,
+            min_width: (incr.base_width + incr.x).into(),
+            min_height: (incr.base_height + incr.y).into(),
             max_width: 0,
             max_height: 0,
             width_inc: incr.x.into(),

--- a/window/src/os/x11/window.rs
+++ b/window/src/os/x11/window.rs
@@ -1532,7 +1532,7 @@ impl XWindowInner {
     fn set_resize_increments(&mut self, incr: ResizeIncrement) -> anyhow::Result<()> {
         use xcb_util::*;
         let hints = xcb_size_hints_t {
-            flags: XCB_ICCCM_SIZE_HINT_P_RESIZE_INC,
+            flags: XCB_ICCCM_SIZE_HINT_P_RESIZE_INC | XCB_ICCCM_SIZE_HINT_BASE_SIZE,
             x: 0,
             y: 0,
             width: 0,
@@ -1547,8 +1547,8 @@ impl XWindowInner {
             min_aspect_den: 0,
             max_aspect_num: 0,
             max_aspect_den: 0,
-            base_width: 0,
-            base_height: 0,
+            base_width: incr.base_width.into(),
+            base_height: incr.base_height.into(),
             win_gravity: 0,
         };
 

--- a/window/src/os/x_and_wayland.rs
+++ b/window/src/os/x_and_wayland.rs
@@ -9,8 +9,8 @@ use crate::os::x11::connection::XConnection;
 use crate::os::x11::window::XWindow;
 use crate::screen::Screens;
 use crate::{
-    Appearance, Clipboard, MouseCursor, Rect, RequestedWindowGeometry, ScreenPoint, WindowEvent,
-    WindowOps,
+    Appearance, Clipboard, MouseCursor, Rect, RequestedWindowGeometry, ResizeIncrement,
+    ScreenPoint, WindowEvent, WindowOps,
 };
 use async_trait::async_trait;
 use config::ConfigHandle;
@@ -314,11 +314,11 @@ impl WindowOps for Window {
         }
     }
 
-    fn set_resize_increments(&self, x: u16, y: u16) {
+    fn set_resize_increments(&self, incr: ResizeIncrement) {
         match self {
-            Self::X11(x11) => x11.set_resize_increments(x, y),
+            Self::X11(x11) => x11.set_resize_increments(incr),
             #[cfg(feature = "wayland")]
-            Self::Wayland(w) => w.set_resize_increments(x, y),
+            Self::Wayland(w) => w.set_resize_increments(incr),
         }
     }
 


### PR DESCRIPTION
These changes fix an issue where the number of terminal cells can change when (1) using X11, (2) during zooming in or out (e.g., when pressing `ctrl+-` or `ctrl+=`), (3) with `use_resize_increment` enabled.

As a desirable side effect of these changes, when resizing the terminal, many X11 window managers will now report the current cell dimensions of the terminal (e.g., 80x24) as an overlay when resizing the window.  Previously this would be a different number (e.g., 81x25) that was near to but not exactly the cell dimensions.

Depending on the amount of padding, we could previously resize by dragging the edge of the window to get a negative size displayed by the window manager's overlay (e.g., 80x-1 for a very short window displaying zero terminal lines and only partially showing the top of the tabs).  It is also desirable to avoid 80x0 or 0x24 dimensions as these can render strangely.  For example, when there is a lot of padding, an 80x0 size can still show part of the top of the first line despite it being described as a cell height of zero. Therefore, we now hint to the window manager that the terminal should be a minimum of 1x1 cells.

Note that I have only been able to test these changes on X11.

This is my first time using rust, so I apologize for any unidiomatic code or for any unfamiliarity with this code base. :)

Note that these changes don't make much sense without [!4822](https://github.com/wez/wezterm/pull/4822), but I wanted to split that one off because I am hoping that one will be more straightforward to review.