### PR TITLE
Feature/search field arrows support

### DIFF
--- a/mux/src/pane.rs
+++ b/mux/src/pane.rs
@@ -67,7 +67,7 @@ impl Default for Pattern {
 }
 
 impl Pattern {
-    /// 更新枚举中的字符串值
+    /// Update string value in enum
     pub fn set_string(&mut self, new_string: String) {
         match self {
             Pattern::CaseSensitiveString(ref mut s) => *s = new_string,

--- a/mux/src/pane.rs
+++ b/mux/src/pane.rs
@@ -66,6 +66,17 @@ impl Default for Pattern {
     }
 }
 
+impl Pattern {
+    /// 更新枚举中的字符串值
+    pub fn set_string(&mut self, new_string: String) {
+        match self {
+            Pattern::CaseSensitiveString(ref mut s) => *s = new_string,
+            Pattern::CaseInSensitiveString(ref mut s) => *s = new_string,
+            Pattern::Regex(ref mut s) => *s = new_string,
+        }
+    }
+}
+
 impl std::ops::Deref for Pattern {
     type Target = String;
     fn deref(&self) -> &String {

--- a/wezterm-gui/src/overlay/copy.rs
+++ b/wezterm-gui/src/overlay/copy.rs
@@ -1173,6 +1173,15 @@ impl Pane for CopyOverlay {
                         render.schedule_update_search();
                     }
                 }
+                (KeyCode::Delete, KeyModifiers::NONE) => {
+                    // Delete to edit the pattern
+                    if render.pattern.len() > 0 {
+                        let position = render.search_cursor_index;
+                        let new_pattern = delete_char_at(&mut render.pattern, position);
+                        render.pattern.set_string(new_pattern);
+                        render.schedule_update_search();
+                    }
+                }
                 (KeyCode::LeftArrow, KeyModifiers::NONE) => {
                     if render.search_cursor_index > 0 {
                         render.search_cursor_index -= 1;

--- a/wezterm-gui/src/overlay/copy.rs
+++ b/wezterm-gui/src/overlay/copy.rs
@@ -1943,7 +1943,7 @@ pub fn copy_key_table() -> KeyTable {
 fn insert_char_at(s: &str, position: usize, insert_char: char) -> String {
     let graphemes = Graphemes::new(s).collect::<Vec<&str>>();
 
-    // 保证插入位置不超出范围
+    // Ensure that the insertion position does not exceed the range
     let position = if position > graphemes.len() {
         graphemes.len()
     } else {
@@ -1959,7 +1959,7 @@ fn insert_char_at(s: &str, position: usize, insert_char: char) -> String {
         result.push_str(grapheme);
     }
 
-    // 如果插入位置正好是字符串末尾，需要在末尾追加插入字符
+    // append the char at the end if the insertion position is exactly at the end of the string
     if position == graphemes.len() {
         result.push(insert_char);
     }
@@ -1968,15 +1968,13 @@ fn insert_char_at(s: &str, position: usize, insert_char: char) -> String {
 }
 
 fn delete_char_at(s: &str, position: usize) -> String {
-    // 将字符串按 Unicode 字符拆分
     let graphemes = Graphemes::new(s).collect::<Vec<&str>>();
 
-    // 如果位置超出范围，返回原字符串
     if position >= graphemes.len() {
         return s.to_string();
     }
 
-    // 组合新的字符串，排除指定位置的字符
+    // Combine new strings, excluding characters at specified positions
     graphemes.iter().enumerate()
         .filter(|&(i, _)| i != position)
         .map(|(_, &c)| c)
@@ -1988,7 +1986,7 @@ fn first_n_chars(s: &str, n: usize) -> String {
     if n >= graphemes.len() {
         return s.to_string();
     }
-    // 获取前 n 个字符的字节长度
+    // Get the first n characters
     graphemes.iter().enumerate()
         .filter(|&(i, _)| i + 1 <= n)
         .map(|(_, &c)| c)


### PR DESCRIPTION
Related PR https://github.com/wez/wezterm/pull/5416

Impliment https://github.com/wez/wezterm/issues/3087#issue-1578427455
- Add support of cursor and arrows in search field.
- Support the [Delete] key to edit the pattern
- Support unicode.

As a Rust beginner, I'm not sure if there are more convenient existing string handling functions.

@Mrreadiness 