### PR TITLE
Use more stable format when first describing SGR sequence

### DIFF
--- a/docs/escape-sequences.md
+++ b/docs/escape-sequences.md
@@ -140,10 +140,8 @@ are broken out below.
 
 #### Graphic Rendition (SGR)
 
-SGR sequences are of the form `CSI DIGITS [; DIGITS ]+ m`.  That is, any number
-of semicolon separated numbers, terminated by the `m` codepoint.  There are a handful
-of slightly more modern sequences that use colon `:` codepoints to encode additional
-context.
+SGR sequences are of the form `CSI DIGITS [: DIGITS ]+ m`.  That is, any number
+of colon separated numbers, terminated by the `m` codepoint.
 
 The digits map to one of the codes in the table below, which manipulate the
 presentation attributes of subsequently printed characters.


### PR DESCRIPTION
Since the older ambiguous format using semicolon is described later (below the table), I opted to removing the 2nd part of the paragraph instead of adapting it.

Related: #5450