### PR TITLE
replace all 'psuedo' by 'pseudo'

### DIFF
--- a/pty/src/lib.rs
+++ b/pty/src/lib.rs
@@ -1,5 +1,5 @@
 //! This crate provides a cross platform API for working with the
-//! psuedo terminal (pty) interfaces provided by the system.
+//! pseudo terminal (pty) interfaces provided by the system.
 //! Unlike other crates in this space, this crate provides a set
 //! of traits that allow selecting from different implementations
 //! at runtime.

--- a/pty/src/win/conpty.rs
+++ b/pty/src/win/conpty.rs
@@ -1,5 +1,5 @@
 use crate::cmdbuilder::CommandBuilder;
-use crate::win::psuedocon::PsuedoCon;
+use crate::win::pseudocon::PseudoCon;
 use crate::{Child, MasterPty, PtyPair, PtySize, PtySystem, SlavePty};
 use anyhow::Error;
 use filedescriptor::{FileDescriptor, Pipe};
@@ -14,7 +14,7 @@ impl PtySystem for ConPtySystem {
         let stdin = Pipe::new()?;
         let stdout = Pipe::new()?;
 
-        let con = PsuedoCon::new(
+        let con = PseudoCon::new(
             COORD {
                 X: size.cols as i16,
                 Y: size.rows as i16,
@@ -44,7 +44,7 @@ impl PtySystem for ConPtySystem {
 }
 
 struct Inner {
-    con: PsuedoCon,
+    con: PseudoCon,
     readable: FileDescriptor,
     writable: Option<FileDescriptor>,
     size: PtySize,

--- a/pty/src/win/mod.rs
+++ b/pty/src/win/mod.rs
@@ -13,7 +13,7 @@ use winapi::um::winbase::INFINITE;
 
 pub mod conpty;
 mod procthreadattr;
-mod psuedocon;
+mod pseudocon;
 
 use filedescriptor::OwnedHandle;
 

--- a/pty/src/win/procthreadattr.rs
+++ b/pty/src/win/procthreadattr.rs
@@ -1,4 +1,4 @@
-use crate::win::psuedocon::HPCON;
+use crate::win::pseudocon::HPCON;
 use anyhow::{ensure, Error};
 use std::io::Error as IoError;
 use std::{mem, ptr};

--- a/pty/src/win/pseudocon.rs
+++ b/pty/src/win/pseudocon.rs
@@ -63,20 +63,20 @@ lazy_static! {
     static ref CONPTY: ConPtyFuncs = load_conpty();
 }
 
-pub struct PsuedoCon {
+pub struct PseudoCon {
     con: HPCON,
 }
 
-unsafe impl Send for PsuedoCon {}
-unsafe impl Sync for PsuedoCon {}
+unsafe impl Send for PseudoCon {}
+unsafe impl Sync for PseudoCon {}
 
-impl Drop for PsuedoCon {
+impl Drop for PseudoCon {
     fn drop(&mut self) {
         unsafe { (CONPTY.ClosePseudoConsole)(self.con) };
     }
 }
 
-impl PsuedoCon {
+impl PseudoCon {
     pub fn new(size: COORD, input: FileDescriptor, output: FileDescriptor) -> Result<Self, Error> {
         let mut con: HPCON = INVALID_HANDLE_VALUE;
         let result = unsafe {
@@ -92,7 +92,7 @@ impl PsuedoCon {
         };
         ensure!(
             result == S_OK,
-            "failed to create psuedo console: HRESULT {}",
+            "failed to create pseudo console: HRESULT {}",
             result
         );
         Ok(Self { con })


### PR DESCRIPTION
Replace all internal occurrences of 'psuedo' and 'Psuedo' by 'pseudo' and 'Pseudo' in filename, module name, and types. No external interfaces depend on this AFAIK, and I was able to build on linux after this modification, so it should be fine.

This is a minor change and mainly me getting more familiar with the contributing process and being perfectionist, wanting consistency after [the previous pull request that also changed this in the docs](https://github.com/wez/wezterm/pull/5571) got merged