### PR TITLE
fix wrapped long line copy problem on tmux

### DIFF
--- a/term/src/terminalstate/performer.rs
+++ b/term/src/terminalstate/performer.rs
@@ -162,14 +162,13 @@ impl<'a> Performer<'a> {
                         }
                     }
 
-                    let should_mark_wrapped = !is_alt
-                        && (!is_conpty
-                            || screen
-                                .line_mut(y)
-                                .visible_cells()
-                                .last()
-                                .map(|cell| makes_sense_to_wrap(cell.str()))
-                                .unwrap_or(false));
+                    let should_mark_wrapped = !is_conpty
+                        || screen
+                            .line_mut(y)
+                            .visible_cells()
+                            .last()
+                            .map(|cell| makes_sense_to_wrap(cell.str()))
+                            .unwrap_or(false);
                     if should_mark_wrapped {
                         screen.line_mut(y).set_last_cell_was_wrapped(true, seqno);
                     }


### PR DESCRIPTION
wezterm ignores wrapped long line when alt screen is used and tmux uses alt screen that makes copying wrapped long line into multiple lines.

After testing on sevaral tui apps like tmux, w3m, htop it seems to show reasonable performance on resizing.

Fixes #5283