### PR TITLE
Add additional outputs for nix's flake package

### DIFF
--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -125,6 +125,34 @@
             --add-needed "${pkgs.vulkan-loader}/lib/libvulkan.so.1" \
             $out/bin/wezterm-gui
         '';
+
+        postInstall = ''
+          mkdir -p $out/nix-support
+          echo "${passthru.terminfo}" >> $out/nix-support/propagated-user-env-packages
+
+          install -Dm644 assets/icon/terminal.png $out/share/icons/hicolor/128x128/apps/org.wezfurlong.wezterm.png
+          install -Dm644 assets/wezterm.desktop $out/share/applications/org.wezfurlong.wezterm.desktop
+          install -Dm644 assets/wezterm.appdata.xml $out/share/metainfo/org.wezfurlong.wezterm.appdata.xml
+
+          install -Dm644 assets/shell-integration/wezterm.sh -t $out/etc/profile.d
+          installShellCompletion --cmd wezterm \
+            --bash assets/shell-completion/bash \
+            --fish assets/shell-completion/fish \
+            --zsh assets/shell-completion/zsh
+
+          install -Dm644 assets/wezterm-nautilus.py -t $out/share/nautilus-python/extensions
+        '';
+
+        passthru = {
+          terminfo =
+            pkgs.runCommand "wezterm-terminfo"
+            {
+              nativeBuildInputs = [pkgs.ncurses];
+            } ''
+              mkdir -p $out/share/terminfo $out/nix-support
+              tic -x -o $out/share/terminfo ${src}/termwiz/data/wezterm.terminfo
+            '';
+        };
       };
 
       devShell = pkgs.mkShell {


### PR DESCRIPTION
Based on https://github.com/wez/wezterm/pull/3547#issuecomment-1890599432 and https://github.com/wez/wezterm/pull/3547#issuecomment-1890790535, I just added the additional outputs to the default package (terminfo, icon, desktop file, shell scripts), copied from https://github.com/NixOS/nixpkgs/blob/3dc440faeee9e889fe2d1b4d25ad0f430d449356/pkgs/applications/terminal-emulators/wezterm/default.nix