### PR TITLE
chore(nix): Update refs to submodules & explain why this is needed

### DIFF
--- a/nix/flake.lock
+++ b/nix/flake.lock
@@ -21,17 +21,17 @@
     "freetype2": {
       "flake": false,
       "locked": {
-        "lastModified": 1675923892,
-        "narHash": "sha256-dOm8VKYdclTLLkqWMLv7DQI0Qyjit7S4SOCszKEkG3o=",
+        "lastModified": 1687587065,
+        "narHash": "sha256-+Fh+/k+NWL5Ow9sDLtp8Cv/8rLNA1oByQQCIQS/bysY=",
         "owner": "wez",
         "repo": "freetype2",
-        "rev": "de8b92dd7ec634e9e2b25ef534c54a3537555c11",
+        "rev": "e4586d960f339cf75e2e0b34aee30a0ed8353c0d",
         "type": "github"
       },
       "original": {
         "owner": "wez",
-        "ref": "VER-2-13-0",
         "repo": "freetype2",
+        "rev": "e4586d960f339cf75e2e0b34aee30a0ed8353c0d",
         "type": "github"
       }
     },

--- a/nix/flake.lock
+++ b/nix/flake.lock
@@ -30,25 +30,25 @@
       },
       "original": {
         "owner": "wez",
+        "ref": "VER-2-13-0",
         "repo": "freetype2",
-        "rev": "de8b92dd7ec634e9e2b25ef534c54a3537555c11",
         "type": "github"
       }
     },
     "harfbuzz": {
       "flake": false,
       "locked": {
-        "lastModified": 1677798343,
-        "narHash": "sha256-Lsd0Vrkrv67CMyV0ZveShfjUvqh/jDhI8rAK9ps+SZQ=",
+        "lastModified": 1711722720,
+        "narHash": "sha256-GdxcAPx5QyniSHPAN1ih28AD9JLUPR0ItqW9JEsl3pU=",
         "owner": "harfbuzz",
         "repo": "harfbuzz",
-        "rev": "60841e26187576bff477c1a09ee2ffe544844abc",
+        "rev": "63973005bc07aba599b47fdd4cf788647b601ccd",
         "type": "github"
       },
       "original": {
         "owner": "harfbuzz",
+        "ref": "8.4.0",
         "repo": "harfbuzz",
-        "rev": "60841e26187576bff477c1a09ee2ffe544844abc",
         "type": "github"
       }
     },
@@ -146,8 +146,8 @@
       },
       "original": {
         "owner": "madler",
+        "ref": "v1.2.11",
         "repo": "zlib",
-        "rev": "cacf7f1d4e3d44d871b605da3b647f07d718623f",
         "type": "github"
       }
     }

--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -12,23 +12,27 @@
       };
     };
 
+    # NOTE: @2024-05 Nix flakes does not support getting git submodules of 'self'.
+    # refs:
+    # - https://discourse.nixos.org/t/get-nix-flake-to-include-git-submodule/30324
+    # - https://github.com/NixOS/nix/pull/7862
+    #
+    # ... In the meantime we kinda duplicate the dependencies here then replace the submodules with
+    # links to each repo in package sources.
     freetype2 = {
-      url = "github:wez/freetype2/de8b92dd7ec634e9e2b25ef534c54a3537555c11";
+      url = "github:wez/freetype2/VER-2-13-0";
       flake = false;
     };
-
     harfbuzz = {
-      url = "github:harfbuzz/harfbuzz/60841e26187576bff477c1a09ee2ffe544844abc";
+      url = "github:harfbuzz/harfbuzz/8.4.0";
       flake = false;
     };
-
     libpng = {
       url = "github:glennrp/libpng/8439534daa1d3a5705ba92e653eda9251246dd61";
       flake = false;
     };
-
     zlib = {
-      url = "github:madler/zlib/cacf7f1d4e3d44d871b605da3b647f07d718623f";
+      url = "github:madler/zlib/v1.2.11";
       flake = false;
     };
   };

--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -19,8 +19,12 @@
     #
     # ... In the meantime we kinda duplicate the dependencies here then replace the submodules with
     # links to each repo in package sources.
+    #
+    # Try to use tags when possible to increase readability
+    # (note: `git submodule status` in wezterm repo will show the `git describe` result for each
+    # submodule, can help finding a tag if any)
     freetype2 = {
-      url = "github:wez/freetype2/VER-2-13-0";
+      url = "github:wez/freetype2/e4586d960f339cf75e2e0b34aee30a0ed8353c0d";
       flake = false;
     };
     harfbuzz = {


### PR DESCRIPTION
I saw that you updated harfbuzz' version in ec438e714c25f24783e2a23df5d3fb8eef192b55, and noticed last time that the Nix code currently needs to get the submodules manually, so here you go.
I added some explanation why this whole submodule duplication thing is needed at the moment.

I also preferred to use tags instead of commit hash to be much more readable and maintainable.

cc: @happenslol @gabyx is that okay for you?