### PR TITLE
fix: add short circuit to set active pane

### DIFF
--- a/mux/src/tab.rs
+++ b/mux/src/tab.rs
@@ -1748,6 +1748,12 @@ impl TabInner {
     }
 
     fn set_active_pane(&mut self, pane: &Arc<dyn Pane>) {
+        let prior = self.get_active_pane();
+
+        if is_pane(pane, &prior.as_ref()) {
+            return;
+        }
+
         if self.zoomed.is_some() {
             if !configuration().unzoom_on_switch_pane {
                 return;
@@ -1760,7 +1766,6 @@ impl TabInner {
             .iter()
             .find(|p| p.pane.pane_id() == pane.pane_id())
         {
-            let prior = self.get_active_pane();
             self.active = item.index;
             self.recency.tag(item.index);
             self.advise_focus_change(prior);


### PR DESCRIPTION
This is a go at addressing #5928. It solves the problem by short circuiting setting the active pane by checking if the requested pane is indeed already the active pane.

The end result is mainly the same with one caveat. The recency table is not getting updated if we short circuit...I am under the impression this won't change anything in a meaningful way as the active pane should already have the highest recency score. This might sort of be a bug as is...

If there's a good reason to keep the recency tag this can be refactored to ensure it gets set in the short circuit.