### PR TITLE
Updates for openSUSE/SUSE

### DIFF
--- a/docs/install/linux.md
+++ b/docs/install/linux.md
@@ -172,20 +172,29 @@ hide:
     * openSUSE Tumbleweed
     * RHEL 8, 9
 
-    For openSUSE, install `dnf` beforehand with
-
-    ```console
-    $ sudo zypper in dnf
-    ```
 
     To perform initial installation:
 
     ```console
+    $ sudo dnf copr enable wezfurlong/wezterm-nightly
+    $ sudo dnf install wezterm
+    ```
+    ## openSUSE specific
+
+    To perform initial installation:
+
+    ```console
+    $ sudo zypper in dnf
     $ sudo dnf copr enable wezfurlong/wezterm-nightly <repository>
+    ```
+    where `<repository>` is one of the following, depending on the flavor and architecture:
+    `opensuse-tumbleweed-x86_64`, `opensuse-tumbleweed-aarch64`, `opensuse-leap-15.5-x86_64`, `opensuse-leap-15.5-aarch64`.
+
+    ```console
     $ sudo dnf install wezterm
     ```
 
-    To update:
+    ## Update
 
     ```console
     $ sudo dnf update wezterm
@@ -223,16 +232,10 @@ hide:
     ## openSUSE
 
     !!! note
-        If you want nightly versions of WezTerm, it is recommended to use Copr.
+        It is recommended that you install via Copr so that it is easiest
+        to stay up to date as future versions of wezterm are released.
 
-    ## openSUSE Tumbleweed
-
-    The stable version of WezTerm is available in the official repositories.
-
-    ```console
-    $ zypper install wezterm
-    ```
-    ## openSUSE Slowroll
+    ## openSUSE Tumbleweed/Slowroll
 
     The stable version of WezTerm is available in the official repositories.
 
@@ -242,7 +245,7 @@ hide:
 
     ## openSUSE Leap
 
-    Use Copr or built if from source.
+    Use Copr or build if from source.
 
 === "Arch"
     ## Arch Linux

--- a/docs/install/linux.md
+++ b/docs/install/linux.md
@@ -168,14 +168,20 @@ hide:
 
     * Centos Stream 8 and 9
     * Fedora 38, 39, 40, rawhide
-    * OpenSUSE Leap 15.5
-    * OpenSUSE Tumbleweed
+    * openSUSE Leap 15.5
+    * openSUSE Tumbleweed
     * RHEL 8, 9
+
+    For openSUSE, install `dnf` beforehand with
+
+    ```console
+    $ sudo zypper in dnf
+    ```
 
     To perform initial installation:
 
     ```console
-    $ sudo dnf copr enable wezfurlong/wezterm-nightly
+    $ sudo dnf copr enable wezfurlong/wezterm-nightly <repository>
     $ sudo dnf install wezterm
     ```
 
@@ -213,24 +219,30 @@ hide:
     $ sudo dnf install -y {{ fedora39_rpm_stable }}
     ```
 
-=== "SUSE"
-    ## SUSE Linux
+=== "openSUSE"
+    ## openSUSE
 
     !!! note
-        It is recommended that you install via Copr so that it is easiest
-        to stay up to date as future versions of wezterm are released.
+        If you want nightly versions of WezTerm, it is recommended to use Copr.
 
-    WezTerm is also available in the official Factory repo in openSUSE
-    Tumbleweed. To install from Factory instead of Copr:
+    ## openSUSE Tumbleweed
+
+    The stable version of WezTerm is available in the official repositories.
 
     ```console
-    $ zypper addrepo https://download.opensuse.org/repositories/openSUSE:Factory/standard/openSUSE:Factory.repo
-    $ zypper refresh
+    $ zypper install wezterm
+    ```
+    ## openSUSE Slowroll
+
+    The stable version of WezTerm is available in the official repositories.
+
+    ```console
     $ zypper install wezterm
     ```
 
-    * The package installs `/usr/bin/wezterm` and `/usr/share/applications/org.wezfurlong.wezterm.desktop`
-    * Configuration instructions can be [found here](../config/files.md)
+    ## openSUSE Leap
+
+    Use Copr or built if from source.
 
 === "Arch"
     ## Arch Linux

