### PR TITLE
Fix Windows CI.

### DIFF
--- a/.github/workflows/gen_windows.yml
+++ b/.github/workflows/gen_windows.yml
@@ -23,6 +23,7 @@ jobs:
       CARGO_INCREMENTAL: "0"
       SCCACHE_GHA_ENABLED: "true"
       RUSTC_WRAPPER: "sccache"
+      RUSTUP_WINDOWS_PATH_ADD_BIN: "1"
 
     steps:
       - name: "checkout repo"

--- a/.github/workflows/gen_windows_continuous.yml
+++ b/.github/workflows/gen_windows_continuous.yml
@@ -26,6 +26,7 @@ jobs:
       CARGO_INCREMENTAL: "0"
       SCCACHE_GHA_ENABLED: "true"
       RUSTC_WRAPPER: "sccache"
+      RUSTUP_WINDOWS_PATH_ADD_BIN: "1"
 
     steps:
       - name: "checkout repo"

--- a/.github/workflows/gen_windows_tag.yml
+++ b/.github/workflows/gen_windows_tag.yml
@@ -13,6 +13,7 @@ jobs:
       CARGO_INCREMENTAL: "0"
       SCCACHE_GHA_ENABLED: "true"
       RUSTC_WRAPPER: "sccache"
+      RUSTUP_WINDOWS_PATH_ADD_BIN: "1"
 
     steps:
       - name: "checkout repo"

--- a/ci/generate-workflows.py
+++ b/ci/generate-workflows.py
@@ -812,6 +812,8 @@ rustup default {toolchain}
             self.env["MACOSX_DEPLOYMENT_TARGET"] = "10.9"
         if "alpine" in self.name:
             self.env["RUSTFLAGS"] = "-C target-feature=-crt-static"
+        if "win" in self.name:
+            self.env["RUSTUP_WINDOWS_PATH_ADD_BIN"] = "1"
         return
 
     def prep_environment(self, cache=True):


### PR DESCRIPTION
It's currently failing when running tests with errors of the form:

> error: creating test list failed
>
> Caused by:
>   for `wezterm-config-derive`, command
>   `'D:\a\wezterm\wezterm\target\debug\deps\wezterm_config_derive-f1c7f0f2de220b6e.exe'
>   --list --format terse` exited with code 0xc0000135: The specified
>   module could not be found. (os error 126)

This seems to have been caused by nextest-rs/nextest#1493, with this comment as a workaround fix: https://github.com/nextest-rs/nextest/issues/1493#issuecomment-2106331574