### PR TITLE
Fix rescale race

### DIFF
--- a/wezterm-gui/src/scripting/guiwin.rs
+++ b/wezterm-gui/src/scripting/guiwin.rs
@@ -56,7 +56,8 @@ impl UserData for GuiWin {
         methods.add_method(
             "set_inner_size",
             |_, this, (width, height): (usize, usize)| {
-                this.window.set_inner_size(width, height);
+                this.window
+                    .notify(TermWindowNotif::SetInnerSize { width, height });
                 Ok(())
             },
         );

--- a/window/examples/async.rs
+++ b/window/examples/async.rs
@@ -86,7 +86,8 @@ impl MyWindow {
             | WindowEvent::DraggedFile(_)
             | WindowEvent::DroppedFile(_)
             | WindowEvent::PerformKeyAssignment(_)
-            | WindowEvent::MouseLeave => {}
+            | WindowEvent::MouseLeave
+            | WindowEvent::SetInnerSizeCompleted => {}
         }
     }
 }

--- a/window/src/lib.rs
+++ b/window/src/lib.rs
@@ -171,6 +171,9 @@ pub enum WindowEvent {
         live_resizing: bool,
     },
 
+    /// Called when a program-requested set_inner_size() has finished
+    SetInnerSizeCompleted,
+
     /// Called when the window has been invalidated and needs to
     /// be repainted
     NeedRepaint,

--- a/window/src/os/macos/window.rs
+++ b/window/src/os/macos/window.rs
@@ -776,6 +776,13 @@ impl WindowOps for Window {
     fn set_inner_size(&self, width: usize, height: usize) {
         Connection::with_window_inner(self.id, move |inner| {
             inner.set_inner_size(width, height);
+            if let Some(window_view) = WindowView::get_this(unsafe { &**inner.view }) {
+                window_view
+                    .inner
+                    .borrow_mut()
+                    .events
+                    .dispatch(WindowEvent::SetInnerSizeCompleted);
+            }
             Ok(())
         });
     }

--- a/window/src/os/wayland/window.rs
+++ b/window/src/os/wayland/window.rs
@@ -976,7 +976,7 @@ impl WaylandWindowInner {
         Ok(())
     }
 
-    fn set_inner_size(&mut self, width: usize, height: usize) -> Dimensions {
+    fn set_inner_size(&mut self, width: usize, height: usize) {
         let pixel_width = width as i32;
         let pixel_height = height as i32;
         let surface_width = self.pixels_to_surface(pixel_width) as u32;
@@ -993,7 +993,7 @@ impl WaylandWindowInner {
         // apply the synthetic configure event to the inner surfaces
         self.dispatch_pending_event();
 
-        self.dimensions.clone()
+        self.events.dispatch(WindowEvent::SetInnerSizeCompleted);
     }
 
     fn do_paint(&mut self) -> anyhow::Result<()> {

--- a/window/src/os/windows/window.rs
+++ b/window/src/os/windows/window.rs
@@ -898,6 +898,10 @@ impl WindowOps for Window {
                             SWP_NOACTIVATE | SWP_NOMOVE | SWP_NOZORDER,
                         );
                         wm_paint(hwnd.0, 0, 0, 0);
+                        if let Some(inner) = rc_from_hwnd(hwnd.0) {
+                            let mut inner = inner.borrow_mut();
+                            inner.events.dispatch(WindowEvent::SetInnerSizeCompleted);
+                        }
                     }
                 } else {
                     log::trace!(


### PR DESCRIPTION
This merge request introduces and implements `ResizeFinished` events.  These are used to signal, after a resize request (namely, a call to `WindowOps::set_inner_size()`), at what point we can expect any and all of its related `Resized` events to have already been dispatched.  `ResizeFinished` events are used to fix a race condition in rescaling the terminal in which the number of cells of the terminal (e.g., 80x24) can change when quickly rescaling the terminal. We do this by not executing rescale requests until all pending resize requests are finished, queuing the rescale requests if necessary.

On Wayland, we dispatch a `ResizeFinished` event after `WaylandWindowInner::set_inner_size()` is called.  In my testing on weston, this addresses the race on Wayland, but there may be some subtleties to this platform that I don't currently appreciate.

On X11, well, this is currently a little complicated, but it seems to work in my testing. After issuing a `ConfigureRequest` for our "real" window, we create an unmapped dummy window and immediately reconfigure it as well.  Once we receive the corresponding `ConfigureNotify` event for this dummy window, we issue a `ResizeFinished` request after all of the `Resized` events we have to dispatch for all of the "real" `ConfigureNotify` events that we have already received have already been dispatched.  The basic assumption of this approach is that we will have received the `ConfigureNotify` event for our "real" `ConfigureWindow` request before receiving the one for our dummy `ConfigureWindow` request since we reconfigured the "real" window before the dummy.  Is it a valid assumption?  At least in my testing by mashing the rescale shortcut keys, this approach seems to address the race condition on muffin, metacity, kwin, xfwm4, and awesome (in tiling mode).  The underlying difficulty with X11 motivating this approach is that we cannot easily distinguish `ConfigureNotify` events generated in response to our `ConfigureWindow` request versus those from other sources such as, say, a user resizing the window by dragging the window's border, whereas a `ConfigureNotify` event for an unmapped dummy window is easier to interpret.

On Windows and MacOS, I'm doing this blindly without testing or type checking, but I'm presently assuming that the solution is similar to Wayland's.  Otherwise, I'm hoping that with some additional instrumentation these platforms can be correctly implemented similar to what was necessary to implement X11.

I'm curious what you think about this overall approach.  My overall goal is to be able to fearlessly rescale the terminal by mashing ctrl+- or ctrl+= without the # of terminal cells changing.