### PR TITLE
Fix wezterm not starting on Hyprland >= 0.37.0

### DIFF
--- a/window/src/os/wayland/window.rs
+++ b/window/src/os/wayland/window.rs
@@ -547,8 +547,8 @@ impl WaylandWindowInner {
         // If the do_paint function has been called previously, calling it again will not
         // send the NeedRepaint event. This results in the window not being displayed
         // correctly.
-        // Therefore, when frame_callback is set to some, it indicates that do_paint has
-        // been called before. We need to send the NeedRepaint event again.
+        // Therefore, when frame_callback is set to some, we need to send the NeedRepaint
+        // event again to ensure the window is displayed.
         // Fix: https://github.com/wez/wezterm/issues/5103
         if self.frame_callback.is_some() {
             self.events.dispatch(WindowEvent::NeedRepaint);

--- a/window/src/os/wayland/window.rs
+++ b/window/src/os/wayland/window.rs
@@ -545,11 +545,10 @@ impl WaylandWindowInner {
         }
 
         // If the do_paint function has been called previously, calling it again will not
-        // trigger the NeedRepaint event. This results in the window not being displayed
-        // correctly after show is called.
+        // send the NeedRepaint event. This results in the window not being displayed
+        // correctly.
         // Therefore, when frame_callback is set to some, it indicates that do_paint has
-        // been called before. We need to trigger the Repaint event again to ensure the
-        // window is displayed correctly.
+        // been called before. We need to send the NeedRepaint event again.
         // Fix: https://github.com/wez/wezterm/issues/5103
         if self.frame_callback.is_some() {
             self.events.dispatch(WindowEvent::NeedRepaint);

--- a/window/src/os/wayland/window.rs
+++ b/window/src/os/wayland/window.rs
@@ -544,6 +544,17 @@ impl WaylandWindowInner {
             return;
         }
 
+        // If the do_paint function has been called previously, calling it again will not
+        // trigger the NeedRepaint event. This results in the window not being displayed
+        // correctly after show is called.
+        // Therefore, when frame_callback is set to some, it indicates that do_paint has
+        // been called before. We need to trigger the Repaint event again to ensure the
+        // window is displayed correctly.
+        // Fix: https://github.com/wez/wezterm/issues/5103
+        if self.frame_callback.is_some() {
+            self.events.dispatch(WindowEvent::NeedRepaint);
+        }
+
         self.do_paint().unwrap();
     }
 


### PR DESCRIPTION
Fix: https://github.com/wez/wezterm/issues/5103

The explanation is here: https://github.com/wez/wezterm/issues/5103#issuecomment-2033827351

I didn't update `do_paint` because I'm not familiar with the logic there.