### PR TITLE
fix: Swap horizontally/vertically split pane nomenclature

### DIFF
--- a/assets/shell-completion/fish
+++ b/assets/shell-completion/fish
@@ -105,10 +105,10 @@ complete -c wezterm -n "__fish_seen_subcommand_from cli; and __fish_seen_subcomm
 complete -c wezterm -n "__fish_seen_subcommand_from cli; and __fish_seen_subcommand_from split-pane" -l cwd -d 'Specify the current working directory for the initially spawned program' -r -f -a "(__fish_complete_directories)"
 complete -c wezterm -n "__fish_seen_subcommand_from cli; and __fish_seen_subcommand_from split-pane" -l move-pane-id -d 'Instead of spawning a new command, move the specified pane into the newly created split' -r
 complete -c wezterm -n "__fish_seen_subcommand_from cli; and __fish_seen_subcommand_from split-pane" -l horizontal -d 'Equivalent to `--right`. If neither this nor any other direction is specified, the default is equivalent to `--bottom`'
-complete -c wezterm -n "__fish_seen_subcommand_from cli; and __fish_seen_subcommand_from split-pane" -l left -d 'Split horizontally, with the new pane on the left'
-complete -c wezterm -n "__fish_seen_subcommand_from cli; and __fish_seen_subcommand_from split-pane" -l right -d 'Split horizontally, with the new pane on the right'
-complete -c wezterm -n "__fish_seen_subcommand_from cli; and __fish_seen_subcommand_from split-pane" -l top -d 'Split vertically, with the new pane on the top'
-complete -c wezterm -n "__fish_seen_subcommand_from cli; and __fish_seen_subcommand_from split-pane" -l bottom -d 'Split vertically, with the new pane on the bottom'
+complete -c wezterm -n "__fish_seen_subcommand_from cli; and __fish_seen_subcommand_from split-pane" -l left -d 'Split vertically, with the new pane on the left'
+complete -c wezterm -n "__fish_seen_subcommand_from cli; and __fish_seen_subcommand_from split-pane" -l right -d 'Split vertically, with the new pane on the right'
+complete -c wezterm -n "__fish_seen_subcommand_from cli; and __fish_seen_subcommand_from split-pane" -l top -d 'Split horizontally, with the new pane on the top'
+complete -c wezterm -n "__fish_seen_subcommand_from cli; and __fish_seen_subcommand_from split-pane" -l bottom -d 'Split horizontally, with the new pane on the bottom'
 complete -c wezterm -n "__fish_seen_subcommand_from cli; and __fish_seen_subcommand_from split-pane" -l top-level -d 'Rather than splitting the active pane, split the entire window'
 complete -c wezterm -n "__fish_seen_subcommand_from cli; and __fish_seen_subcommand_from split-pane" -s h -l help -d 'Print help'
 complete -c wezterm -n "__fish_seen_subcommand_from cli; and __fish_seen_subcommand_from spawn" -l pane-id -d 'Specify the current pane. The default is to use the current pane based on the environment variable WEZTERM_PANE. The pane is used to determine the current domain and window' -r

--- a/assets/shell-completion/zsh
+++ b/assets/shell-completion/zsh
@@ -181,10 +181,10 @@ _arguments "${_arguments_options[@]}" \
 '--cwd=[Specify the current working directory for the initially spawned program]:CWD:_files -/' \
 '(--cwd)--move-pane-id=[Instead of spawning a new command, move the specified pane into the newly created split]:MOVE_PANE_ID: ' \
 '(--left --right --top --bottom)--horizontal[Equivalent to \`--right\`. If neither this nor any other direction is specified, the default is equivalent to \`--bottom\`]' \
-'(--right --top --bottom)--left[Split horizontally, with the new pane on the left]' \
-'(--left --top --bottom)--right[Split horizontally, with the new pane on the right]' \
-'(--left --right --bottom)--top[Split vertically, with the new pane on the top]' \
-'(--left --right --top)--bottom[Split vertically, with the new pane on the bottom]' \
+'(--right --top --bottom)--left[Split vertically, with the new pane on the left]' \
+'(--left --top --bottom)--right[Split vertically, with the new pane on the right]' \
+'(--left --right --bottom)--top[Split horizontally, with the new pane on the top]' \
+'(--left --right --top)--bottom[Split horizontally, with the new pane on the bottom]' \
 '--top-level[Rather than splitting the active pane, split the entire window]' \
 '-h[Print help]' \
 '--help[Print help]' \

--- a/docs/cli/cli/split-pane.md
+++ b/docs/cli/cli/split-pane.md
@@ -39,13 +39,13 @@ The following options affect the behavior:
 
 {{since('20220624-141144-bd1b7c5d')}}
 
-* `--bottom` - Split vertically, with the new pane on the bottom.
+* `--bottom` - Split horizontally, with the new pane on the bottom.
 * `--cells CELLS` - The number of cells that the new split should have. If omitted, 50% of the available space is used.
-* `--left` - Split horizontally, with the new pane on the left.
+* `--left` - Split vertically, with the new pane on the left.
 * `--move-pane-id MOVE_PANE_ID` - Instead of spawning a new command, move the specified pane into the newly created split.
 * `--percent PERCENT` - Specify the number of cells that the new split should have, expressed as a percentage of the available space.
