### PR TITLE
use correct flake dir in update-flake workflow

### DIFF
--- a/.github/workflows/update-flake.yml
+++ b/.github/workflows/update-flake.yml
@@ -25,3 +25,4 @@ jobs:
             automated
           pr-assignees: happenslol,gabyx,emiller88
           # TODO pr-reviewers: SomeOtherGitHubUsername,SomeThirdGitHubUsername
+          path-to-flake-dir: 'nix/'


### PR DESCRIPTION
Will fix the update-flake workflow, which is currently failing each time. Will also remove the warning of an old nixpkgs revision that is currently shown on each Nix build workflow.

Fix was posted here: https://github.com/wez/wezterm/pull/5373#issuecomment-2103484296