### PR TITLE
Check for the presence of CARGO_BUILD_TARGET_DIR env variable 

### DIFF
--- a/wezterm-gui/build.rs
+++ b/wezterm-gui/build.rs
@@ -168,7 +168,7 @@ END
             .join("WezTerm.app")
             .join("Contents")
             .join("Info.plist");
-        let build_target_dir = std::env::var("CARGO_BUILD_TARGET_DIR")
+        let build_target_dir = std::env::var("CARGO_TARGET_DIR")
             .and_then(|s| Ok(std::path::PathBuf::from(s)))
             .unwrap_or(repo_dir.join("target").join(profile));
         let dest_plist = build_target_dir.join("Info.plist");

--- a/wezterm-gui/build.rs
+++ b/wezterm-gui/build.rs
@@ -168,7 +168,10 @@ END
             .join("WezTerm.app")
             .join("Contents")
             .join("Info.plist");
-        let dest_plist = repo_dir.join("target").join(profile).join("Info.plist");
+        let build_target_dir = std::env::var("CARGO_BUILD_TARGET_DIR")
+            .and_then(|s| Ok(std::path::PathBuf::from(s)))
+            .unwrap_or(repo_dir.join("target").join(profile));
+        let dest_plist = build_target_dir.join("Info.plist");
         println!("cargo:rerun-if-changed=assets/macos/WezTerm.app/Contents/Info.plist");
 
         std::fs::copy(&src_plist, &dest_plist)


### PR DESCRIPTION
When building in the presence of a CARGO_BUILD_TARGET_DIR, there is no target dir created inside the repo, so copying to a location within the local repo dir fails, hence we need to copy to the actual target dir that is being used.