### PR TITLE
Add YAML/TOML parsers for Lua configuration API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1555,7 +1555,6 @@ dependencies = [
  "dirs-next",
  "env_logger 0.10.2",
  "filesystem",
- "json",
  "lazy_static",
  "libc",
  "log",
@@ -1564,6 +1563,7 @@ dependencies = [
  "objc",
  "plugin",
  "procinfo-funcs",
+ "serde-funcs",
  "share-data",
  "spawn-funcs",
  "ssh-funcs",
@@ -2774,17 +2774,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a1d36f1235bc969acba30b7f5990b864423a6068a10f7c90ae8f0112e3a59d1"
 dependencies = [
  "wasm-bindgen",
-]
-
-[[package]]
-name = "json"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "config",
- "luahelper",
- "serde_json",
- "wezterm-dynamic",
 ]
 
 [[package]]
@@ -4764,6 +4753,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "870026e60fa08c69f064aa766c10f10b1d62db9ccd4d0abb206472bee0ce3b32"
 dependencies = [
  "serde_derive",
+]
+
+[[package]]
+name = "serde-funcs"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "config",
+ "luahelper",
+ "serde_json",
+ "serde_yaml",
+ "toml 0.8.9",
+ "wezterm-dynamic",
 ]
 
 [[package]]

--- a/ci/generate-docs.py
+++ b/ci/generate-docs.py
@@ -395,6 +395,10 @@ TOC = [
                 "config/lua/wezterm.procinfo",
             ),
             Gen(
+                "module: wezterm.serde",
+                "config/lua/wezterm.serde",
+            ),
+            Gen(
                 "module: wezterm.time",
                 "config/lua/wezterm.time",
             ),

--- a/docs/config/lua/wezterm.serde/index.markdown
+++ b/docs/config/lua/wezterm.serde/index.markdown
@@ -1,0 +1,8 @@
+# `wezterm.serde` module
+
+{{since('nightly')}}
+
+The `wezterm.serde` module provides functions for parsing the given string as 
+`json`, `yaml`, or `toml`, returning the corresponding `Lua` values, and vice versa.
+
+## Available functions

--- a/docs/config/lua/wezterm.serde/json_decode.md
+++ b/docs/config/lua/wezterm.serde/json_decode.md
@@ -1,0 +1,12 @@
+# `wezterm.serde.json_decode(string)`
+
+{{since('nightly')}}
+
+Parses the supplied string as `json` and returns the equivalent `lua` values:
+
+```
+> wezterm.serde.json_decode('{"foo":"bar"}')
+{
+    "foo": "bar",
+}
+```

--- a/docs/config/lua/wezterm.serde/json_encode.md
+++ b/docs/config/lua/wezterm.serde/json_encode.md
@@ -1,0 +1,10 @@
+# `wezterm.serde.json_encode(value)`
+
+{{since('nightly')}}
+
+Encodes the supplied `lua` value as `json`:
+
+```
+> wezterm.serde.json_encode({foo = "bar"})
+"{\"foo\":\"bar\"}"
+```

--- a/docs/config/lua/wezterm.serde/json_encode_pretty.md
+++ b/docs/config/lua/wezterm.serde/json_encode_pretty.md
@@ -1,0 +1,10 @@
+# `wezterm.serde.json_encode_pretty(value)`
+
+{{since('nightly')}}
+
+Encodes the supplied `lua` value as a pretty-printed string of `json`: 
+
+```
+> wezterm.serde.json_encode_pretty({foo = "bar"})
+"{\n  \"foo\": \"bar\"\n}"
+```

--- a/docs/config/lua/wezterm.serde/toml_decode.md
+++ b/docs/config/lua/wezterm.serde/toml_decode.md
@@ -1,0 +1,12 @@
+# `wezterm.serde.toml_decode(string)`
+
+{{since('nightly')}}
+
+Parses the supplied string as `toml` and returns the equivalent `lua` values:
+
+```
+> wezterm.serde.toml_decode('foo = "bar"')
+{
+    "foo": "bar",
+}
+```

