### PR TITLE
ci: include PopOS on deploy file

### DIFF
--- a/ci/deploy.sh
+++ b/ci/deploy.sh
@@ -248,7 +248,7 @@ EOF
         fi
 
         ;;
-      Ubuntu*|Debian*)
+      Ubuntu*|Debian*|Pop)
         rm -rf pkg
         mkdir -p pkg/debian/usr/bin pkg/debian/DEBIAN pkg/debian/usr/share/{applications,wezterm}
 


### PR DESCRIPTION
When running the `ci/deploy.sh` script on a PopOS-powered  machine,  such script don't finish the deb package assembly since Pop it's not included on the distro options case:

![image](https://github.com/wez/wezterm/assets/15330034/36d60b43-03a9-4861-9887-bc7df78976f8)

Just adding the case to finish the build