### PR TITLE
Windows: fix warnings in `portable-pty`

### DIFF
--- a/pty/src/cmdbuilder.rs
+++ b/pty/src/cmdbuilder.rs
@@ -6,7 +6,9 @@ use std::collections::BTreeMap;
 use std::ffi::{OsStr, OsString};
 #[cfg(windows)]
 use std::os::windows::ffi::OsStrExt;
-use std::path::{Component, Path};
+#[cfg(unix)]
+use std::path::Component;
+use std::path::Path;
 
 /// Used to deal with Windows having case-insensitive environment variables.
 #[derive(Clone, Debug, PartialEq, PartialOrd)]
@@ -605,8 +607,6 @@ impl CommandBuilder {
     }
 
     pub(crate) fn current_directory(&self) -> Option<Vec<u16>> {
-        use std::path::Path;
-
         let home: Option<&OsStr> = self
             .get_env("USERPROFILE")
             .filter(|path| Path::new(path).is_dir());
@@ -745,6 +745,7 @@ impl CommandBuilder {
     }
 }
 
+#[cfg(unix)]
 /// Returns true if the path begins with `./` or `../`
 fn is_cwd_relative_path<P: AsRef<Path>>(p: P) -> bool {
     matches!(
@@ -757,6 +758,7 @@ fn is_cwd_relative_path<P: AsRef<Path>>(p: P) -> bool {
 mod tests {
     use super::*;
 
+    #[cfg(unix)]
     #[test]
     fn test_cwd_relative() {
         assert!(is_cwd_relative_path("."));


### PR DESCRIPTION
Hi! Tiny PR, just fixes up a few build warnings when building `portable-pty` on Windows:

```
warning: the item `Path` is imported redundantly
   --> pty\src\cmdbuilder.rs:608:13
    |
9   | use std::path::{Component, Path};
    |                            ---- the item `Path` is already imported here
...
608 |         use std::path::Path;
    |             ^^^^^^^^^^^^^^^
    |
    = note: `#[warn(unused_imports)]` on by default

warning: function `is_cwd_relative_path` is never used
   --> pty\src\cmdbuilder.rs:749:4
    |
749 | fn is_cwd_relative_path<P: AsRef<Path>>(p: P) -> bool {
    |    ^^^^^^^^^^^^^^^^^^^^
    |
    = note: `#[warn(dead_code)]` on by default
 ```
 
I'm hoping to contribute more substantial Windows fixes soon. I've been noticing that every few days WezTerm pegs a CPU core on Windows but haven't been able to pinpoint why. I now have a build with debug symbols and I'll profile it next time the issue occurs.