### PR TITLE
macos/clipboard: use try_quote instead of quote

### DIFF
--- a/window/src/os/macos/clipboard.rs
+++ b/window/src/os/macos/clipboard.rs
@@ -22,7 +22,10 @@ impl Clipboard {
             if !plist.is_null() {
                 let mut filenames = vec![];
                 for i in 0..plist.count() {
-                    filenames.push(shlex::quote(nsstring_to_str(plist.objectAtIndex(i))));
+                    filenames.push(
+                        shlex::try_quote(nsstring_to_str(plist.objectAtIndex(i)))
+                            .unwrap_or_else(|_| "".into()),
+                    );
                 }
                 return Ok(filenames.join(" "));
             }


### PR DESCRIPTION
[`shlex::quote`](https://github.com/comex/rust-shlex/security/advisories/GHSA-r7qv-8r2h-pg27) is deprecated, use `try_quote` to remove the warning in macOS