### PR TITLE
Nix flake fixes

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -32,4 +32,4 @@ jobs:
           flake-lock-path: ./nix/flake.lock
           ignore-missing-flake-lock: false
       - name: Build default package
-        run: nix build nix
+        run: nix build ./nix

--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -98,8 +98,7 @@
         cargoLock = {
           lockFile = ../Cargo.lock;
           outputHashes = {
-            "xcb-imdkit-0.2.0" = "sha256-L+NKD0rsCk9bFABQF4FZi9YoqBHr4VAZeKAWgsaAegw=";
-            "xcb-1.2.1" = "sha256-zkuW5ATix3WXBAj2hzum1MJ5JTX3+uVQ01R1vL6F1rY=";
+            "xcb-imdkit-0.3.0" = "sha256-fTpJ6uNhjmCWv7dZqVgYuS2Uic36XNYTbqlaly5QBjI=";
           };
         };
 


### PR DESCRIPTION
- xcb is no longer fetched from git
  - Now successfully builds (after 201fc1bf8e248a2c8ec3a7fbb168f7d130f7092e)
- ci was building `nix` the package manager itself instead of wezterm

cc: @happenslol, @gabyx, @edmundmiller