### PR TITLE
docs(lua/config/front_end): default value of OpenGL

### DIFF
--- a/docs/config/lua/config/front_end.md
+++ b/docs/config/lua/config/front_end.md
@@ -15,6 +15,9 @@ possible values:
 {{since('20240127-113634-bbcac864', outline=true)}}
     The default is `"WebGpu"`. In earlier versions it was `"OpenGL"`
 
+{{since('20240128-202157-1e552d76', outline=true)}}
+    The default has been reverted to `"OpenGL"`.
+
 You may wish (or need!) to select `Software` if there are issues with your
 GPU/OpenGL drivers.
 


### PR DESCRIPTION
Reflects changes made as of `20240128-202157-1e552d76`.

Low hanging fruit I noticed at random. From other pages seems like we should be keeping the change history of default values and behavior, As such I've only appended a "sinse block".