### PR TITLE
Hotfix/search overlay move to end of line

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5212,6 +5212,7 @@ dependencies = [
  "pest",
  "pest_derive",
  "phf",
+ "rstest",
  "serde",
  "sha2",
  "signal-hook",

--- a/termwiz/Cargo.toml
+++ b/termwiz/Cargo.toml
@@ -59,6 +59,7 @@ criterion = "0.5"
 varbincode = "0.1"
 k9 = "0.12"
 env_logger = "0.11"
+rstest = "0.21.0"
 
 
 [target."cfg(unix)".dependencies]

--- a/termwiz/src/lineedit/buffer.rs
+++ b/termwiz/src/lineedit/buffer.rs
@@ -174,15 +174,7 @@ impl LineEditBuffer {
                 position
             }
             Movement::StartOfLine => 0,
-            Movement::EndOfLine => {
-                let mut cursor =
-                    GraphemeCursor::new(self.line.len().saturating_sub(1), self.line.len(), false);
-                if let Ok(Some(pos)) = cursor.next_boundary(&self.line, 0) {
-                    pos
-                } else {
-                    self.cursor
-                }
-            }
+            Movement::EndOfLine => self.line.len(),
             Movement::None => self.cursor,
         }
     }


### PR DESCRIPTION
- Fix crash when jumping to the end of the line. 
- add some unit tests for LineEditBuffer

see https://github.com/wez/wezterm/pull/5564#discussion_r1640757300

@wez @Mrreadiness 