### PR TITLE
Add Wayland Scroll Factor

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,7 +111,7 @@ to reviewing the code.
 
 ## Submitting a Pull Request
 
-After considering all of the above, and once you're prepared your contribution
+After considering all of the above, and once you've prepared your contribution
 and are ready to submit it, you'll need to create a pull request.
 
 If you're new to GitHub pull requests, read through

--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -839,6 +839,9 @@ pub struct Config {
 
     #[dynamic(default = "default_ulimit_nproc")]
     pub ulimit_nproc: u64,
+
+    #[dynamic(default = "default_wayland_scroll_factor")]
+    pub wayland_scroll_factor: f64,
 }
 impl_lua_conversion_dynamic!(Config);
 
@@ -852,6 +855,10 @@ fn default_ulimit_nofile() -> u64 {
 
 fn default_ulimit_nproc() -> u64 {
     2048
+}
+
+fn default_wayland_scroll_factor() -> f64 {
+    1.0
 }
 
 impl Default for Config {

--- a/window/src/os/wayland/window.rs
+++ b/window/src/os/wayland/window.rs
@@ -685,7 +685,7 @@ impl WaylandWindowInner {
         }
 
         if let Some((value_x, value_y)) = PendingMouse::scroll(&pending_mouse) {
-            let factor = self.get_dpi_factor() as f64;
+            let factor = self.get_dpi_factor() as f64 * self.config.wayland_scroll_factor;
 
             if value_x.signum() != self.hscroll_remainder.signum() {
                 // reset accumulator when changing scroll direction


### PR DESCRIPTION
Wayland users are reporting that mouse and trackpad scrolling is much to fast under Wayland.

#3142
#4455

Using @SuperSandro2000's recommendation [here](https://github.com/wez/wezterm/issues/3142#issuecomment-1821787347), I've added a config option to modify the scroll factor on Wayland (`config.wayland_scroll_factor`).

I've found that setting this value to `0.25` is ideal on my environment (Hyprland, Zellij).

I haven't modified the documentation yet because I wanted to see if this was a desirable approach first. I suppose it's possible to derive a suitable scroll factor from the window's scale factor, but I do not have enough familiarity with the Wayland protocol to implement this. If the config option route is acceptable, I will update the docs.


This also fixes a typo in `CONTRIBUTING.md` as proof that I actually read it.
