### PR TITLE
chore: add signal getter on exit status

### DIFF
--- a/pty/src/lib.rs
+++ b/pty/src/lib.rs
@@ -198,6 +198,11 @@ impl ExitStatus {
     pub fn exit_code(&self) -> u32 {
         self.code
     }
+
+    /// Returns the signal if present that this ExitStatus was constructed with
+    pub fn signal(&self) -> Option<&str> {
+        self.signal.as_deref()
+    }
 }
 
 impl From<std::process::ExitStatus> for ExitStatus {


### PR DESCRIPTION
Hi Wez, thanks for the great pty library.

Adding a getter for the signal on exit status.

I have a need to differentiate between processes that exit with a code of 1 and those that are killed by a signal. I'm currently using `exit_status.to_string().contains("Terminated by")` to determine if an exit status has a signal associated with it.

