### PR TITLE
fix: disproportionate cursor

### DIFF
--- a/wezterm-gui/src/customglyph.rs
+++ b/wezterm-gui/src/customglyph.rs
@@ -262,7 +262,7 @@ impl PolyStyle {
                 let mut stroke = Stroke::default();
                 stroke.width = width;
                 if self == PolyStyle::OutlineHeavy {
-                    stroke.width *= 3.1; // NOTE: Changing this makes block cursor unproportinal at different font sizes
+                    stroke.width *= 3.01; // NOTE: Changing this makes block cursor disproportionate at different font sizes and resolutions
                 } else if self == PolyStyle::OutlineThin {
                     stroke.width = 1.2;
                 }


### PR DESCRIPTION
Fixes disproportionate cursor on 4K resolution at any font size and on 1440p with font sizes bigger than 22.

Before:
![3 1-linux](https://github.com/wez/wezterm/assets/39203616/3f12f765-fd0f-4278-aca6-f2a5a54e6855)
After:
![3 01-linux](https://github.com/wez/wezterm/assets/39203616/c8458d0a-a473-4193-8d39-e517436450af)
