### PR TITLE
Set default cargo target to wezterm-gui

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
   "wezterm-open-url",
   "wezterm-ssh"
 ]
+default-members = ["wezterm-gui"]
 resolver = "2"
 exclude = [
   "termwiz/codegen"


### PR DESCRIPTION
I was following the steps in the CONTRIBUTING file and I was prompted to specify a bin when I used `cargo run`. This change makes `cargo run` choose the `wezterm-gui` package if nothing is specified.

https://doc.rust-lang.org/cargo/reference/workspaces.html#the-default-members-field