### PR TITLE
nix: allowBuiltinFetchGit = true

### DIFF
--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -105,10 +105,7 @@
 
         cargoLock = {
           lockFile = ../Cargo.lock;
-          outputHashes = {
-            "xcb-imdkit-0.3.0" = "sha256-fTpJ6uNhjmCWv7dZqVgYuS2Uic36XNYTbqlaly5QBjI=";
-            "sqlite-cache-0.1.3" = "sha256-sBAC8MsQZgH+dcWpoxzq9iw5078vwzCijgyQnMOWIkk";
-          };
+          allowBuiltinFetchGit = true;
         };
 
         preConfigure = ''


### PR DESCRIPTION
implement https://github.com/wez/wezterm/pull/5373#issuecomment-2106088660

This will reduce the frequency of nix-related maintenance.
I tested this change with `nix run ./nix`.