### PR TITLE
chore: Fix Nix build after recent dependencies updates

### DIFF
--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -99,6 +99,7 @@
           lockFile = ../Cargo.lock;
           outputHashes = {
             "xcb-imdkit-0.3.0" = "sha256-fTpJ6uNhjmCWv7dZqVgYuS2Uic36XNYTbqlaly5QBjI=";
+            "sqlite-cache-0.1.3" = "sha256-sBAC8MsQZgH+dcWpoxzq9iw5078vwzCijgyQnMOWIkk";
           };
         };
 


### PR DESCRIPTION
The issue comes from 8c9ab05fb49f34e37f57c1f12fc726dff1e542ef which changed where `sqlite-cache` is retrieved from:
```diff
diff --git a/sync-color-schemes/Cargo.toml b/sync-color-schemes/Cargo.toml
index b1cc34f8a..0fbf28059 100644
--- a/sync-color-schemes/Cargo.toml
+++ b/sync-color-schemes/Cargo.toml
...
-sqlite-cache = "0.1.3"
+sqlite-cache = {git="https://github.com/losfair/sqlite-cache", rev="0961b50385ff189bb12742716331c05ed0bf7805" }
...
```
When a dependency is retrieved from git, Nix needs the resulting hash in Nix format (a combination of sha256 + Nix stuff), hence this change.

I tested the change locally with `cd nix/ ; nix build ; ./result/bin/wezterm`

@wez if you can test this out 🙃

(related to #5373)