### PR TITLE
chore: typo psuedo -> pseudo

### DIFF
--- a/pty/src/lib.rs
+++ b/pty/src/lib.rs
@@ -1,5 +1,5 @@
 //! This crate provides a cross platform API for working with the
-//! psuedo terminal (pty) interfaces provided by the system.
+//! pseudo terminal (pty) interfaces provided by the system.
 //! Unlike other crates in this space, this crate provides a set
 //! of traits that allow selecting from different implementations
 //! at runtime.

--- a/pty/src/win/conpty.rs
+++ b/pty/src/win/conpty.rs
@@ -1,5 +1,5 @@
 use crate::cmdbuilder::CommandBuilder;
-use crate::win::psuedocon::PsuedoCon;
+use crate::win::pseudocon::PsuedoCon;
 use crate::{Child, MasterPty, PtyPair, PtySize, PtySystem, SlavePty};
 use anyhow::Error;
 use filedescriptor::{FileDescriptor, Pipe};

--- a/pty/src/win/mod.rs
+++ b/pty/src/win/mod.rs
@@ -13,7 +13,7 @@ use winapi::um::winbase::INFINITE;
 
 pub mod conpty;
 mod procthreadattr;
-mod psuedocon;
+mod pseudocon;
 
 use filedescriptor::OwnedHandle;
 

--- a/pty/src/win/procthreadattr.rs
+++ b/pty/src/win/procthreadattr.rs
@@ -1,4 +1,4 @@
-use crate::win::psuedocon::HPCON;
+use crate::win::pseudocon::HPCON;
 use anyhow::{ensure, Error};
 use std::io::Error as IoError;
 use std::{mem, ptr};

--- a/pty/src/win/pseudocon.rs
+++ b/pty/src/win/pseudocon.rs
@@ -24,7 +24,7 @@ use winapi::um::winnt::HANDLE;
 
 pub type HPCON = HANDLE;
 
-pub const PSUEDOCONSOLE_INHERIT_CURSOR: DWORD = 0x1;
+pub const PSEUDOCONSOLE_INHERIT_CURSOR: DWORD = 0x1;
 pub const PSEUDOCONSOLE_RESIZE_QUIRK: DWORD = 0x2;
 pub const PSEUDOCONSOLE_WIN32_INPUT_MODE: DWORD = 0x4;
 #[allow(dead_code)]
@@ -84,7 +84,7 @@ impl PsuedoCon {
                 size,
                 input.as_raw_handle() as _,
                 output.as_raw_handle() as _,
-                PSUEDOCONSOLE_INHERIT_CURSOR
+                PSEUDOCONSOLE_INHERIT_CURSOR
                     | PSEUDOCONSOLE_RESIZE_QUIRK
                     | PSEUDOCONSOLE_WIN32_INPUT_MODE,
                 &mut con,
@@ -92,7 +92,7 @@ impl PsuedoCon {
         };
         ensure!(
             result == S_OK,
-            "failed to create psuedo console: HRESULT {}",
+            "failed to create pseudo console: HRESULT {}",
             result
         );
         Ok(Self { con })


### PR DESCRIPTION
In https://github.com/microsoft/terminal/issues/17688 among other things I have been pointed out that wezterm has `psuedo` instead of `pseudo` in the codebase.

## This pr
Just fixes a typo, this makes `rg -t rust pseudo` show what you expect.

I hope you don't find this pr impolite, as I am just renaming a file in a codebase I don't mantain.

## NOTEs
In https://github.com/microsoft/terminal/issues/17688 I was told that there might be some problems the way wezterm uses `conpty.dll`, a separate pr will follow on that.