### PR TITLE
Fix dependency conflict with rustup on Arch

### DIFF
--- a/get-deps
+++ b/get-deps
@@ -191,7 +191,6 @@ arch_deps() {
     'libxkbcommon-x11' \
     'pkgconf' \
     'python3' \
-    'rust' \
     'wayland' \
     'xcb-util' \
     'xcb-util-image' \


### PR DESCRIPTION
Running `./get-deps` on Arch Linux can fail due to conflict issues in case `rustup` is installed already instead.

```
$ ./get-deps
warning: base-devel-1-1 is up to date -- skipping
warning: rustup-1.26.0-5 is up to date -- skipping
warning: cmake-3.28.3-1 is up to date -- skipping
warning: fontconfig-2:2.15.0-2 is up to date -- skipping
warning: git-2.43.2-1 is up to date -- skipping
warning: hicolor-icon-theme-0.17-3 is up to date -- skipping
warning: libx11-1.8.7-1 is up to date -- skipping
warning: libxkbcommon-x11-1.6.0-1 is up to date -- skipping
warning: pkgconf-2.1.0-2 is up to date -- skipping
warning: python-3.11.7-1 is up to date -- skipping
warning: wayland-1.22.0-1 is up to date -- skipping
warning: xcb-util-0.4.1-1 is up to date -- skipping
warning: xcb-util-image-0.4.1-2 is up to date -- skipping
warning: xcb-util-keysyms-0.4.1-4 is up to date -- skipping
warning: xcb-util-wm-0.4.2-1 is up to date -- skipping
resolving dependencies...
looking for conflicting packages...
:: rust and rustup are in conflict (cargo). Remove rustup? [y/N]
error: unresolvable package conflicts detected
error: failed to prepare transaction (conflicting dependencies)
:: rust and rustup are in conflict
```

Removing `rust` as a dependency fixes this potential conflict issue. This should be alright as `cargo` is already included as a dependency and when installed `pacman` will automatically resolve dependencies and install `rust` in case both `rust` and `rustup` packages are missing on the machine.