### PR TITLE
WIP: add logging to help investigate incorrect terminal size on macOS

### DIFF
--- a/mux/src/domain.rs
+++ b/mux/src/domain.rs
@@ -606,6 +606,8 @@ impl Domain for LocalDomain {
         let child_result = pair.slave.spawn_command(cmd);
         let mut writer = WriterWrapper::new(pair.master.take_writer()?);
 
+        log::warn!("LocalDomain.spawn_pane size: {size:?}");
+
         let mut terminal = wezterm_term::Terminal::new(
             size,
             std::sync::Arc::new(config::TermConfig::new()),

--- a/mux/src/lib.rs
+++ b/mux/src/lib.rs
@@ -1278,6 +1278,7 @@ impl Mux {
 
         let tab = Arc::new(Tab::new(&size));
         tab.assign_pane(&pane);
+        log::warn!("Mux.move_pane_to_new_tab size: {size:?}");
         pane.resize(size)?;
         self.add_tab_and_active_pane(&tab)?;
         self.add_tab_to_window(&tab, window_id)?;

--- a/mux/src/localpane.rs
+++ b/mux/src/localpane.rs
@@ -411,6 +411,7 @@ impl Pane for LocalPane {
     }
 
     fn resize(&self, size: TerminalSize) -> Result<(), Error> {
+        log::warn!("LocalPane.resize size: {size:?}");
         self.pty.lock().resize(PtySize {
             rows: size.rows.try_into()?,
             cols: size.cols.try_into()?,

--- a/mux/src/tab.rs
+++ b/mux/src/tab.rs
@@ -491,6 +491,7 @@ fn apply_sizes_from_splits(tree: &Tree, size: &TerminalSize) {
             apply_sizes_from_splits(&*right, &data.second);
         }
         Tree::Leaf(pane) => {
+            log::warn!("apply_sizes_from_splits size: {size:?}");
             pane.resize(*size).ok();
         }
     }

--- a/term/src/terminalstate/mod.rs
+++ b/term/src/terminalstate/mod.rs
@@ -515,6 +515,8 @@ impl TerminalState {
 
         let unicode_version = config.unicode_version();
 
+        log::warn!("TerminalState.new size: {size:?}");
+
         TerminalState {
             config,
             screen,
@@ -876,6 +878,9 @@ impl TerminalState {
             self.seqno,
             self.enable_conpty_quirks,
         );
+
+        log::warn!("TerminalState.resize size: {size:?}");
+
         self.top_and_bottom_margins = 0..size.rows as i64;
         self.left_and_right_margins = 0..size.cols;
         self.pixel_height = size.pixel_height;

--- a/window/src/connection.rs
+++ b/window/src/connection.rs
@@ -84,7 +84,7 @@ pub trait ConnectionOps {
     fn resolve_geometry(&self, geometry: RequestedWindowGeometry) -> ResolvedGeometry {
         let bounds = match self.screens() {
             Ok(screens) => {
-                log::trace!("{screens:?}");
+                log::warn!("ConnectionOps.resolve_geometry {screens:?}");
 
                 match geometry.origin {
                     GeometryOrigin::ScreenCoordinateSystem => screens.virtual_rect,

--- a/window/src/os/macos/connection.rs
+++ b/window/src/os/macos/connection.rs
@@ -180,6 +180,7 @@ impl ConnectionOps for Connection {
         for idx in 0..unsafe { screens.count() } {
             let screen = unsafe { screens.objectAtIndex(idx) };
             let screen = nsscreen_to_screen_info(screen);
+            // This seems to be incorrect. Union does not adjust for scaling factor.
             virtual_rect = virtual_rect.union(&screen.rect);
             by_name.insert(screen.name.clone(), screen);
         }
@@ -202,6 +203,8 @@ impl ConnectionOps for Connection {
 pub fn nsscreen_to_screen_info(screen: *mut Object) -> ScreenInfo {
     let frame = unsafe { NSScreen::frame(screen) };
     let backing_frame = unsafe { NSScreen::convertRectToBacking_(screen, frame) };
+    log::warn!("nsscreen_to_screen_info frame: width: {}, height: {}", frame.size.width, frame.size.height);
+    log::warn!("nsscreen_to_screen_info backing_frame: width: {}, height: {}", backing_frame.size.width, backing_frame.size.height);
     let rect = euclid::rect(
         backing_frame.origin.x as isize,
         backing_frame.origin.y as isize,
@@ -220,6 +223,7 @@ pub fn nsscreen_to_screen_info(screen: *mut Object) -> ScreenInfo {
             backing_frame.origin.y
         )
     };
+    log::warn!("nsscreen_to_screen_info name: {name}");
 
     let has_max_fps: BOOL =
         unsafe { msg_send!(screen, respondsToSelector: sel!(maximumFramesPerSecond)) };

--- a/window/src/os/macos/window.rs
+++ b/window/src/os/macos/window.rs
@@ -453,11 +453,18 @@ impl Window {
             y,
         } = conn.resolve_geometry(geometry);
 
+        log::warn!("new_window ResolvedGeometry: width: {width}, height: {height}, x: {x:?}, y: {y:?}");
+
         let scale_factor = (conn.default_dpi() / crate::DEFAULT_DPI) as usize;
+        // let scale_factor = 2 as usize;
         let width = width / scale_factor;
         let height = height / scale_factor;
         let x = x.map(|x| x / scale_factor as i32);
         let y = y.map(|y| y / scale_factor as i32);
+
+        log::warn!("new_window conn.default_dpi: {}", conn.default_dpi());
+        log::warn!("new_window scale_factor: {scale_factor}");
+        log::warn!("new_window after scaling: width: {width}, height: {height}, x: {x:?}, y: {y:?}");
 
         let initial_pos = match (x, y) {
             (Some(x), Some(y)) => Some(ScreenPoint::new(x as isize, y as isize)),
@@ -615,10 +622,16 @@ impl Window {
             let backing_frame = NSView::convertRectToBacking(*view, frame);
             let width = backing_frame.size.width;
             let height = backing_frame.size.height;
+            log::warn!("new_window backing frame: width: {width}, height: {height}");
+
+            let dpi_for_window_screen_value = dpi_for_window_screen(*window, &config);
+            log::warn!("new_window dpi_for_window_screen: {dpi_for_window_screen_value:?}");
 
             let dpi = dpi_for_window_screen(*window, &config)
                 .unwrap_or(crate::DEFAULT_DPI * (backing_frame.size.width / frame.size.width))
                 as usize;
+
+            log::warn!("new_window dpi: {dpi}");
 
             let weak_window = window.weak();
             let window_handle = Window {
@@ -1201,6 +1214,7 @@ impl WindowInner {
         unsafe {
             NSWindow::setLevel_(*self.window, window_level_to_nswindow_level(level));
             // Dispatch a resize event with the updated window state
+            log::warn!("WindowInner.set_window_level");
             WindowView::did_resize(&mut **self.view, sel!(windowDidResize:), nil);
         }
     }
@@ -2785,6 +2799,7 @@ impl WindowView {
         let backing_frame = unsafe { NSView::convertRectToBacking(this as *mut _, frame) };
         let width = backing_frame.size.width;
         let height = backing_frame.size.height;
+        log::warn!("did_resize backing frame: width: {width}, height: {height}, x: {}, y: {}", backing_frame.origin.x, backing_frame.origin.y);
         if let Some(this) = Self::get_this(this) {
             let mut inner = this.inner.borrow_mut();
 
@@ -2845,6 +2860,7 @@ impl WindowView {
                 .unwrap_or(crate::DEFAULT_DPI * (backing_frame.size.width / frame.size.width))
                 as usize;
 
+            log::warn!("WindowView.did_resize dpi: {dpi}");
             inner.events.dispatch(WindowEvent::Resized {
                 dimensions: Dimensions {
                     pixel_width: width as usize,
@@ -2920,6 +2936,7 @@ impl WindowView {
                 // and a repaint.
                 inner.screen_changed = false;
                 drop(inner);
+                log::warn!("WindowView.draw_rect screen_changed");
                 Self::did_resize(view, sel, nil);
                 return;
             }


### PR DESCRIPTION
Some logging changes to help investigate https://github.com/wez/wezterm/issues/2958. Not meant for merging, but rather just to help other folks to figure out the solution.

I have the following in my config:
```
config.initial_rows = 24
config.initial_cols = 80
```

When you have a setup with Retina screen (such as MBP internal screen) and non-Retina external monitor, `ConnectionOps.screens` ([link](https://github.com/wez/wezterm/blob/4f123a461bffdd8ac2e21c0697d02c5c992abd29/window/src/os/macos/connection.rs#L175)) incorrectly calculates `virtual_rect`. Specifically it doesn't adjust for scaling factor, which is 2 for Retina displays and 1 for non-Retina displays. Current algorithm completely ignores scaling factors and just naively adds backing coordinates.

Here is one of the setups I have checked:
![Screenshot 2024-08-13 at 00 44 10](https://github.com/user-attachments/assets/beb62dfc-b223-4e3d-b7db-bd644ce96ec4)

The top display is an external non-Retina monitor and the bottom one is an internal MBP Retina display. As you can see, non-Retina display (which has both frame and backing frame (width of 3440, height of 1440), and scale of 1) is bigger than the internal one (which has frame (width of 1728, height of 1117) and backing frame (width of 3456, height of 2234), and scale of 2). But `virtual_rect` is incorrectly calculated as having width of 3456 (max of 3440 and 3456) and height of 3674 (1440 + 2234).

Some helpful resources I used while trying to understand macOS's behavior:
https://www.thinkandbuild.it/deal-with-multiple-screens-programming/
https://stackoverflow.com/questions/14579880/strange-nsscreen-coordinates
https://stackoverflow.com/questions/21751105/mac-os-x-convert-between-nsview-coordinates-and-global-screen-coordinates
https://developer.apple.com/documentation/appkit/nsscreen
https://developer.apple.com/documentation/appkit/nsscreen/1388389-convertrecttobacking
https://developer.apple.com/documentation/appkit/nsview/view_coordinates

Here are slightly edited logs (I removed duplicate lines with `nsscreen_to_screen_info`) when I run wezterm-gui from non-Retina external monitor. Notice that there are 3 lines with `TerminalState.resize` that have different values of pixel_width, pixel_height, and dpi.
```
01:21:07.824  WARN   window::os::macos::connection > nsscreen_to_screen_info frame: width: 3440, height: 1440
01:21:07.825  WARN   window::os::macos::connection > nsscreen_to_screen_info backing_frame: width: 3440, height: 1440
01:21:07.829  WARN   window::os::macos::connection > nsscreen_to_screen_info name: DELL U3419W
01:21:07.829  WARN   window::os::macos::connection > nsscreen_to_screen_info frame: width: 1728, height: 1117
01:21:07.829  WARN   window::os::macos::connection > nsscreen_to_screen_info backing_frame: width: 3456, height: 2234
01:21:07.829  WARN   window::os::macos::connection > nsscreen_to_screen_info name: Built-in Retina Display
01:21:07.842  WARN   mux::domain                   > LocalDomain.spawn_pane size: TerminalSize { rows: 24, cols: 80, pixel_width: 880, pixel_height: 624, dpi: 72 }
01:21:07.843  WARN   wezterm_term::terminalstate   > TerminalState.new size: TerminalSize { rows: 24, cols: 80, pixel_width: 880, pixel_height: 624, dpi: 72 }
01:21:07.864  WARN   window::connection            > ConnectionOps.resolve_geometry Screens { main: ScreenInfo { name: "DELL U3419W", rect: Rect(3440x1440 at (0, 0)), scale: 1.0, max_fps: Some(60), effective_dpi: Some(72.0) }, active: ScreenInfo { name: "DELL U3419W", rect: Rect(3440x1440 at (0, 0)), scale: 1.0, max_fps: Some(60), effective_dpi: Some(72.0) }, by_name: {"DELL U3419W": ScreenInfo { name: "DELL U3419W", rect: Rect(3440x1440 at (0, 0)), scale: 1.0, max_fps: Some(60), effective_dpi: Some(72.0) }, "Built-in Retina Display": ScreenInfo { name: "Built-in Retina Display", rect: Rect(3456x2234 at (0, -2234)), scale: 2.0, max_fps: Some(120), effective_dpi: Some(144.0) }}, virtual_rect: Rect(3456x3674 at (0, -2234)) }
01:21:07.865  WARN   window::os::macos::window     > new_window ResolvedGeometry: width: 902, height: 675, x: None, y: None
01:21:07.867  WARN   window::os::macos::window     > new_window conn.default_dpi: 72
01:21:07.867  WARN   window::os::macos::window     > new_window scale_factor: 1
01:21:07.867  WARN   window::os::macos::window     > new_window after scaling: width: 902, height: 675, x: None, y: None
01:21:07.883  WARN   window::os::macos::window     > new_window backing frame: width: 902, height: 675
01:21:07.884  WARN   window::os::macos::window     > new_window dpi_for_window_screen: None
01:21:07.884  WARN   window::os::macos::window     > new_window dpi: 72
01:21:07.938  WARN   window::os::macos::window     > did_resize backing frame: width: 1804, height: 1350, x: 0, y: -1350
01:21:07.938  WARN   window::os::macos::window     > WindowView.did_resize dpi: 144
01:21:07.942  WARN   mux::tab                      > apply_sizes_from_splits size: TerminalSize { rows: 24, cols: 80, pixel_width: 1840, pixel_height: 1224, dpi: 144 }
01:21:07.942  WARN   mux::localpane                > LocalPane.resize size: TerminalSize { rows: 24, cols: 80, pixel_width: 1840, pixel_height: 1224, dpi: 144 }
01:21:07.943  WARN   wezterm_term::terminalstate   > TerminalState.resize size: TerminalSize { rows: 24, cols: 80, pixel_width: 1840, pixel_height: 1224, dpi: 144 }
01:21:07.947  WARN   window::os::macos::window     > did_resize backing frame: width: 1804, height: 1350, x: 0, y: -1350
01:21:07.947  WARN   window::os::macos::window     > WindowView.did_resize dpi: 144
01:21:07.947  WARN   mux::tab                      > apply_sizes_from_splits size: TerminalSize { rows: 24, cols: 76, pixel_width: 1748, pixel_height: 1224, dpi: 144 }
01:21:07.947  WARN   mux::localpane                > LocalPane.resize size: TerminalSize { rows: 24, cols: 76, pixel_width: 1748, pixel_height: 1224, dpi: 144 }
01:21:07.947  WARN   wezterm_term::terminalstate   > TerminalState.resize size: TerminalSize { rows: 24, cols: 76, pixel_width: 1748, pixel_height: 1224, dpi: 144 }
01:21:07.965  WARN   window::os::macos::window     > did_resize backing frame: width: 1886, height: 1324, x: 0, y: -1324
01:21:07.965  WARN   window::os::macos::window     > WindowView.did_resize dpi: 72
01:21:07.969  WARN   mux::tab                      > apply_sizes_from_splits size: TerminalSize { rows: 48, cols: 169, pixel_width: 1859, pixel_height: 1248, dpi: 72 }
01:21:07.969  WARN   mux::localpane                > LocalPane.resize size: TerminalSize { rows: 48, cols: 169, pixel_width: 1859, pixel_height: 1248, dpi: 72 }
01:21:07.969  WARN   wezterm_term::terminalstate   > TerminalState.resize size: TerminalSize { rows: 48, cols: 169, pixel_width: 1859, pixel_height: 1248, dpi: 72 }
```

Here are slightly edited logs (I removed duplicate lines with `nsscreen_to_screen_info`) when I run wezterm-gui from an internal MBP Retina display. Notice that there are 2 lines with `TerminalState.resize` that have the same values of pixel_width, pixel_height, and dpi.
```
01:24:49.402  WARN   window::os::macos::connection > nsscreen_to_screen_info frame: width: 3440, height: 1440
01:24:49.402  WARN   window::os::macos::connection > nsscreen_to_screen_info backing_frame: width: 3440, height: 1440
01:24:49.403  WARN   window::os::macos::connection > nsscreen_to_screen_info name: DELL U3419W
01:24:49.403  WARN   window::os::macos::connection > nsscreen_to_screen_info frame: width: 1728, height: 1117
01:24:49.403  WARN   window::os::macos::connection > nsscreen_to_screen_info backing_frame: width: 3456, height: 2234
01:24:49.403  WARN   window::os::macos::connection > nsscreen_to_screen_info name: Built-in Retina Display
01:24:49.416  WARN   mux::domain                   > LocalDomain.spawn_pane size: TerminalSize { rows: 24, cols: 80, pixel_width: 1840, pixel_height: 1224, dpi: 144 }
01:24:49.416  WARN   wezterm_term::terminalstate   > TerminalState.new size: TerminalSize { rows: 24, cols: 80, pixel_width: 1840, pixel_height: 1224, dpi: 144 }
01:24:49.440  WARN   window::connection            > ConnectionOps.resolve_geometry Screens { main: ScreenInfo { name: "DELL U3419W", rect: Rect(3440x1440 at (0, 0)), scale: 1.0, max_fps: Some(60), effective_dpi: Some(72.0) }, active: ScreenInfo { name: "Built-in Retina Display", rect: Rect(3456x2234 at (0, -2234)), scale: 2.0, max_fps: Some(120), effective_dpi: Some(144.0) }, by_name: {"Built-in Retina Display": ScreenInfo { name: "Built-in Retina Display", rect: Rect(3456x2234 at (0, -2234)), scale: 2.0, max_fps: Some(120), effective_dpi: Some(144.0) }, "DELL U3419W": ScreenInfo { name: "DELL U3419W", rect: Rect(3440x1440 at (0, 0)), scale: 1.0, max_fps: Some(60), effective_dpi: Some(72.0) }}, virtual_rect: Rect(3456x3674 at (0, -2234)) }
01:24:49.441  WARN   window::os::macos::window     > new_window ResolvedGeometry: width: 1886, height: 1324, x: None, y: None
01:24:49.445  WARN   window::os::macos::window     > new_window conn.default_dpi: 144
01:24:49.445  WARN   window::os::macos::window     > new_window scale_factor: 2
01:24:49.445  WARN   window::os::macos::window     > new_window after scaling: width: 943, height: 662, x: None, y: None
01:24:49.456  WARN   window::os::macos::window     > new_window backing frame: width: 1886, height: 1324
01:24:49.456  WARN   window::os::macos::window     > new_window dpi_for_window_screen: None
01:24:49.456  WARN   window::os::macos::window     > new_window dpi: 144
01:24:49.499  WARN   window::os::macos::window     > did_resize backing frame: width: 1886, height: 1324, x: 0, y: -1324
01:24:49.500  WARN   window::os::macos::window     > WindowView.did_resize dpi: 144
01:24:49.501  WARN   mux::tab                      > apply_sizes_from_splits size: TerminalSize { rows: 24, cols: 80, pixel_width: 1840, pixel_height: 1224, dpi: 144 }
01:24:49.501  WARN   mux::localpane                > LocalPane.resize size: TerminalSize { rows: 24, cols: 80, pixel_width: 1840, pixel_height: 1224, dpi: 144 }
01:24:49.501  WARN   wezterm_term::terminalstate   > TerminalState.resize size: TerminalSize { rows: 24, cols: 80, pixel_width: 1840, pixel_height: 1224, dpi: 144 }
01:24:49.505  WARN   window::os::macos::window     > did_resize backing frame: width: 1886, height: 1324, x: 0, y: -1324
01:24:49.505  WARN   window::os::macos::window     > WindowView.did_resize dpi: 144
01:24:49.505  WARN   mux::tab                      > apply_sizes_from_splits size: TerminalSize { rows: 24, cols: 80, pixel_width: 1840, pixel_height: 1224, dpi: 144 }
01:24:49.505  WARN   mux::localpane                > LocalPane.resize size: TerminalSize { rows: 24, cols: 80, pixel_width: 1840, pixel_height: 1224, dpi: 144 }
01:24:49.506  WARN   wezterm_term::terminalstate   > TerminalState.resize size: TerminalSize { rows: 24, cols: 80, pixel_width: 1840, pixel_height: 1224, dpi: 144 }

```