### PR TITLE
Fix macOS notch avoidance padding in full screen mode

### DIFF
--- a/window/src/os/macos/window.rs
+++ b/window/src/os/macos/window.rs
@@ -895,11 +895,13 @@ impl WindowOps for Window {
                     let insets: NSEdgeInsets = unsafe { msg_send![main_screen, safeAreaInsets] };
                     log::trace!("{:?}", insets);
 
-                    // Bleh, the API is supposed to give us the right metrics, but it needs
-                    // a tweak to look good around the notch.
-                    // <https://github.com/wez/wezterm/issues/1737#issuecomment-1085923867>
-                    let top = insets.top.ceil() as usize;
-                    let top = if top > 0 { top + 2 } else { 0 };
+                    let scale = unsafe {
+                        let frame = NSScreen::frame(main_screen);
+                        let backing_frame = NSScreen::convertRectToBacking_(main_screen, frame);
+                        backing_frame.size.height / frame.size.height
+                    };
+
+                    let top = (insets.top.ceil() * scale) as usize;
                     Some(Border {
                         top: ULength::new(top),
                         left: ULength::new(insets.left.ceil() as usize),


### PR DESCRIPTION
Fixes https://github.com/wez/wezterm/issues/3807

The values returned by [`safeAreaInsets`][0] need to be multipled by the scale factor of the display (in case of the MacBook Pro 14-inch, 2021, a value of 2.0).

There's a code comment referencing [#1737 (comment)][1], where an extra `2` was added to this number, but something must have changed since then because I cannot see a need for this now.

(Not familiar with Rust, so let me know if there's a better way to write this!)

[0]: https://developer.apple.com/documentation/appkit/nsscreen/3882821-safeareainsets
[1]: https://github.com/wez/wezterm/issues/1737#issuecomment-1085923867