### PR TITLE
Add show_close_tab_button_in_tab config option

### DIFF
--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -457,6 +457,9 @@ pub struct Config {
     #[dynamic(default = "default_true")]
     pub show_new_tab_button_in_tab_bar: bool,
 
+    #[dynamic(default = "default_true")]
+    pub show_close_tab_button_in_tab: bool,
+
     /// If true, show_tab_index_in_tab_bar uses a zero-based index.
     /// The default is false and the tab shows a one-based index.
     #[dynamic(default)]

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -24,6 +24,9 @@ As features stabilize some brief notes about them will accumulate here.
 #### Changed
 * Not yet!
 #### New
+* [show_close_tab_button_in_tab](config/lua/config/show_close_tab_button_in_tab.md)
+  config option to customize the tab bar appearance.
+
 #### Fixed
 
 ### 20240128-202157-1e552d76

--- a/docs/config/lua/config/show_close_tab_button_in_tab.md
+++ b/docs/config/lua/config/show_close_tab_button_in_tab.md
@@ -1,0 +1,27 @@
+---
+tags:
+  - tab_bar
+---
+# `show_close_tab_button_in_tab = true`
+
+{{since('nightly')}}
+
+When set to `true` (the default), the tab bar will display the close-tab
+button in each tab, which can be left-clicked to close the tab.
+
+When set to `false`, the close-tab button will not be drawn into each tab.
+
+This example turns off the tabs, new-tab button, and close-tab buttons, leaving
+just the left and right status areas:
+
+```lua
+wezterm.on('update-right-status', function(window, pane)
+  window:set_left_status 'left'
+  window:set_right_status 'right'
+end)
+
+config.use_fancy_tab_bar = false
+config.show_tabs_in_tab_bar = false
+config.show_new_tab_button_in_tab_bar = false
+config.show_close_tab_button_in_tab = false
+```

--- a/wezterm-gui/src/termwindow/render/fancy_tab_bar.rs
+++ b/wezterm-gui/src/termwindow/render/fancy_tab_bar.rs
@@ -343,63 +343,65 @@ impl crate::TermWindow {
                         ElementContent::Text(_) => unreachable!(),
                         ElementContent::Poly { .. } => unreachable!(),
                         ElementContent::Children(mut kids) => {
-                            let x_button = Element::new(
-                                &font,
-                                ElementContent::Poly {
-                                    line_width: metrics.underline_height.max(2),
-                                    poly: SizedPoly {
-                                        poly: X_BUTTON,
-                                        width: Dimension::Pixels(
-                                            metrics.cell_size.height as f32 / 2.,
-                                        ),
-                                        height: Dimension::Pixels(
-                                            metrics.cell_size.height as f32 / 2.,
-                                        ),
+                            if self.config.show_close_tab_button_in_tab {
+                                let x_button = Element::new(
+                                    &font,
+                                    ElementContent::Poly {
+                                        line_width: metrics.underline_height.max(2),
+                                        poly: SizedPoly {
+                                            poly: X_BUTTON,
+                                            width: Dimension::Pixels(
+                                                metrics.cell_size.height as f32 / 2.,
+                                            ),
+                                            height: Dimension::Pixels(
+                                                metrics.cell_size.height as f32 / 2.,
+                                            ),
+                                        },
                                     },
-                                },
-                            )
-                            // Ensure that we draw our background over the
-                            // top of the rest of the tab contents
-                            .zindex(1)
-                            .vertical_align(VerticalAlign::Middle)
-                            .float(Float::Right)
-                            .item_type(UIItemType::CloseTab(tab_idx))
-                            .hover_colors({
-                                let inactive_tab_hover = colors.inactive_tab_hover();
-                                let active_tab = colors.active_tab();
+                                )
+                                // Ensure that we draw our background over the
+                                // top of the rest of the tab contents
+                                .zindex(1)
+                                .vertical_align(VerticalAlign::Middle)
+                                .float(Float::Right)
+                                .item_type(UIItemType::CloseTab(tab_idx))
+                                .hover_colors({
+                                    let inactive_tab_hover = colors.inactive_tab_hover();
+                                    let active_tab = colors.active_tab();
 
-                                Some(ElementColors {
-                                    border: BorderColor::default(),
-                                    bg: (if active {
-                                        inactive_tab_hover.bg_color
-                                    } else {
-                                        active_tab.bg_color
+                                    Some(ElementColors {
+                                        border: BorderColor::default(),
+                                        bg: (if active {
+                                            inactive_tab_hover.bg_color
+                                        } else {
+                                            active_tab.bg_color
+                                        })
+                                        .to_linear()
+                                        .into(),
+                                        text: (if active {
+                                            inactive_tab_hover.fg_color
+                                        } else {
+                                            active_tab.fg_color
+                                        })
+                                        .to_linear()
+                                        .into(),
                                     })
-                                    .to_linear()
-                                    .into(),
-                                    text: (if active {
-                                        inactive_tab_hover.fg_color
-                                    } else {
-                                        active_tab.fg_color
-                                    })
-                                    .to_linear()
-                                    .into(),
                                 })
-                            })
-                            .padding(BoxDimension {
-                                left: Dimension::Cells(0.25),
-                                right: Dimension::Cells(0.25),
-                                top: Dimension::Cells(0.25),
-                                bottom: Dimension::Cells(0.25),
-                            })
-                            .margin(BoxDimension {
-                                left: Dimension::Cells(0.5),
-                                right: Dimension::Cells(0.),
-                                top: Dimension::Cells(0.),
-                                bottom: Dimension::Cells(0.),
-                            });
+                                .padding(BoxDimension {
+                                    left: Dimension::Cells(0.25),
+                                    right: Dimension::Cells(0.25),
+                                    top: Dimension::Cells(0.25),
+                                    bottom: Dimension::Cells(0.25),
+                                })
+                                .margin(BoxDimension {
+                                    left: Dimension::Cells(0.5),
+                                    right: Dimension::Cells(0.),
+                                    top: Dimension::Cells(0.),
+                                    bottom: Dimension::Cells(0.),
+                                });
 
-                            kids.push(x_button);
+                                kids.push(x_button);
+                            }
                             ElementContent::Children(kids)
                         }
                     };


### PR DESCRIPTION
This allows for hiding the close button on each tab when using the fancy_tab_bar.

For the doc I based it on `show_new_tab_button_in_tab_bar.md`.