--- a/get-deps
+++ b/get-deps
@@ -115,7 +115,6 @@ suse_deps() {
   if [ "${CI}" == "yes" ] ; then
     RESOLVE="--allow-downgrade"
   fi
-  $ZYPPER install $RESOLVE -yl 'perl-FindBin' 'perl-File-Compare' || true
   $ZYPPER install $RESOLVE -yl \
     'make' \
     'gcc' \


### PR DESCRIPTION
This PR

- updates the documentation for openSUSE/SUSE (it is always recommended to install a stable package from the official repositories if it is available)
- updates the Corpr docs

When using Copr on openSUSE distros, you need to specify which repository you want to use, otherwise the command will fail:

```bash
❯ sudo dnf copr enable wezfurlong/wezterm-nightly
Enabling a Copr repository. Please note that this repository is not part
of the main distribution, and quality may vary.

The Fedora Project does not exercise any power over the contents of
this repository beyond the rules outlined in the Copr FAQ at
<https://docs.pagure.org/copr.copr/user_documentation.html#what-i-can-build-in-copr>,
and packages are not held to any quality or security level.

Please do not file bug reports about these packages in Fedora
Bugzilla. In case of problems, contact the owner of this repository.

Do you really want to enable copr.fedorainfracloud.org/wezfurlong/wezterm-nightly? [y/N]: y
Error: It wasn't possible to enable this project.
Repository 'epel-20240506-x86_64' does not exist in project 'wezfurlong/wezterm-nightly'.
Available repositories: 'rhel-8-aarch64', 'centos-stream-8-aarch64', 'fedora-40-x86_64', 'fedora-38-aarch64', 'fedora-40-aarch64', 'opensuse-tumbleweed-aarch64', 'fedora-rawhide-x86_64', 'opensuse-leap-15.5-aarch64', 'centos-stream-9-aarch64', 'fedora-rawhide-aarch64', 'rhel-8-x86_64', 'opensuse-tumbleweed-x86_64', 'fedora-39-aarch64', 'rhel-9-aarch64', 'fedora-39-x86_64', 'rhel-9-x86_64', 'centos-stream-9-x86_64', 'opensuse-leap-15.5-x86_64', 'fedora-38-x86_64', 'centos-stream-8-x86_64'

If you want to enable a non-default repository, use the following command:
  'dnf copr enable wezfurlong/wezterm-nightly <repository>'
But note that the installed repo file will likely need a manual modification.
```
The same with a repository works:
```bash
❯ sudo dnf copr enable wezfurlong/wezterm-nightly opensuse-tumbleweed-x86_64
[sudo] password for root:
Enabling a Copr repository. Please note that this repository is not part
of the main distribution, and quality may vary.

The Fedora Project does not exercise any power over the contents of
this repository beyond the rules outlined in the Copr FAQ at
<https://docs.pagure.org/copr.copr/user_documentation.html#what-i-can-build-in-copr>,
and packages are not held to any quality or security level.

Please do not file bug reports about these packages in Fedora
Bugzilla. In case of problems, contact the owner of this repository.

Do you really want to enable copr.fedorainfracloud.org/wezfurlong/wezterm-nightly? [y/N]: y
Repository successfully enabled.
```

- removes 2 not needed dependencies for building from source (tested on Tumbleweed, Slowroll and Leap 15.5)

```bash
❯ ./get-deps
Loading repository data...
Reading installed packages...
Package 'perl-File-Compare' not found.
Package 'perl-FindBin' not found.
Loading repository data...
Reading installed packages...
(...)
```
However, the installation from source afterwards was successful.

```bash
(...) 
   Compiling wezterm-font v0.1.0 (/home/dgedon/git/wezterm/wezterm-font)
   Compiling window-funcs v0.1.0 (/home/dgedon/git/wezterm/lua-api-crates/window-funcs)
    Finished release [optimized] target(s) in 2m 41s

wezterm on  suse via 🐍 v3.11.9 via 🦀 v1.77.2 took 2m41s 
❯ cargo run --release --bin wezterm -- start
    Finished release [optimized] target(s) in 0.18s
     Running `target/release/wezterm start`
```

### Tests/linting
I ran 

```bash
rustup component add rustfmt-preview
$ cargo test --all
(...)
failures:
    e2e::agent_forward::no_agent_forward_should_happen_when_disabled
    e2e::agent_forward::ssh_add_should_be_able_to_list_identities_with_agent_forward

test result: FAILED. 37 passed; 2 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.64s

$ cargo fmt --all
Warning: can't set `imports_granularity = Module`, unstable features are only available in nightly channel.
(...)
```
as mentioned in the contribution guide, but was not able to get the tests to pass, although I did not touch the code of WezTerm itself.


