### PR TITLE
WIP fix for i3 terminals sending mouse press before focus event

### DIFF
--- a/wezterm-gui/src/termwindow/mouseevent.rs
+++ b/wezterm-gui/src/termwindow/mouseevent.rs
@@ -755,7 +755,7 @@ impl super::TermWindow {
         }
 
         let allow_action = if self.is_click_to_focus_window || !is_focused {
-            matches!(&event.kind, WMEK::VertWheel(_) | WMEK::HorzWheel(_))
+            matches!(&event.kind, WMEK::VertWheel(_) | WMEK::HorzWheel(_) | WMEK::Press(_))
         } else {
             true
         };


### PR DESCRIPTION
I don't expect this is the correct place for this fix but the thinking
is that the window only gets the mouse press event if the mouse is over
the terminal window. In this case it makes sense (to me?) that if the
window doesn't have focus, the click should still be passed to the
application.
