### PR TITLE
Line wrapping

### DIFF
--- a/term/src/terminalstate/mod.rs
+++ b/term/src/terminalstate/mod.rs
@@ -1001,11 +1001,7 @@ impl TerminalState {
                     if self.dec_origin_mode {
                         self.left_and_right_margins.end
                     } else {
-                        // We allow 1 extra for the cursor x position
-                        // to account for some resize/rewrap scenarios
-                        // where we don't want to forget that the
-                        // cursor belongs to a wrapped line
-                        self.screen().physical_cols + 1
+                        self.screen().physical_cols
                     } as i64
                         - 1,
                 )

--- a/term/src/terminalstate/mod.rs
+++ b/term/src/terminalstate/mod.rs
@@ -1001,7 +1001,11 @@ impl TerminalState {
                     if self.dec_origin_mode {
                         self.left_and_right_margins.end
                     } else {
-                        self.screen().physical_cols
+                        // We allow 1 extra for the cursor x position
+                        // to account for some resize/rewrap scenarios
+                        // where we don't want to forget that the
+                        // cursor belongs to a wrapped line
+                        self.screen().physical_cols + 1
                     } as i64
                         - 1,
                 )

--- a/term/src/terminalstate/performer.rs
+++ b/term/src/terminalstate/performer.rs
@@ -208,8 +208,11 @@ impl<'a> Performer<'a> {
             self.screen_mut()
                 .set_cell_grapheme(x, y, g, print_width, attr_edited, seqno);
 
-            if !wrappable {
+            if !wrappable || self.cursor.x + print_width == width {
                 self.cursor.x += print_width;
+            }
+
+            if !wrappable {
                 self.wrap_next = false;
             } else {
                 self.wrap_next = self.dec_auto_wrap;

--- a/term/src/terminalstate/performer.rs
+++ b/term/src/terminalstate/performer.rs
@@ -203,8 +203,10 @@ impl<'a> Performer<'a> {
                 g,
                 self.pen
             );
+            let mut attr_edited = pen.clone();
+            attr_edited.set_edited(true);
             self.screen_mut()
-                .set_cell_grapheme(x, y, g, print_width, pen, seqno);
+                .set_cell_grapheme(x, y, g, print_width, attr_edited, seqno);
 
             if !wrappable {
                 self.cursor.x += print_width;
@@ -645,7 +647,7 @@ impl<'a> Performer<'a> {
                     line.resize(col_range.end, seqno);
                     line.fill_range(
                         col_range.clone(),
-                        &Cell::new('E', CellAttributes::default()),
+                        &Cell::new('E', CellAttributes::new_edited()),
                         seqno,
                     );
                 }

--- a/termwiz/src/surface/line/line.rs
+++ b/termwiz/src/surface/line/line.rs
@@ -136,13 +136,15 @@ impl Line {
         unicode_version: Option<UnicodeVersion>,
     ) -> Line {
         let mut cells = Vec::new();
+        let mut edited_attr = attrs.clone();
+        edited_attr.set_edited(true);
 
         for sub in Graphemes::new(s) {
-            let cell = Cell::new_grapheme(sub, attrs.clone(), unicode_version);
+            let cell = Cell::new_grapheme(sub, edited_attr.clone(), unicode_version);
             let width = cell.width();
             cells.push(cell);
             for _ in 1..width {
-                cells.push(Cell::new(' ', attrs.clone()));
+                cells.push(Cell::new(' ', edited_attr.clone()));
             }
         }
 
@@ -196,7 +198,7 @@ impl Line {
     /// Returns the list of resultant line(s)
     pub fn wrap(self, width: usize, seqno: SequenceNo) -> Vec<Self> {
         let mut cells: Vec<CellRef> = self.visible_cells().collect();
-        if let Some(end_idx) = cells.iter().rposition(|c| c.str() != " ") {
+        if let Some(end_idx) = cells.iter().rposition(|c| c.attrs().edited()) {
             cells.truncate(end_idx + 1);
 
             let mut lines: Vec<Self> = vec![];
@@ -225,6 +227,7 @@ impl Line {
 
             lines
         } else {
+            cells.truncate(0);
             vec![self]
         }
     }
@@ -746,11 +749,6 @@ impl Line {
         }
 
         if let CellStorage::C(cl) = &mut self.cells {
-            if idx > cl.len() && text == " " && attr == CellAttributes::blank() {
-                // Appending blank beyond end of line; is already
-                // implicitly blank
-                return;
-            }
             while cl.len() < idx {
                 // Fill out any implied blanks until we can append
                 // their intended cell content
@@ -799,11 +797,6 @@ impl Line {
         }
 
         if let CellStorage::C(cl) = &mut self.cells {
-            if idx > cl.len() && cell == Cell::blank() {
-                // Appending blank beyond end of line; is already
-                // implicitly blank
-                return;
-            }
             while cl.len() < idx {
                 // Fill out any implied blanks until we can append
                 // their intended cell content
@@ -847,9 +840,10 @@ impl Line {
         &mut self,
         mut start_idx: usize,
         text: &str,
-        attr: CellAttributes,
+        mut attr: CellAttributes,
         seqno: SequenceNo,
     ) {
+        attr.set_edited(true);
         for (i, c) in Graphemes::new(text).enumerate() {
             let cell = Cell::new_grapheme(c, attr.clone(), None);
             let width = cell.width();
@@ -962,11 +956,19 @@ impl Line {
 
         let def_attr = CellAttributes::blank();
         let cells = self.coerce_vec_storage();
-        if let Some(end_idx) = cells
+        let truncate_len = if let Some(end_idx) = cells
             .iter()
             .rposition(|c| c.str() != " " || c.attrs() != &def_attr)
         {
-            cells.resize_with(end_idx + 1, Cell::blank);
+            Some(end_idx + 1)
+        } else if !cells.is_empty() {
+            Some(0)
+        } else {
+            None
+        };
+
+        if let Some(truncate_len) = truncate_len {
+            cells.truncate(truncate_len);
             self.update_last_change_seqno(seqno);
             self.invalidate_zones();
         }

--- a/termwiz/src/surface/mod.rs
+++ b/termwiz/src/surface/mod.rs
@@ -459,7 +459,9 @@ impl Surface {
                 self.xpos = 0;
             }
 
-            let cell = Cell::new_grapheme(g, self.attributes.clone(), None);
+            let mut cell_attr = self.attributes.clone();
+            cell_attr.set_edited(true);
+            let cell = Cell::new_grapheme(g, cell_attr, None);
             // the max(1) here is to ensure that we advance to the next cell
             // position for zero-width graphemes.  We want to make sure that
             // they occupy a cell so that we can re-emit them when we output them.


### PR DESCRIPTION
Fixes:
* Multiline-wrapping `clear && echo -n some really long long text1 && read`
* Line wrapping with space at end: `clear && echo -n "test test test  " && read`
* Empty lines at end disappearing when resizing: `clear && echo -en "abc\n\n\n\n" && read`
* #3033

Not regressed:
* Cursor wrapping in middle line: `clear && echo -en "aaa\nbbbbbbbbbb\ncc\033[2;11H" && read`
* Wrapping line one time: `clear && echo -n some long long text && read`

Noteworthy:
1. Fish disables it's own rewrapping mechanism for select terminals, such as Alacritty or Konsole.
https://github.com/faho/fish-shell/blob/8c620cb5ccbf5955d6271fd3460c1f799d91abd1/share/functions/__fish_config_interactive.fish#L244-L262
Since it doesn't do so for wezterm, line wrapping will have the usual issues just like with bash. But it's possible to test out what it would look like without their redrawing: `KONSOLE_VERSION=210400 ./target/debug/wezterm -e fish`
2. Lines will still disappear in bash when resizing. Is there a way to disable bash's redrawing on resize?
3. I haven't thoroughly tested this PR, and I wouldn't be surprised if it breaks (perhaps even a lot) of things

Open questions:
1. See commit message of the second commit
2. Is the approach with the `set_edited` for Cell actually fine?

I wouldn't be surprised if there are still changes needed for this PR to land. But right now, I don't feel like working on this PR anymore, and if there are still some things to do, anyone is free to take over this PR. Even if this PR doesn't land, it might serve as an inspiration for other line wrapping PRs.