### PR TITLE
Fix inconsistent spawn behaviour when using default_mux_server_domain.

### DIFF
--- a/wezterm-client/src/domain.rs
+++ b/wezterm-client/src/domain.rs
@@ -20,7 +20,6 @@ use wezterm_term::TerminalSize;
 pub struct ClientInner {
     pub client: Client,
     pub local_domain_id: DomainId,
-    pub remote_domain_id: DomainId,
     pub local_echo_threshold_ms: Option<u64>,
     pub overlay_lag_indicator: bool,
     remote_to_local_window: Mutex<HashMap<WindowId, WindowId>>,
@@ -238,15 +237,9 @@ impl ClientInner {
         local_echo_threshold_ms: Option<u64>,
         overlay_lag_indicator: bool,
     ) -> Self {
-        // Assumption: that the domain id on the other end is
-        // always the first created default domain.  In the future
-        // we'll add a way to discover/enumerate domains to populate
-        // this a bit rigorously.
-        let remote_domain_id = 0;
         Self {
             client,
             local_domain_id,
-            remote_domain_id,
             local_echo_threshold_ms,
             overlay_lag_indicator,
             remote_to_local_window: Mutex::new(HashMap::new()),
@@ -837,7 +830,7 @@ impl Domain for ClientDomain {
         let result = inner
             .client
             .spawn_v2(SpawnV2 {
-                domain: SpawnTabDomain::DomainId(inner.remote_domain_id),
+                domain: SpawnTabDomain::DefaultDomain,
                 window_id: inner.local_to_remote_window(window),
                 size,
                 command,


### PR DESCRIPTION
When using an exec domain as a default_mux_server_domain, you currently witness the following behavior:
- Newly started mux-servers create a pane in the exec domain.
- Splitting an existing pane will create the new pane in the exec domain.
- Calling [wezterm cli spawn] will create a new tab or window in the exec domain.
- Creating a new tab from the Gui does *not* run in the exec domain.

This appears to be due to the fact that ClientDomain hardcodes an assumption that the default domain_id of the remote mux-server is 0.

Instead of having ClientDomain issue a SpawnV2 RPC explicitly asking for domain_id 0, simply use DefaultDomain.