### PR TITLE
Documentation naming fixes

### DIFF
--- a/docs/config/lua/keyassignment/CopyMode/MoveForwardSemanticZone.md
+++ b/docs/config/lua/keyassignment/CopyMode/MoveForwardSemanticZone.md
@@ -1,4 +1,4 @@
-# CopyMode `MoveForewardSemanticZone`
+# CopyMode `MoveForwardSemanticZone`
 
 {{since('20220903-194523-3bb1ed61')}}
 
@@ -17,7 +17,7 @@ return {
       {
         key = 'Z',
         mods = 'NONE',
-        action = act.CopyMode 'MoveForewardSemanticZone',
+        action = act.CopyMode 'MoveForwardSemanticZone',
       },
     },
   },

--- a/docs/config/lua/keyassignment/CopyMode/MoveToSelectionOtherEndHoriz.md
+++ b/docs/config/lua/keyassignment/CopyMode/MoveToSelectionOtherEndHoriz.md
@@ -17,7 +17,7 @@ return {
       {
         key = 'O',
         mods = 'NONE',
-        action = act.CopyMode 'MoveToSelectionOtherEnd',
+        action = act.CopyMode 'MoveToSelectionOtherEndHoriz',
       },
     },
   },


### PR DESCRIPTION
Reading though the docs i found an error in the action for MoveToSelectionOtherEndHoriz as the code calls MoveToSelectionOtherEnd not MoveToSelectionOtherEndHoriz as expected.

The docs also has MoveFor[**e**]wardSemanticZone instead of MoveForwardSemanticZone