### PR TITLE
termwiz: support NO_COLOR environment variable

### DIFF
--- a/termwiz/src/color.rs
+++ b/termwiz/src/color.rs
@@ -5,14 +5,8 @@
 use num_derive::*;
 #[cfg(feature = "use_serde")]
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::Once;
 pub use wezterm_color_types::{LinearRgba, SrgbaTuple};
 use wezterm_dynamic::{FromDynamic, FromDynamicOptions, ToDynamic, Value};
-
-const NO_COLOR_ENV: &str = "NO_COLOR";
-static ANSI_COLOR_DISABLED: AtomicBool = AtomicBool::new(false);
-static INITIALIZER: Once = Once::new();
 
 #[derive(Debug, Clone, Copy, FromPrimitive, PartialEq, Eq, FromDynamic, ToDynamic)]
 #[cfg_attr(feature = "use_serde", derive(Serialize, Deserialize))]
@@ -52,24 +46,6 @@ pub enum AnsiColor {
     Aqua,
     /// Bright white
     White,
-}
-
-impl AnsiColor {
-    /// Checks whether ANSI color sequences are disabled
-    /// by setting of `NO_COLOR` in environment as per https://no-color.org/
-    pub fn color_disabled() -> bool {
-        !std::env::var(NO_COLOR_ENV)
-            .unwrap_or("".to_string())
-            .is_empty()
-    }
-
-    /// Returns true if the colors are disabled.
-    pub fn color_disabled_memoized() -> bool {
-        INITIALIZER.call_once(|| {
-            ANSI_COLOR_DISABLED.store(Self::color_disabled(), Ordering::SeqCst);
-        });
-        ANSI_COLOR_DISABLED.load(Ordering::SeqCst)
-    }
 }
 
 impl From<AnsiColor> for u8 {
@@ -265,9 +241,6 @@ impl Default for ColorSpec {
 
 impl From<AnsiColor> for ColorSpec {
     fn from(col: AnsiColor) -> Self {
-        if AnsiColor::color_disabled_memoized() {
-            return Self::default();
-        }
         ColorSpec::PaletteIndex(col as u8)
     }
 }
@@ -309,9 +282,6 @@ impl Default for ColorAttribute {
 
 impl From<AnsiColor> for ColorAttribute {
     fn from(col: AnsiColor) -> Self {
-        if AnsiColor::color_disabled_memoized() {
-            return Self::default();
-        }
         ColorAttribute::PaletteIndex(col as u8)
     }
 }

--- a/termwiz/src/color.rs
+++ b/termwiz/src/color.rs
@@ -5,10 +5,8 @@
 use num_derive::*;
 #[cfg(feature = "use_serde")]
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use std::sync::{
-    atomic::{AtomicBool, Ordering},
-    Once,
-};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Once;
 pub use wezterm_color_types::{LinearRgba, SrgbaTuple};
 use wezterm_dynamic::{FromDynamic, FromDynamicOptions, ToDynamic, Value};
 

--- a/termwiz/src/render/terminfo.rs
+++ b/termwiz/src/render/terminfo.rs
@@ -149,7 +149,9 @@ impl TerminfoRenderer {
                 None => 0,
             };
 
-            if attr.foreground() != current_foreground {
+            if attr.foreground() != current_foreground
+                && self.caps.color_level() != ColorLevel::MonoChrome
+            {
                 match (has_true_color, attr.foreground()) {
                     (true, ColorAttribute::TrueColorWithPaletteFallback(tc, _))
                     | (true, ColorAttribute::TrueColorWithDefaultFallback(tc)) => {
@@ -183,7 +185,9 @@ impl TerminfoRenderer {
                 }
             }
 
-            if attr.background() != current_background {
+            if attr.background() != current_background
+                && self.caps.color_level() != ColorLevel::MonoChrome
+            {
                 match (has_true_color, attr.background()) {
                     (true, ColorAttribute::TrueColorWithPaletteFallback(tc, _))
                     | (true, ColorAttribute::TrueColorWithDefaultFallback(tc)) => {


### PR DESCRIPTION
Hey!

I'm one of the maintainers of @ratatui-org and we had one issue where we discussed supporting the `NO_COLOR` environment variable: https://github.com/ratatui-org/ratatui/issues/884

We support `termwiz` as one of our backends and I realized it does not support `NO_COLOR` environment variable which brought me here.

I'm pretty sure you are familiar with it but here is more information about no color: https://no-color.org

One example use case is:

> As a color-blind user, I frequently struggle distinguishing colorized output and appreciate the ability to disable it as per no-color.org

In this PR, I give this a quick stab (based on [crossterm's implementation](https://github.com/crossterm-rs/crossterm/pull/782)) and you can see this taking effect in our `termwiz` example:

![termwiz no color](https://paste.orhun.dev/5KxPeS.gif)

I'm happy to make changes in the implementation (and also add tests) - just let me know! :bear:
