### PR TITLE
nix/flake.nix: remove invalid follows

### DIFF
--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -6,10 +6,7 @@
     flake-utils.url = "github:numtide/flake-utils";
     rust-overlay = {
       url = "github:oxalica/rust-overlay";
-      inputs = {
-        nixpkgs.follows = "nixpkgs";
-        flake-utils.follows = "flake-utils";
-      };
+      inputs.nixpkgs.follows = "nixpkgs";
     };
 
     # NOTE: @2024-05 Nix flakes does not support getting git submodules of 'self'.


### PR DESCRIPTION
Rust overlay no longer uses flake-utls as of https://github.com/oxalica/rust-overlay/pull/180