-* `--right` - Split horizontally, with the new pane on the right.
-* `--top` - Split vertically, with the new pane on the top.
+* `--right` - Split vertically, with the new pane on the right.
+* `--top` - Split horizontally, with the new pane on the top.
 * `--top-level` - Rather than splitting the active pane, split the entire window.
 
 ## Synopsis

--- a/docs/examples/cmd-synopsis-wezterm-cli-split-pane--help.txt
+++ b/docs/examples/cmd-synopsis-wezterm-cli-split-pane--help.txt
@@ -16,13 +16,13 @@ Options:
           Equivalent to `--right`. If neither this nor any other direction is
           specified, the default is equivalent to `--bottom`
       --left
-          Split horizontally, with the new pane on the left
+          Split vertically, with the new pane on the left
       --right
-          Split horizontally, with the new pane on the right
+          Split vertically, with the new pane on the right
       --top
-          Split vertically, with the new pane on the top
+          Split horizontally, with the new pane on the top
       --bottom
-          Split vertically, with the new pane on the bottom
+          Split horizontally, with the new pane on the bottom
       --top-level
           Rather than splitting the active pane, split the entire window
       --cells <CELLS>

--- a/wezterm-gui/src/commands.rs
+++ b/wezterm-gui/src/commands.rs
@@ -1449,8 +1449,8 @@ pub fn derive_command_from_key_assignment(action: &KeyAssignment) -> Option<Comm
             domain: SpawnTabDomain::CurrentPaneDomain,
             ..
         }) => CommandDef {
-            brief: label_string(action, "Split Vertically (Top/Bottom)".to_string()).into(),
-            doc: "Split the current pane vertically into two panes, by spawning \
+            brief: label_string(action, "Split horizontally (Top/Bottom)".to_string()).into(),
+            doc: "Split the current pane horizontally into two panes, by spawning \
             the default program into the bottom half"
                 .into(),
             keys: vec![(
@@ -1467,8 +1467,8 @@ pub fn derive_command_from_key_assignment(action: &KeyAssignment) -> Option<Comm
             domain: SpawnTabDomain::CurrentPaneDomain,
             ..
         }) => CommandDef {
-            brief: label_string(action, "Split Horizontally (Left/Right)".to_string()).into(),
-            doc: "Split the current pane horizontally into two panes, by spawning \
+            brief: label_string(action, "Split vertically (Left/Right)".to_string()).into(),
+            doc: "Split the current pane vertically into two panes, by spawning \
             the default program into the right hand side"
                 .into(),
             keys: vec![(
@@ -1482,8 +1482,8 @@ pub fn derive_command_from_key_assignment(action: &KeyAssignment) -> Option<Comm
             icon: Some("cod_split_horizontal"),
         },
         SplitHorizontal(_) => CommandDef {
-            brief: label_string(action, "Split Horizontally (Left/Right)".to_string()).into(),
-            doc: "Split the current pane horizontally into two panes, by spawning \
+            brief: label_string(action, "Split vertically (Left/Right)".to_string()).into(),
+            doc: "Split the current pane vertically into two panes, by spawning \
             the default program into the right hand side"
                 .into(),
             keys: vec![],
@@ -1492,7 +1492,7 @@ pub fn derive_command_from_key_assignment(action: &KeyAssignment) -> Option<Comm
             icon: Some("cod_split_horizontal"),
         },
         SplitVertical(_) => CommandDef {
-            brief: label_string(action, "Split Vertically (Top/Bottom)".to_string()).into(),
+            brief: label_string(action, "Split horizontally (Top/Bottom)".to_string()).into(),
             doc: "Split the current pane veritically into two panes, by spawning \
             the default program into the bottom"
                 .into(),

--- a/wezterm/src/cli/split_pane.rs
+++ b/wezterm/src/cli/split_pane.rs
@@ -19,19 +19,19 @@ pub struct SplitPane {
     #[arg(long, conflicts_with_all=&["left", "right", "top", "bottom"])]
     horizontal: bool,
 
-    /// Split horizontally, with the new pane on the left
+    /// Split vertically, with the new pane on the left
     #[arg(long, conflicts_with_all=&["right", "top", "bottom"])]
     left: bool,
 
-    /// Split horizontally, with the new pane on the right
+    /// Split vertically, with the new pane on the right
     #[arg(long, conflicts_with_all=&["left", "top", "bottom"])]
     right: bool,
 
-    /// Split vertically, with the new pane on the top
+    /// Split horizontally, with the new pane on the top
     #[arg(long, conflicts_with_all=&["left", "right", "bottom"])]
     top: bool,
 
-    /// Split vertically, with the new pane on the bottom
+    /// Split horizontally, with the new pane on the bottom
     #[arg(long, conflicts_with_all=&["left", "right", "top"])]
     bottom: bool,
 


### PR DESCRIPTION
I checked multiple times that I'm not crazy, but it really seems that `horizontally` and `vertically` are swapped for pane splitting.

Splitting something **horizontally** means dividing it by a line going from left to right, resulting in top and bottom halves.
Splitting something **vertically** means dividing it by a line going from top to bottom, resulting in left and right halves.
Right? [Sauce.](https://english.stackexchange.com/questions/293520/split-horizontally-or-vertically-which-one-is-which) 🥸

Hopefully I found all the right places to change this.

Ran `rustup component add rustfmt-preview && cargo test --all && cargo fmt --all` with no issues. Thanks Wez!