### PR TITLE
Fix: slow close non last tab

### DIFF
--- a/mux/src/window.rs
+++ b/mux/src/window.rs
@@ -131,6 +131,8 @@ impl Window {
 
         if len > 0 && self.active >= len {
             self.set_active_without_saving(len - 1);
+        } else if len > 0 {
+            self.set_active_without_saving(self.active);
         }
     }
 
@@ -161,7 +163,6 @@ impl Window {
         }
         let tab = self.tabs.remove(idx);
         self.fixup_active_tab_after_removal(active);
-        self.invalidate();
         tab
     }
 

--- a/mux/src/window.rs
+++ b/mux/src/window.rs
@@ -161,6 +161,7 @@ impl Window {
         }
         let tab = self.tabs.remove(idx);
         self.fixup_active_tab_after_removal(active);
+        self.invalidate();
         tab
     }
 

--- a/mux/src/window.rs
+++ b/mux/src/window.rs
@@ -131,8 +131,8 @@ impl Window {
 
         if len > 0 && self.active >= len {
             self.set_active_without_saving(len - 1);
-        } else if len > 0 {
-            self.set_active_without_saving(self.active);
+        } else {
+            self.invalidate();
         }
     }
 


### PR DESCRIPTION
Fix issue: https://github.com/wez/wezterm/issues/5304
Problem: after closing a non-last tab [invalidate](https://github.com/wez/wezterm/blob/396c8d9a886d06c4f839a24d3942f8612b6b84d0/mux/src/window.rs#L74) wasn't called, which is important for rendering tabs.