### PR TITLE
windows: set  PSEUDOCONSOLE_INHERIT_CURSOR

### DIFF
--- a/pty/src/win/psuedocon.rs
+++ b/pty/src/win/psuedocon.rs
@@ -83,7 +83,7 @@ impl PsuedoCon {
                 size,
                 input.as_raw_handle() as _,
                 output.as_raw_handle() as _,
-                PSEUDOCONSOLE_RESIZE_QUIRK | PSEUDOCONSOLE_WIN32_INPUT_MODE,
+                1,
                 &mut con,
             )
         };

--- a/pty/src/win/psuedocon.rs
+++ b/pty/src/win/psuedocon.rs
@@ -24,6 +24,7 @@ use winapi::um::winnt::HANDLE;
 
 pub type HPCON = HANDLE;
 
+pub const PSUEDOCONSOLE_INHERIT_CURSOR: DWORD = 0x1;
 pub const PSEUDOCONSOLE_RESIZE_QUIRK: DWORD = 0x2;
 pub const PSEUDOCONSOLE_WIN32_INPUT_MODE: DWORD = 0x4;
 #[allow(dead_code)]
@@ -83,7 +84,9 @@ impl PsuedoCon {
                 size,
                 input.as_raw_handle() as _,
                 output.as_raw_handle() as _,
-                1,
+                PSUEDOCONSOLE_INHERIT_CURSOR
+                    | PSEUDOCONSOLE_RESIZE_QUIRK
+                    | PSEUDOCONSOLE_WIN32_INPUT_MODE,
                 &mut con,
             )
         };


### PR DESCRIPTION
This adds `PSEUDOCONSOLE_INHERIT_CURSOR` as a flag for `CreatePseudoConsole`

There's some remarks in the Microsoft docs([learn.microsoft.com/en-us/windows/console/createpseudoconsole](https://learn.microsoft.com/en-us/windows/console/createpseudoconsole)) about handling the cursor, and I'm not sure if we need to handle that in the actual Wezterm application somewhere. 

If we do, then I can possibly just make setting this flag optional?

Fixes #4784
