### PR TITLE
Add lua version to debug overlay

### DIFF
--- a/wezterm-gui/src/overlay/debug.rs
+++ b/wezterm-gui/src/overlay/debug.rs
@@ -149,6 +149,7 @@ pub fn show_debug_overlay(
 
     lua.load("wezterm = require 'wezterm'").exec()?;
     lua.globals().set("window", gui_win)?;
+    let lua_version: String = lua.globals().get("_VERSION")?;
 
     let mut host = Some(LuaReplHost::new(lua));
 
@@ -199,6 +200,7 @@ pub fn show_debug_overlay(
         "Debug Overlay\r\n\
          wezterm version: {version} {triple}\r\n\
          Window Environment: {connection_info}\r\n\
+         Lua Version: {lua_version}\r\n\
          {opengl_info}\r\n\
          Enter lua statements or expressions and hit Enter.\r\n\
          Press ESC or CTRL-D to exit\r\n",


### PR DESCRIPTION
Work for https://github.com/wez/wezterm/issues/4917 (I'll also try to update the docs)

<img width="632" alt="image" src="https://github.com/wez/wezterm/assets/6081085/2d81afca-0398-4279-acc9-29b905a20c8e">

﻿﻿In addition to manually testing by opening the debug overlay in the screenshot above, I also ran `cargo test`, `cargo fmt` and `cargo build`. I'm not a Rust dev, so I hope I didn't miss a step!