### PR TITLE
Bugfix/docs typos

### DIFF
--- a/docs/config/lua/keyassignment/SelectTextAtMouseCursor.md
+++ b/docs/config/lua/keyassignment/SelectTextAtMouseCursor.md
@@ -11,7 +11,7 @@ to take the surrounding semantic zone.
 
 In this example, the triple-left-click mouse action is set to
 automatically select the entire command output when clicking
-on any character withing that region:
+on any character within that region:
 
 ```lua
 config.mouse_bindings = {

--- a/docs/config/lua/pane/index.markdown
+++ b/docs/config/lua/pane/index.markdown
@@ -12,7 +12,7 @@ for the sake of simplicity.
 
 A Pane object is typically passed to your code via an event callback.  A Pane
 object is a handle to a live instance of a Pane that is known to the wezterm
-process.  A Pane object tracks the psuedo terminal (or real serial terminal)
+process.  A Pane object tracks the pseudo terminal (or real serial terminal)
 and associated process(es) and the parsed screen and scrollback.
 
 A Pane object can be used to send input to the associated processes and


### PR DESCRIPTION
fixing two typos I encountered in the docs
s/within/withing
s/psuedo/pseudo

that last one has been made a bunch of times in the code itself as well I noticed, see below. But for now I'm only going to propose these minor docs typo corrections

```
$ rg psuedo
pty/src/lib.rs
2://! psuedo terminal (pty) interfaces provided by the system.

pty/src/win/psuedocon.rs
95:            "failed to create psuedo console: HRESULT {}",

pty/src/win/conpty.rs
2:use crate::win::psuedocon::PsuedoCon;

pty/src/win/mod.rs
16:mod psuedocon;

pty/src/win/procthreadattr.rs
1:use crate::win::psuedocon::HPCON;

docs/config/lua/pane/index.markdown
15:process.  A Pane object tracks the psuedo terminal (or real serial terminal)
```
psuedo is a common spelling mistake of pseudo, but definitely a mistake