### PR TITLE
Fix ghost space left by SplitPane with top_level=true

### DIFF
--- a/mux/src/tab.rs
+++ b/mux/src/tab.rs
@@ -2004,6 +2004,9 @@ impl TabInner {
                 } else {
                     self.resize(split_info.second.clone());
                 }
+                // Resize the tab back to the original tab size
+                // to avoid leaving unusable space within the tab
+                self.resize(tab_size)
             }
 
             let mut cursor = self.pane.take().unwrap().cursor();


### PR DESCRIPTION
Fixes  #2579, #4984

When there is more than one pane in the tab, the tab.resize() is
called and the tab resize logic is reused to correctly resize all the
panes in the tab before adding the new pane split, so the new split
pane will not overwrite any existing pane.

The issue seems to be that after this resize, the tab "remembers" its
new size, and when the new split pane is closed, the tab is left with
ghost space which cannot be reused.

The fix is quite simple: we just need to immediately resize the tab
back to its original proportions. Since the underlying panes have
already been resized by tab.resize(), we don't need to keep the
restricted tab size.

I may have missed something, but this seems to work correctly.