### PR TITLE
Add a CloseWithoutClear copy mode key assignment

### DIFF
--- a/config/src/keyassignment.rs
+++ b/config/src/keyassignment.rs
@@ -673,7 +673,6 @@ pub enum CopyModeAssignment {
     PageUp,
     PageDown,
     Close,
-    CloseWithoutClear,
     PriorMatch,
     NextMatch,
     PriorMatchPage,
@@ -690,6 +689,7 @@ pub enum CopyModeAssignment {
     JumpBackward { prev_char: bool },
     JumpAgain,
     JumpReverse,
+    ResetViewport,
 }
 
 pub type KeyTable = HashMap<(KeyCode, Modifiers), KeyTableEntry>;

--- a/config/src/keyassignment.rs
+++ b/config/src/keyassignment.rs
@@ -673,6 +673,7 @@ pub enum CopyModeAssignment {
     PageUp,
     PageDown,
     Close,
+    CloseWithoutClear,
     PriorMatch,
     NextMatch,
     PriorMatchPage,

--- a/config/src/keyassignment.rs
+++ b/config/src/keyassignment.rs
@@ -689,7 +689,6 @@ pub enum CopyModeAssignment {
     JumpBackward { prev_char: bool },
     JumpAgain,
     JumpReverse,
-    ResetViewport,
 }
 
 pub type KeyTable = HashMap<(KeyCode, Modifiers), KeyTableEntry>;

--- a/docs/examples/default-copy-mode-key-table.markdown
+++ b/docs/examples/default-copy-mode-key-table.markdown
@@ -17,8 +17,8 @@ return {
         action = act.CopyMode 'MoveToStartOfNextLine',
       },
       { key = 'Escape', mods = 'NONE', action = act.Multiple {
+          { CopyMode = 'ScrollToBottom' },
           { CopyMode = 'Close' },
-          { CopyMode = 'ResetViewport' },
       } },
       {
         key = 'Space',
@@ -128,8 +128,8 @@ return {
       { key = 'b', mods = 'ALT', action = act.CopyMode 'MoveBackwardWord' },
       { key = 'b', mods = 'CTRL', action = act.CopyMode 'PageUp' },
       { key = 'c', mods = 'CTRL', action = act.Multiple {
+          { CopyMode = 'ScrollToBottom' },
           { CopyMode = 'Close' },
-          { CopyMode = 'ResetViewport' },
       } },
       {
         key = 'd',
@@ -154,8 +154,8 @@ return {
         action = act.CopyMode 'MoveToScrollbackTop',
       },
       { key = 'g', mods = 'CTRL', action = act.Multiple {
+          { CopyMode = 'ScrollToBottom' },
           { CopyMode = 'Close' },
-          { CopyMode = 'ResetViewport' },
       } },
       { key = 'h', mods = 'NONE', action = act.CopyMode 'MoveLeft' },
       { key = 'j', mods = 'NONE', action = act.CopyMode 'MoveDown' },
@@ -172,8 +172,8 @@ return {
         action = act.CopyMode 'MoveToSelectionOtherEnd',
       },
       { key = 'q', mods = 'NONE', action = act.Multiple {
+          { CopyMode = 'ScrollToBottom' },
           { CopyMode = 'Close' },
-          { CopyMode = 'ResetViewport' },
       } },
       {
         key = 't',
@@ -201,8 +201,8 @@ return {
         mods = 'NONE',
         action = act.Multiple {
           { CopyTo = 'ClipboardAndPrimarySelection' },
+          { CopyMode = 'ScrollToBottom' },
           { CopyMode = 'Close' },
-          { CopyMode = 'ResetViewport' },
         },
       },
       { key = 'PageUp', mods = 'NONE', action = act.CopyMode 'PageUp' },

--- a/docs/examples/default-copy-mode-key-table.markdown
+++ b/docs/examples/default-copy-mode-key-table.markdown
@@ -16,7 +16,10 @@ return {
         mods = 'NONE',
         action = act.CopyMode 'MoveToStartOfNextLine',
       },
-      { key = 'Escape', mods = 'NONE', action = act.CopyMode 'Close' },
+      { key = 'Escape', mods = 'NONE', action = act.Multiple {
+          { CopyMode = 'Close' },
+          { CopyMode = 'ResetViewport' },
+      } },
       {
         key = 'Space',
         mods = 'NONE',
@@ -124,7 +127,10 @@ return {
       { key = 'b', mods = 'NONE', action = act.CopyMode 'MoveBackwardWord' },
       { key = 'b', mods = 'ALT', action = act.CopyMode 'MoveBackwardWord' },
       { key = 'b', mods = 'CTRL', action = act.CopyMode 'PageUp' },
-      { key = 'c', mods = 'CTRL', action = act.CopyMode 'Close' },
+      { key = 'c', mods = 'CTRL', action = act.Multiple {
+          { CopyMode = 'Close' },
+          { CopyMode = 'ResetViewport' },
+      } },
       {
         key = 'd',
         mods = 'CTRL',
@@ -147,7 +153,10 @@ return {
         mods = 'NONE',
         action = act.CopyMode 'MoveToScrollbackTop',
       },
-      { key = 'g', mods = 'CTRL', action = act.CopyMode 'Close' },
+      { key = 'g', mods = 'CTRL', action = act.Multiple {
+          { CopyMode = 'Close' },
+          { CopyMode = 'ResetViewport' },
+      } },
       { key = 'h', mods = 'NONE', action = act.CopyMode 'MoveLeft' },
       { key = 'j', mods = 'NONE', action = act.CopyMode 'MoveDown' },
       { key = 'k', mods = 'NONE', action = act.CopyMode 'MoveUp' },
@@ -162,7 +171,10 @@ return {
         mods = 'NONE',
         action = act.CopyMode 'MoveToSelectionOtherEnd',
       },
-      { key = 'q', mods = 'NONE', action = act.CopyMode 'Close' },
+      { key = 'q', mods = 'NONE', action = act.Multiple {
+          { CopyMode = 'Close' },
+          { CopyMode = 'ResetViewport' },
+      } },
       {
         key = 't',
         mods = 'NONE',
@@ -190,6 +202,7 @@ return {
         action = act.Multiple {
           { CopyTo = 'ClipboardAndPrimarySelection' },
           { CopyMode = 'Close' },
+          { CopyMode = 'ResetViewport' },
         },
       },
       { key = 'PageUp', mods = 'NONE', action = act.CopyMode 'PageUp' },

--- a/wezterm-gui/src/overlay/copy.rs
+++ b/wezterm-gui/src/overlay/copy.rs
@@ -1206,7 +1206,6 @@ impl Pane for CopyOverlay {
                     JumpBackward { prev_char } => render.jump(false, *prev_char),
                     JumpAgain => render.jump_again(false),
                     JumpReverse => render.jump_again(true),
-                    ResetViewport => render.set_viewport(None),
                 }
                 PerformAssignmentResult::Handled
             }
@@ -1574,40 +1573,35 @@ pub fn search_key_table() -> KeyTable {
     table
 }
 
+fn scroll_to_bottom_and_close() -> KeyAssignment {
+    KeyAssignment::Multiple(vec![
+        KeyAssignment::ScrollToBottom,
+        KeyAssignment::CopyMode(CopyModeAssignment::Close),
+    ])
+}
+
 pub fn copy_key_table() -> KeyTable {
     let mut table = KeyTable::default();
     for (key, mods, action) in [
         (
             WKeyCode::Char('c'),
             Modifiers::CTRL,
-            KeyAssignment::Multiple(vec![
-                KeyAssignment::CopyMode(CopyModeAssignment::Close),
-                KeyAssignment::CopyMode(CopyModeAssignment::ResetViewport),
-            ]),
+            scroll_to_bottom_and_close(),
         ),
         (
             WKeyCode::Char('g'),
             Modifiers::CTRL,
-            KeyAssignment::Multiple(vec![
-                KeyAssignment::CopyMode(CopyModeAssignment::Close),
-                KeyAssignment::CopyMode(CopyModeAssignment::ResetViewport),
-            ]),
+            scroll_to_bottom_and_close(),
         ),
         (
             WKeyCode::Char('q'),
             Modifiers::NONE,
-            KeyAssignment::Multiple(vec![
-                KeyAssignment::CopyMode(CopyModeAssignment::Close),
-                KeyAssignment::CopyMode(CopyModeAssignment::ResetViewport),
-            ]),
+            scroll_to_bottom_and_close(),
         ),
         (
             WKeyCode::Char('\x1b'),
             Modifiers::NONE,
-            KeyAssignment::Multiple(vec![
-                KeyAssignment::CopyMode(CopyModeAssignment::Close),
-                KeyAssignment::CopyMode(CopyModeAssignment::ResetViewport),
-            ]),
+            scroll_to_bottom_and_close(),
         ),
         (
             WKeyCode::Char('h'),
@@ -1859,8 +1853,7 @@ pub fn copy_key_table() -> KeyTable {
             Modifiers::NONE,
             KeyAssignment::Multiple(vec![
                 KeyAssignment::CopyTo(ClipboardCopyDestination::ClipboardAndPrimarySelection),
-                KeyAssignment::CopyMode(CopyModeAssignment::Close),
-                KeyAssignment::CopyMode(CopyModeAssignment::ResetViewport),
+                scroll_to_bottom_and_close(),
             ]),
         ),
         (

--- a/wezterm-gui/src/overlay/copy.rs
+++ b/wezterm-gui/src/overlay/copy.rs
@@ -556,8 +556,10 @@ impl CopyRenderable {
             })));
     }
 
-    fn close(&self) {
-        self.set_viewport(None);
+    fn close(&self, clear_viewport: bool) {
+        if clear_viewport {
+            self.set_viewport(None);
+        }
         TermWindow::schedule_cancel_overlay_for_pane(self.window.clone(), self.delegate.pane_id());
     }
 
@@ -1188,7 +1190,8 @@ impl Pane for CopyOverlay {
                     MoveByPage(n) => render.move_by_page(**n),
                     PageUp => render.move_by_page(-1.0),
                     PageDown => render.move_by_page(1.0),
-                    Close => render.close(),
+                    Close => render.close(true),
+                    CloseWithoutClear => render.close(false),
                     PriorMatch => render.prior_match(),
                     NextMatch => render.next_match(),
                     PriorMatchPage => render.prior_match_page(),
@@ -1521,7 +1524,7 @@ pub fn search_key_table() -> KeyTable {
         (
             WKeyCode::Char('\x1b'),
             Modifiers::NONE,
-            KeyAssignment::CopyMode(CopyModeAssignment::Close),
+            KeyAssignment::CopyMode(CopyModeAssignment::CloseWithoutClear),
         ),
         (
             WKeyCode::UpArrow,

--- a/wezterm-gui/src/overlay/copy.rs
+++ b/wezterm-gui/src/overlay/copy.rs
@@ -556,10 +556,7 @@ impl CopyRenderable {
             })));
     }
 
-    fn close(&self, clear_viewport: bool) {
-        if clear_viewport {
-            self.set_viewport(None);
-        }
+    fn close(&self) {
         TermWindow::schedule_cancel_overlay_for_pane(self.window.clone(), self.delegate.pane_id());
     }
 
@@ -1190,8 +1187,7 @@ impl Pane for CopyOverlay {
                     MoveByPage(n) => render.move_by_page(**n),
                     PageUp => render.move_by_page(-1.0),
                     PageDown => render.move_by_page(1.0),
-                    Close => render.close(true),
-                    CloseWithoutClear => render.close(false),
+                    Close => render.close(),
                     PriorMatch => render.prior_match(),
                     NextMatch => render.next_match(),
                     PriorMatchPage => render.prior_match_page(),
@@ -1210,6 +1206,7 @@ impl Pane for CopyOverlay {
                     JumpBackward { prev_char } => render.jump(false, *prev_char),
                     JumpAgain => render.jump_again(false),
                     JumpReverse => render.jump_again(true),
+                    ResetViewport => render.set_viewport(None),
                 }
                 PerformAssignmentResult::Handled
             }
@@ -1524,7 +1521,7 @@ pub fn search_key_table() -> KeyTable {
         (
             WKeyCode::Char('\x1b'),
             Modifiers::NONE,
-            KeyAssignment::CopyMode(CopyModeAssignment::CloseWithoutClear),
+            KeyAssignment::CopyMode(CopyModeAssignment::Close),
         ),
         (
             WKeyCode::UpArrow,
@@ -1583,22 +1580,34 @@ pub fn copy_key_table() -> KeyTable {
         (
             WKeyCode::Char('c'),
             Modifiers::CTRL,
-            KeyAssignment::CopyMode(CopyModeAssignment::Close),
+            KeyAssignment::Multiple(vec![
+                KeyAssignment::CopyMode(CopyModeAssignment::Close),
+                KeyAssignment::CopyMode(CopyModeAssignment::ResetViewport),
+            ]),
         ),
         (
             WKeyCode::Char('g'),
             Modifiers::CTRL,
-            KeyAssignment::CopyMode(CopyModeAssignment::Close),
+            KeyAssignment::Multiple(vec![
+                KeyAssignment::CopyMode(CopyModeAssignment::Close),
+                KeyAssignment::CopyMode(CopyModeAssignment::ResetViewport),
+            ]),
         ),
         (
             WKeyCode::Char('q'),
             Modifiers::NONE,
-            KeyAssignment::CopyMode(CopyModeAssignment::Close),
+            KeyAssignment::Multiple(vec![
+                KeyAssignment::CopyMode(CopyModeAssignment::Close),
+                KeyAssignment::CopyMode(CopyModeAssignment::ResetViewport),
+            ]),
         ),
         (
             WKeyCode::Char('\x1b'),
             Modifiers::NONE,
-            KeyAssignment::CopyMode(CopyModeAssignment::Close),
+            KeyAssignment::Multiple(vec![
+                KeyAssignment::CopyMode(CopyModeAssignment::Close),
+                KeyAssignment::CopyMode(CopyModeAssignment::ResetViewport),
+            ]),
         ),
         (
             WKeyCode::Char('h'),
@@ -1851,6 +1860,7 @@ pub fn copy_key_table() -> KeyTable {
             KeyAssignment::Multiple(vec![
                 KeyAssignment::CopyTo(ClipboardCopyDestination::ClipboardAndPrimarySelection),
                 KeyAssignment::CopyMode(CopyModeAssignment::Close),
+                KeyAssignment::CopyMode(CopyModeAssignment::ResetViewport),
             ]),
         ),
         (


### PR DESCRIPTION
Closing the copy overlay currently unconditionally clears the viewport,
in particular resetting scroll. For the search overlay, we don't
necessarily want to scroll back to the prompt after finding a match --
indeed, the old search overlay (which didn't use copy mode) had this
behaviour.

Add a CloseWithoutClear key assignment which has this desired behaviour,
and make it the default for ESC in search mode.