--- a/docs/config/lua/wezterm.serde/toml_encode.md
+++ b/docs/config/lua/wezterm.serde/toml_encode.md
@@ -1,0 +1,10 @@
+# `wezterm.serde.toml_encode(value)`
+
+{{since('nightly')}}
+
+Encodes the supplied `lua` value as `toml`:
+
+```
+> wezterm.serde.toml_encode({foo = { "bar", "baz", "qux" } })
+"foo = [\"bar\", \"baz\", \"qux\"]\n"
+```

--- a/docs/config/lua/wezterm.serde/toml_encode_pretty.md
+++ b/docs/config/lua/wezterm.serde/toml_encode_pretty.md
@@ -1,0 +1,10 @@
+# `wezterm.serde.toml_encode_pretty(value)`
+
+{{since('nightly')}}
+
+Encodes the supplied `lua` value as a pretty-printed string of `toml`: 
+
+```
+> wezterm.serde.toml_encode_pretty({foo = { "bar", "baz", "qux" } })
+"foo = [\n    \"bar\",\n    \"baz\",\n    \"qux\",\n]\n"
+```

--- a/docs/config/lua/wezterm.serde/yaml_decode.md
+++ b/docs/config/lua/wezterm.serde/yaml_decode.md
@@ -1,0 +1,12 @@
+# `wezterm.serde.yaml_decode(string)`
+
+{{since('nightly')}}
+
+Parses the supplied string as `yaml` and returns the equivalent `lua` values:
+
+```
+> wezterm.serde.yaml_decode('---\n# comment\nfoo: "bar"')
+{
+    "foo": "bar",
+}
+```

--- a/docs/config/lua/wezterm.serde/yaml_encode.md
+++ b/docs/config/lua/wezterm.serde/yaml_encode.md
@@ -1,0 +1,10 @@
+# `wezterm.serde.yaml_encode(value)`
+
+{{since('nightly')}}
+
+Encodes the supplied `lua` value as `yaml`:
+
+```
+> wezterm.serde.yaml_encode({foo = "bar"})
+"foo: bar\n"
+```

--- a/env-bootstrap/Cargo.toml
+++ b/env-bootstrap/Cargo.toml
@@ -23,7 +23,7 @@ logging = { path = "../lua-api-crates/logging" }
 mux-lua = { path = "../lua-api-crates/mux" }
 procinfo-funcs = { path = "../lua-api-crates/procinfo-funcs" }
 filesystem = { path = "../lua-api-crates/filesystem" }
-json = { path = "../lua-api-crates/json" }
+serde-funcs = { path = "../lua-api-crates/serde-funcs" }
 plugin = { path = "../lua-api-crates/plugin" }
 share-data = { path = "../lua-api-crates/share-data" }
 ssh-funcs = { path = "../lua-api-crates/ssh-funcs" }

