### PR TITLE
wayland: consider base in resize increment calculation

### DIFF
--- a/window/src/os/wayland/window.rs
+++ b/window/src/os/wayland/window.rs
@@ -672,14 +672,11 @@ impl WaylandWindowInner {
                     if let Some(incr) = self.resize_increments {
                         let min_width = incr.base_width + incr.x;
                         let min_height = incr.base_height + incr.y;
-                        let desired_pixel_width = max(
-                            pixel_width - (pixel_width % incr.x as i32),
-                            min_width as i32,
-                        );
-                        let desired_pixel_height = max(
-                            pixel_height - (pixel_height % incr.y as i32),
-                            min_height as i32,
-                        );
+                        let extra_width = (pixel_width - incr.base_width as i32) % incr.x as i32;
+                        let extra_height = (pixel_height - incr.base_height as i32) % incr.y as i32;
+                        let desired_pixel_width = max(pixel_width - extra_width, min_width as i32);
+                        let desired_pixel_height =
+                            max(pixel_height - extra_height, min_height as i32);
                         w = self.pixels_to_surface(desired_pixel_width) as u32;
                         h = self.pixels_to_surface(desired_pixel_height) as u32;
                         pixel_width = self.surface_to_pixels(w.try_into().unwrap());


### PR DESCRIPTION
This corrects the calculation so that the # of terminal cells will not change on a scale change.