### PR TITLE
Squish a Bunch of Clippy Errors and Warnings

### DIFF
--- a/bidi/generate/src/main.rs
+++ b/bidi/generate/src/main.rs
@@ -19,7 +19,7 @@ fn gen_class() -> anyhow::Result<()> {
     impl Entry {
         fn parse(line: &str) -> anyhow::Result<Option<Self>> {
             let line = line.trim();
-            if line.starts_with("#") || line.is_empty() {
+            if line.starts_with('#') || line.is_empty() {
                 return Ok(None);
             }
             let fields: Vec<&str> = line.split(';').collect();
@@ -152,7 +152,7 @@ fn gen_brackets() -> anyhow::Result<()> {
     impl Entry {
         fn parse(line: &str) -> anyhow::Result<Option<Self>> {
             let line = line.trim();
-            if line.starts_with("#") || line.is_empty() {
+            if line.starts_with('#') || line.is_empty() {
                 return Ok(None);
             }
             let fields: Vec<&str> = line.split(';').collect();

--- a/bidi/src/bidi_brackets.rs
+++ b/bidi/src/bidi_brackets.rs
@@ -5,7 +5,7 @@ pub enum BracketType {
     Open,
     Close,
 }
-pub const BIDI_BRACKETS: &'static [(char, char, BracketType)] = &[
+pub const BIDI_BRACKETS: &[(char, char, BracketType)] = &[
     ('\u{28}', '\u{29}', BracketType::Open),   // LEFT PARENTHESIS
     ('\u{29}', '\u{28}', BracketType::Close),  // RIGHT PARENTHESIS
     ('\u{5b}', '\u{5d}', BracketType::Open),   // LEFT SQUARE BRACKET

--- a/bidi/src/bidi_class.rs
+++ b/bidi/src/bidi_class.rs
@@ -28,7 +28,7 @@ pub enum BidiClass {
     WhiteSpace,
 }
 
-pub const BIDI_CLASS: &'static [(char, char, BidiClass)] = &[
+pub const BIDI_CLASS: &[(char, char, BidiClass)] = &[
     ('\u{0}', '\u{8}', BidiClass::BoundaryNeutral), // Cc   [9] <control-0000>..<control-0008>
     ('\u{9}', '\u{9}', BidiClass::SegmentSeparator), // Cc       <control-0009>
     ('\u{a}', '\u{a}', BidiClass::ParagraphSeparator), // Cc       <control-000A>

--- a/bintree/src/lib.rs
+++ b/bintree/src/lib.rs
@@ -159,11 +159,11 @@ impl<'a, L, N> std::iter::Iterator for ParentIterator<'a, L, N> {
         match self.path {
             Path::Top => None,
             Path::Left { data, up, .. } => {
-                self.path = &*up;
+                self.path = up;
                 Some((PathBranch::IsLeft, data))
             }
             Path::Right { data, up, .. } => {
-                self.path = &*up;
+                self.path = up;
                 Some((PathBranch::IsRight, data))
             }
         }
@@ -211,7 +211,7 @@ impl<L, N> Cursor<L, N> {
 
     /// References the subtree at the current cursor position
     pub fn subtree(&self) -> &Tree<L, N> {
-        &*self.it
+        &self.it
     }
 
     /// Returns true if the current position is a leaf node

--- a/deps/freetype/build.rs
+++ b/deps/freetype/build.rs
@@ -230,7 +230,7 @@ fn freetype() {
 
 fn git_submodule_update() {
     let _ = std::process::Command::new("git")
-        .args(&["submodule", "update", "--init"])
+        .args(["submodule", "update", "--init"])
         .status();
 }
 

--- a/deps/freetype/src/lib.rs
+++ b/deps/freetype/src/lib.rs
@@ -40,7 +40,7 @@ impl<T> ::std::default::Default for __BindgenUnionField<T> {
 impl<T> ::std::clone::Clone for __BindgenUnionField<T> {
     #[inline]
     fn clone(&self) -> Self {
-        Self::new()
+        *self
     }
 }
 impl<T> ::std::marker::Copy for __BindgenUnionField<T> {}

--- a/deps/harfbuzz/build.rs
+++ b/deps/harfbuzz/build.rs
@@ -60,7 +60,7 @@ fn harfbuzz() {
 
 fn git_submodule_update() {
     let _ = std::process::Command::new("git")
-        .args(&["submodule", "update", "--init"])
+        .args(["submodule", "update", "--init"])
         .status();
 }
 

--- a/luahelper/src/enumctor.rs
+++ b/luahelper/src/enumctor.rs
@@ -109,6 +109,12 @@ impl<T> Enum<T> {
     }
 }
 
+impl<T> Default for Enum<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl<T> UserData for Enum<T>
 where
     T: FromDynamic,

--- a/luahelper/src/enumctor.rs
+++ b/luahelper/src/enumctor.rs
@@ -133,14 +133,16 @@ where
         methods.add_meta_method(MetaMethod::Index, |lua, _myself, field: String| {
             // Step 1: see if this is a unit variant.
             // A unit variant will be convertible from string
-            if let Ok(_) = T::from_dynamic(
+            if T::from_dynamic(
                 &DynValue::String(field.to_string()),
                 FromDynamicOptions {
                     unknown_fields: UnknownFieldAction::Deny,
                     deprecated_fields: UnknownFieldAction::Ignore,
                 },
-            ) {
-                return Ok(field.into_lua(lua)?);
+            )
+            .is_ok()
+            {
+                return field.into_lua(lua);
             }
 
             // Step 2: see if this is a valid variant, and whether we can

--- a/procinfo/src/macos.rs
+++ b/procinfo/src/macos.rs
@@ -220,7 +220,7 @@ fn parse_exe_and_argv_sysctl(buf: Vec<u8>) -> Option<(PathBuf, Vec<String>)> {
     fn consume_cstr(ptr: &mut &[u8]) -> Option<String> {
         // Parse to the end of a null terminated string
         let nul = ptr.iter().position(|&c| c == 0)?;
-        let s = String::from_utf8_lossy(&ptr[0..nul]).to_owned().to_string();
+        let s = String::from_utf8_lossy(&ptr[0..nul]).to_string();
         *ptr = ptr.get(nul + 1..)?;
 
         // Find the position of the first non null byte. `.position()`

--- a/promise/src/spawn.rs
+++ b/promise/src/spawn.rs
@@ -223,6 +223,12 @@ impl SimpleExecutor {
     }
 }
 
+impl Default for SimpleExecutor {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 pub struct ScopedExecutor {}
 
 impl ScopedExecutor {
@@ -240,6 +246,12 @@ impl ScopedExecutor {
             .expect("SCOPED_EXECUTOR to be alive as long as ScopedExecutor")
             .run(future)
             .await
+    }
+}
+
+impl Default for ScopedExecutor {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/pty/src/cmdbuilder.rs
+++ b/pty/src/cmdbuilder.rs
@@ -306,7 +306,7 @@ impl CommandBuilder {
             EnvEntry {
                 is_from_base_env: false,
                 preferred_key: key,
-                value: value,
+                value,
             },
         );
     }
@@ -446,7 +446,7 @@ impl CommandBuilder {
 
             if let Some(path) = self.resolve_path() {
                 for path in std::env::split_paths(&path) {
-                    let candidate = cwd.join(&path).join(&exe);
+                    let candidate = cwd.join(path).join(exe);
 
                     if candidate.is_dir() {
                         errors.push(format!("{} exists but is a directory", candidate.display()));
@@ -499,8 +499,7 @@ impl CommandBuilder {
         let home = self.get_home_dir()?;
         let dir: &OsStr = self
             .cwd
-            .as_ref()
-            .map(|dir| dir.as_os_str())
+            .as_deref()
             .filter(|dir| std::path::Path::new(dir).is_dir())
             .unwrap_or(home.as_ref());
         let shell = self.get_shell();
@@ -515,7 +514,7 @@ impl CommandBuilder {
             cmd
         } else {
             let resolved = self.search_path(&self.args[0], dir)?;
-            let mut cmd = std::process::Command::new(&resolved);
+            let mut cmd = std::process::Command::new(resolved);
             cmd.arg0(&self.args[0]);
             cmd.args(&self.args[1..]);
             cmd
@@ -552,7 +551,7 @@ impl CommandBuilder {
             }
         }
 
-        get_shell().into()
+        get_shell()
     }
 
     fn get_home_dir(&self) -> anyhow::Result<String> {

--- a/pty/src/lib.rs
+++ b/pty/src/lib.rs
@@ -39,8 +39,6 @@
 //!
 use anyhow::Error;
 use downcast_rs::{impl_downcast, Downcast};
-#[cfg(unix)]
-use libc;
 #[cfg(feature = "serde_support")]
 use serde_derive::*;
 use std::io::Result as IoResult;
@@ -270,10 +268,7 @@ impl_downcast!(PtySystem);
 
 impl Child for std::process::Child {
     fn try_wait(&mut self) -> IoResult<Option<ExitStatus>> {
-        std::process::Child::try_wait(self).map(|s| match s {
-            Some(s) => Some(s.into()),
-            None => None,
-        })
+        std::process::Child::try_wait(self).map(|ops| ops.map(|s| s.into()))
     }
 
     fn wait(&mut self) -> IoResult<ExitStatus> {
@@ -398,7 +393,7 @@ impl ChildKiller for std::process::Child {
 }
 
 pub fn native_pty_system() -> Box<dyn PtySystem + Send> {
-    Box::new(NativePtySystem::default())
+    Box::<NativePtySystem>::default()
 }
 
 #[cfg(unix)]

--- a/pty/src/unix.rs
+++ b/pty/src/unix.rs
@@ -31,7 +31,7 @@ fn openpty(size: PtySize) -> anyhow::Result<(UnixMasterPty, UnixSlavePty)> {
 
     let result = unsafe {
         // BSDish systems may require mut pointers to some args
-        #[cfg_attr(feature = "cargo-clippy", allow(clippy::unnecessary_mut_passed))]
+        #[allow(clippy::unnecessary_mut_passed)]
         libc::openpty(
             &mut master,
             &mut slave,
@@ -261,7 +261,7 @@ impl PtyFd {
                     // type::from(), but the size and potentially signedness
                     // are system dependent, which is why we're using `as _`.
                     // Suppress this lint for this section of code.
-                    #[cfg_attr(feature = "cargo-clippy", allow(clippy::cast_lossless))]
+                    #[allow(clippy::cast_lossless)]
                     if controlling_tty {
                         // Set the pty as the controlling terminal.
                         // Failure to do this means that delivery of

--- a/rangeset/src/lib.rs
+++ b/rangeset/src/lib.rs
@@ -281,10 +281,8 @@ impl<T: Integer + Copy + Debug + ToPrimitive> RangeSet<T> {
             }
         }
         if let Some(r) = self.ranges.get(idx + 1) {
-            if intersects_range(r, range) || r.end == range.start {
-                if first.is_some() {
-                    return (first, Some(idx + 1));
-                }
+            if intersects_range(r, range) || r.end == range.start && first.is_some() {
+                return (first, Some(idx + 1));
             }
         }
         (first, None)
@@ -329,7 +327,7 @@ impl<T: Integer + Copy + Debug + ToPrimitive> RangeSet<T> {
 
     /// Returns an iterator over all of the contained values.
     /// Take care when the range is very large!
-    pub fn iter_values<'a>(&'a self) -> impl Iterator<Item = T> + 'a {
+    pub fn iter_values(&self) -> impl Iterator<Item = T> + '_ {
         self.ranges.iter().flat_map(|r| num::range(r.start, r.end))
     }
 }

--- a/umask/src/lib.rs
+++ b/umask/src/lib.rs
@@ -44,6 +44,12 @@ impl UmaskSaver {
     }
 }
 
+impl Default for UmaskSaver {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Drop for UmaskSaver {
     fn drop(&mut self) {
         #[cfg(unix)]

--- a/wezterm-blob-leases/src/lease_id.rs
+++ b/wezterm-blob-leases/src/lease_id.rs
@@ -37,3 +37,9 @@ impl LeaseId {
         self.pid
     }
 }
+
+impl Default for LeaseId {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/wezterm-blob-leases/src/lease_id.rs
+++ b/wezterm-blob-leases/src/lease_id.rs
@@ -28,7 +28,7 @@ fn get_mac_address() -> [u8; 6] {
 impl LeaseId {
     pub fn new() -> Self {
         static MAC: Lazy<[u8; 6]> = Lazy::new(get_mac_address);
-        let uuid = Uuid::now_v1(&*MAC);
+        let uuid = Uuid::now_v1(&MAC);
         let pid = std::process::id();
         Self { uuid, pid }
     }

--- a/wezterm-blob-leases/src/simple_tempdir.rs
+++ b/wezterm-blob-leases/src/simple_tempdir.rs
@@ -64,10 +64,10 @@ impl BlobStorage for SimpleTempDir {
         let mut file = tempfile::Builder::new()
             .prefix("new-")
             .rand_bytes(5)
-            .tempfile_in(&self.root.path())?;
+            .tempfile_in(self.root.path())?;
 
         file.write_all(data)?;
-        file.persist(&path)
+        file.persist(path)
             .map_err(|persist_err| persist_err.error)?;
 
         *refs.entry(content_id).or_insert(0) += 1;
@@ -91,7 +91,7 @@ impl BlobStorage for SimpleTempDir {
         let _refs = self.refs.lock().unwrap();
 
         let path = self.path_for_content(content_id)?;
-        Ok(std::fs::read(&path)?)
+        Ok(std::fs::read(path)?)
     }
 
     fn get_reader(&self, content_id: ContentId, lease_id: LeaseId) -> Result<BoxedReader, Error> {
@@ -133,7 +133,7 @@ impl BlobStorage for SimpleTempDir {
         }
 
         let path = self.path_for_content(content_id)?;
-        let file = BufReader::new(std::fs::File::open(&path)?);
+        let file = BufReader::new(std::fs::File::open(path)?);
         self.add_ref(content_id);
 
         Ok(Box::new(Reader {

--- a/wezterm-dynamic/src/error.rs
+++ b/wezterm-dynamic/src/error.rs
@@ -16,13 +16,13 @@ thread_local! {
 #[derive(Error, Debug)]
 #[non_exhaustive]
 pub enum Error {
-    #[error("`{}` is not a valid {} variant. {}", .variant_name, .type_name, Self::possible_matches(.variant_name, &.possible))]
+    #[error("`{}` is not a valid {} variant. {}", .variant_name, .type_name, Self::possible_matches(.variant_name, possible))]
     InvalidVariantForType {
         variant_name: String,
         type_name: &'static str,
         possible: &'static [&'static str],
     },
-    #[error("`{}` is not a valid {} field. {}", .field_name, .type_name, Self::possible_matches(.field_name, &.possible))]
+    #[error("`{}` is not a valid {} field. {}", .field_name, .type_name, Self::possible_matches(.field_name, possible))]
     UnknownFieldForStruct {
         field_name: String,
         type_name: &'static str,
@@ -201,7 +201,7 @@ impl Error {
         }
 
         if options.unknown_fields == UnknownFieldAction::Deny {
-            for err in errors {
+            if let Some(err) = errors.into_iter().next() {
                 return Err(err);
             }
         }

--- a/wezterm-dynamic/src/fromdynamic.rs
+++ b/wezterm-dynamic/src/fromdynamic.rs
@@ -51,7 +51,7 @@ impl FromDynamic for Value {
 impl FromDynamic for ordered_float::NotNan<f64> {
     fn from_dynamic(value: &Value, options: FromDynamicOptions) -> Result<Self, Error> {
         let f = f64::from_dynamic(value, options)?;
-        Ok(ordered_float::NotNan::new(f).map_err(|e| Error::Message(e.to_string()))?)
+        ordered_float::NotNan::new(f).map_err(|e| Error::Message(e.to_string()))
     }
 }
 

--- a/wezterm-dynamic/src/object.rs
+++ b/wezterm-dynamic/src/object.rs
@@ -15,11 +15,11 @@ pub enum BorrowedKey<'a> {
 }
 
 pub trait ObjectKeyTrait {
-    fn key<'k>(&'k self) -> BorrowedKey<'k>;
+    fn key(&self) -> BorrowedKey<'_>;
 }
 
 impl ObjectKeyTrait for Value {
-    fn key<'k>(&'k self) -> BorrowedKey<'k> {
+    fn key(&self) -> BorrowedKey<'_> {
         match self {
             Value::String(s) => BorrowedKey::Str(s.as_str()),
             v => BorrowedKey::Value(v),
@@ -27,8 +27,8 @@ impl ObjectKeyTrait for Value {
     }
 }
 
-impl<'a> ObjectKeyTrait for BorrowedKey<'a> {
-    fn key<'k>(&'k self) -> BorrowedKey<'k> {
+impl ObjectKeyTrait for BorrowedKey<'_> {
+    fn key(&self) -> BorrowedKey<'_> {
         *self
     }
 }
@@ -49,7 +49,7 @@ impl<'a> Eq for (dyn ObjectKeyTrait + 'a) {}
 
 impl<'a> PartialOrd for (dyn ObjectKeyTrait + 'a) {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        self.key().partial_cmp(&other.key())
+        Some(self.cmp(other))
     }
 }
 

--- a/wezterm-input-types/src/lib.rs
+++ b/wezterm-input-types/src/lib.rs
@@ -1228,6 +1228,12 @@ impl Handled {
     }
 }
 
+impl Default for Handled {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl PartialEq for Handled {
     fn eq(&self, _: &Self) -> bool {
         true

--- a/wezterm-open-url/src/lib.rs
+++ b/wezterm-open-url/src/lib.rs
@@ -46,11 +46,7 @@ pub fn open_with(url: &str, app: &str) {
         let mut cmd = std::process::Command::new(args[0]);
         cmd.args(&args[1..]);
 
-        if let Ok(status) = cmd.status() {
-            if status.success() {
-                return;
-            }
-        }
+        let _ = cmd.status();
     });
 }
 

--- a/wezterm-ssh/src/config.rs
+++ b/wezterm-ssh/src/config.rs
@@ -175,7 +175,7 @@ impl ParsedConfigFile {
         groups: &mut Vec<MatchGroup>,
         loaded_files: &mut Vec<PathBuf>,
     ) {
-        match filenamegen::Glob::new(&pattern) {
+        match filenamegen::Glob::new(pattern) {
             Ok(g) => {
                 match cwd
                     .as_ref()
@@ -253,8 +253,8 @@ impl ParsedConfigFile {
                     let mut patterns = vec![];
                     for p in v.split(',') {
                         let p = p.trim();
-                        if p.starts_with('!') {
-                            patterns.push(Pattern::new(&p[1..], true));
+                        if let Some(stripped) = p.strip_prefix('!') {
+                            patterns.push(Pattern::new(stripped, true));
                         } else {
                             patterns.push(Pattern::new(p, false));
                         }
@@ -265,8 +265,8 @@ impl ParsedConfigFile {
                     let mut patterns = vec![];
                     for p in v.split_ascii_whitespace() {
                         let p = p.trim();
-                        if p.starts_with('!') {
-                            patterns.push(Pattern::new(&p[1..], true));
+                        if let Some(stripped) = p.strip_prefix('!') {
+                            patterns.push(Pattern::new(stripped, true));
                         } else {
                             patterns.push(Pattern::new(p, false));
                         }
@@ -603,11 +603,16 @@ impl Config {
     /// Return true if a given option name is subject to environment variable
     /// expansion.
     fn should_expand_environment(&self, key: &str) -> bool {
-        match key {
-            "certificatefile" | "controlpath" | "identityagent" | "identityfile"
-            | "userknownhostsfile" | "localforward" | "remoteforward" => true,
-            _ => false,
-        }
+        matches!(
+            key,
+            "certificatefile"
+                | "controlpath"
+                | "identityagent"
+                | "identityfile"
+                | "userknownhostsfile"
+                | "localforward"
+                | "remoteforward"
+        )
     }
 
     /// Returns a set of tokens that should be expanded for a given option name
@@ -730,10 +735,11 @@ impl Config {
                 for c in &group.criteria {
                     if let Criteria::Host(patterns) = c {
                         for pattern in patterns {
-                            if pattern.is_literal && !pattern.negated {
-                                if !hosts.contains(&pattern.original) {
-                                    hosts.push(pattern.original.clone());
-                                }
+                            if pattern.is_literal
+                                && !pattern.negated
+                                && !hosts.contains(&pattern.original)
+                            {
+                                hosts.push(pattern.original.clone());
                             }
                         }
                     }

--- a/wezterm-ssh/src/config.rs
+++ b/wezterm-ssh/src/config.rs
@@ -751,6 +751,12 @@ impl Config {
     }
 }
 
+impl Default for Config {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;

--- a/wezterm-ssh/src/sftp/file.rs
+++ b/wezterm-ssh/src/sftp/file.rs
@@ -172,7 +172,7 @@ impl smol::io::AsyncRead for File {
             Poll::Ready(Err(x)) => Poll::Ready(Err(x)),
             Poll::Ready(Ok(data)) => {
                 let n = data.len();
-                (&mut buf[..n]).copy_from_slice(&data[..n]);
+                (buf[..n]).copy_from_slice(&data[..n]);
                 Poll::Ready(Ok(n))
             }
         }

--- a/wezterm-ssh/src/sftp/types.rs
+++ b/wezterm-ssh/src/sftp/types.rs
@@ -394,15 +394,15 @@ mod libssh_impl {
         }
     }
 
-    impl Into<libssh_rs::SetAttributes> for Metadata {
-        fn into(self) -> libssh_rs::SetAttributes {
-            let size = self.size;
-            let uid_gid = match (self.uid, self.gid) {
+    impl From<Metadata> for libssh_rs::SetAttributes {
+        fn from(val: Metadata) -> Self {
+            let size = val.size;
+            let uid_gid = match (val.uid, val.gid) {
                 (Some(uid), Some(gid)) => Some((uid, gid)),
                 _ => None,
             };
-            let permissions = self.permissions.map(FilePermissions::to_unix_mode);
-            let atime_mtime = match (self.accessed, self.modified) {
+            let permissions = val.permissions.map(FilePermissions::to_unix_mode);
+            let atime_mtime = match (val.accessed, val.modified) {
                 (Some(a), Some(m)) => {
                     let a = unix_to_sys(a);
                     let m = unix_to_sys(m);

--- a/wezterm-ssh/src/sftpwrap.rs
+++ b/wezterm-ssh/src/sftpwrap.rs
@@ -16,9 +16,9 @@ pub(crate) enum SftpWrap {
 fn pathconv(path: std::path::PathBuf) -> SftpChannelResult<Utf8PathBuf> {
     use crate::sftp::SftpChannelError;
     use std::convert::TryFrom;
-    Ok(Utf8PathBuf::try_from(path).map_err(|x| {
+    Utf8PathBuf::try_from(path).map_err(|x| {
         SftpChannelError::from(std::io::Error::new(std::io::ErrorKind::InvalidData, x))
-    })?)
+    })
 }
 
 impl SftpWrap {

--- a/wezterm-version/build.rs
+++ b/wezterm-version/build.rs
@@ -30,7 +30,7 @@ fn main() {
             }
 
             if let Ok(output) = std::process::Command::new("git")
-                .args(&[
+                .args([
                     "-c",
                     "core.abbrev=8",
                     "show",


### PR DESCRIPTION
There are some remaining such as these:
```
error: &-masking with zero
   --> wezterm-input-types/src/lib.rs:479:1
    |
479 | / bitflags! {
480 | |     #[cfg_attr(feature="serde", derive(Serialize, Deserialize))]
481 | |     #[derive(Default, FromDynamic, ToDynamic)]
482 | |     #[dynamic(into="String", try_from="String")]
...   |
498 | |     }
499 | | }
    | |_^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#bad_bit_mask
    = note: `#[deny(clippy::bad_bit_mask)]` on by default
    = note: this error originates in the macro `__impl_bitflags` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)

error: &-masking with zero
    --> wezterm-input-types/src/lib.rs:1174:1
     |
1174 | / bitflags! {
1175 | |     #[derive(Default)]
1176 | |     pub struct MouseButtons: u8 {
1177 | |         const NONE = 0;
...    |
1184 | |     }
1185 | | }
     | |_^
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#bad_bit_mask
     = note: this error originates in the macro `__impl_bitflags` which comes from the expansion of the macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
...
```

But I got rid of a lot of them