--- a/env-bootstrap/src/lib.rs
+++ b/env-bootstrap/src/lib.rs
@@ -199,7 +199,7 @@ fn register_lua_modules() {
         mux_lua::register,
         procinfo_funcs::register,
         filesystem::register,
-        json::register,
+        serde_funcs::register,
         plugin::register,
         ssh_funcs::register,
         spawn_funcs::register,

--- a/lua-api-crates/serde-funcs/Cargo.toml
+++ b/lua-api-crates/serde-funcs/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "json"
+name = "serde-funcs"
 version = "0.1.0"
 edition = "2021"
 
@@ -11,3 +11,5 @@ config = { path = "../../config" }
 luahelper = { path = "../../luahelper" }
 wezterm-dynamic = { path = "../../wezterm-dynamic" }
 serde_json = "1.0.82"
+serde_yaml = "0.9.31"
+toml = "0.8.9"

--- a/lua-api-crates/serde-funcs/src/lib.rs
+++ b/lua-api-crates/serde-funcs/src/lib.rs
@@ -4,7 +4,6 @@ use luahelper::lua_value_to_dynamic;
 use serde_json::{Map, Value as JValue};
 use std::collections::HashSet;
 use wezterm_dynamic::{FromDynamic, Value as DynValue};
-use {serde_yaml, toml};
 
 pub fn register(lua: &Lua) -> anyhow::Result<()> {
     let serde_mod = get_or_create_sub_module(lua, "serde")?;


### PR DESCRIPTION
This PR adds the following two features to the configuration Lua API:
- Parsing of strings in `yaml`/`toml` formats.
- Serialization of Lua objects into `yaml`/`toml` strings.

I renamed the original `lua-api-crates/json` to `lua-api-crates/serde-funcs` and added support for `yaml`/`toml` formats on top of the existing `json` format support. These functions are registered under the `wezterm.serde` submodule and include:
- `yaml_encode`/`yaml_decode`
- `toml_encode`/`toml_decode`
- `json_encode`/`json_decode` (copied and renamed from the original functions)

Additionally, I re-registered `json_decode` and `json_encode` under `wezterm.json_parse` and `wezterm.json_encode`, respectively, for backward compatibility.

Since both the `toml` and `serde_yaml` crates are already in the original project's dependency list, the added functionality has minimal impact on the program's size.

This functionality is particularly useful when configuration files need to store or access data in `yaml`/`toml` formats.  
Some users may prefer using `yaml`/`toml` as the configuration language, and this feature provides convenience for that purpose. 
For example, users may want to write some static configuration items in a `yaml` file and then parse that file in the `wezterm.lua` configuration file to obtain the final configuration result.
In practice, most static configurations can be accomplished using languages like `yaml`. 
Below is a fragment of my `yaml` configuration file and the corresponding Lua parsing code:

````yaml
default_domain_type: "ssh"
domains:
  unix:
    type: "unix"
  node33:
    remote_address: 'x.y.z.33'
  node34:
    remote_address: 'x.y.z.34'
  node36:
    remote_address: 'x.y.z.36'
  node37:
    remote_address: 'x.y.z.37'
  slurm-test:
    remote_address: 'x.y.z.27'
    username: 'slurm1605101085899980801'
    remote_wezterm_path: '/home/slurm1605101085899980801/bin/wezterm'
````

````lua
-- Omitted a lot of lines.

local yaml_cfg = wezterm.serde.yaml_decode(yaml_content)

local ssh_domains = {}
local unix_domains = {}
local tls_domains = {}
local default_domain_type = pop_item(yaml_cfg, "default_domain_type") or "ssh"
for name, args in pairs(pop_item(yaml_cfg, "domains")) do
    args.name = name
    local domain_type = pop_item(args, "type") or default_domain_type

    if domain_type == "ssh" then
        if not args.username then
            args.username = default_user
        end
        local ssh_option = args.ssh_option or {}
        local no_default_identity = pop_item(ssh_option, "no_default_identity")
        if not ssh_option.identity_file and default_identity_file ~= nil and not no_default_identity then
            ssh_option.identity_file = default_identity_file
        end
        if is_empty(ssh_option) then
            args.ssh_option = ssh_option
        end
        table.insert(ssh_domains, args)
        wezterm.log_info(string.format("Added SSH domain: %s: %s@%s", args.name, args.username, args.remote_address))
    elseif domain_type == "unix" then
        table.insert(unix_domains, args)
        wezterm.log_info(string.format("Added Unix domain: %s", args.name))
    else
        table.insert(tls_domains, args)
    end
end
````

In this configuration, I organize domains of different types under the same `yaml` object and use the domain name as the key to ensure the uniqueness domain names, even if they belong to different domains. Otherwise, a modern text editor would issue a warning.
