### PR TITLE
Remove trailing sZs from generated plugin directory if it exists

### DIFF
--- a/lua-api-crates/plugin/src/lib.rs
+++ b/lua-api-crates/plugin/src/lib.rs
@@ -35,6 +35,9 @@ fn compute_repo_dir(url: &str) -> String {
             c => dir.push_str(&format!("u{}", c as u32)),
         }
     }
+    if dir.ends_with("sZs") {
+        dir.truncate(dir.len() - 3);
+    }
     dir
 }
 


### PR DESCRIPTION
Depending on whether you `require` a Wezterm plugin with or without a `/` at the end, a different directory name is generated for the plugin:

`local foo = wezterm.plugin.require 'https://github.com/example/example'` will generate a plugin dir named: `httpssCssZssZsgithubsDscomsZsexamplesZsexample`

`local bar = wezterm.plugin.require 'https://github.com/example/example/'` will generate a plugin dir named: `httpssCssZssZsgithubsDscomsZsexamplesZsexamplesZs`

So if you `require` the same plugin in various modules but aren't consistent (sometime using a `/` and sometimes not), you end up with duplicate versions of the plugin in your Wezterm plugins folder. If a plugin author uses one format, but you use a different format when you `require` the plugin, you will similarly end up with duplicate versions of the plugin.

This PR simply tries to strip trailing `sZs` from the generated directory name if it exists, so the plugin directory name will remain consistent for a given plugin whether or not it was imported with a trailing slash.