### PR TITLE
gui: pass window to set_inner_size()

### DIFF
--- a/wezterm-gui/src/termwindow/mod.rs
+++ b/wezterm-gui/src/termwindow/mod.rs
@@ -1301,18 +1301,16 @@ impl TermWindow {
                 window.invalidate();
             }
             TermWindowNotif::SetInnerSize { width, height } => {
-                self.set_inner_size(width, height);
+                self.set_inner_size(window, width, height);
             }
         }
 
         Ok(())
     }
 
-    fn set_inner_size(&mut self, width: usize, height: usize) {
-        if let Some(window) = &self.window {
-            self.resizes_pending += 1;
-            window.set_inner_size(width, height);
-        }
+    fn set_inner_size(&mut self, window: &Window, width: usize, height: usize) {
+        self.resizes_pending += 1;
+        window.set_inner_size(width, height);
     }
 
     /// Take care to remove our panes from the mux, otherwise

--- a/wezterm-gui/src/termwindow/resize.rs
+++ b/wezterm-gui/src/termwindow/resize.rs
@@ -337,7 +337,7 @@ impl super::TermWindow {
                 // pixel geometry which is considered to be a user-driven resize.
                 // Stashing the dimensions here avoids that misconception.
                 self.dimensions = dims;
-                self.set_inner_size(dims.pixel_width, dims.pixel_height);
+                self.set_inner_size(window, dims.pixel_width, dims.pixel_height);
             }
         }
     }


### PR DESCRIPTION
This fixes a regression from a0974a25 where `TermWindow::set_inner_size()` can be called before the `TermWindow`'s `window` has been set. The consequence of this can be a new window that is not of the correct size.

I can only reproduce this issue on Windows, and although I seem to be able to consistently reproduce it now I would think that I would have noticed this issue earlier had it always reproduced in the past.