### PR TITLE
Add simple implementation to remove_capabilities

### DIFF
--- a/window/src/os/wayland/seat.rs
+++ b/window/src/os/wayland/seat.rs
@@ -65,9 +65,11 @@ impl SeatHandler for WaylandState {
         _conn: &Connection,
         _qh: &QueueHandle<Self>,
         _seat: WlSeat,
-        _capability: smithay_client_toolkit::seat::Capability,
+        capability: smithay_client_toolkit::seat::Capability,
     ) {
-        todo!()
+        if capability == Capability::Keyboard && self.keyboard.is_some() {
+            self.keyboard = None;
+        }
     }
 
     fn remove_seat(&mut self, _conn: &Connection, _qh: &QueueHandle<Self>, _seat: WlSeat) {


### PR DESCRIPTION
Prevents a crash when the only keyboard available is removed which would hit the todo()! and panic