### PR TITLE
nix: add meta.mainProgram

### DIFF
--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -156,6 +156,8 @@
               tic -x -o $out/share/terminfo ${src}/termwiz/data/wezterm.terminfo
             '';
         };
+
+        meta.mainProgram = "wezterm";
       };
 
       devShell = pkgs.mkShell {


### PR DESCRIPTION
To avoid the following warning while using `lib.getExe`:

```
warning: getExe: Package wezterm does not have the meta.mainProgram attribute. We'll assume that the main program has the same name for now, but this behavior is deprecated, because it leads to surprising errors when the assumption does not hold. If the package has a main program, please set `meta.mainProgram` in its definition to make this warning go away. Otherwise, if the package does not have a main program, or if you don't control its definition, use getExe' to specify the name to the program, such as lib.getExe' foo "bar".
```