### PR TITLE
Nix "nightly" build

### DIFF
--- a/.github/workflows/nix_continuous.yml
+++ b/.github/workflows/nix_continuous.yml
@@ -1,0 +1,38 @@
+name: nix_continuous
+
+on:
+  schedule:
+    - cron: "10 3 * * *"
+  push: 
+    branches:
+      - main
+    paths:
+      - '**/*.rs'
+      - '.github/workflows/nix.yml'
+      - 'nix/**'
+
+jobs:
+  lints:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install nix
+        uses: DeterminateSystems/nix-installer-action@main
+      - name: Cache build artifacts
+        uses: DeterminateSystems/magic-nix-cache-action@main
+      - name: Check flake inputs
+        uses: DeterminateSystems/flake-checker-action@main
+        with:
+          flake-lock-path: ./nix/flake.lock
+          ignore-missing-flake-lock: false
+      - name: Setup Cachix
+        uses: cachix/cachix-action@v27
+        with:
+          name: wezterm
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+      - name: Build default package
+        run: |
+          nix build ./nix --json \
+          | jq -r '.[].outputs | to_entries[].value' \
+          | cachix push wezterm

--- a/docs/install/linux.md
+++ b/docs/install/linux.md
@@ -286,6 +286,91 @@ hide:
     $ brew rm wezterm
     $ brew install --HEAD wezterm
     ```
+=== "Nix/NixOS"
+
+    ## Nix
+    
+    WezTerm is available in nixpkgs as `wezterm`.
+
+    ```nix
+    {
+        # configuration.nix
+
+        environment.systemPackages = [
+            pkgs.wezterm
+        ]
+    }
+    ```
+
+    ### Flake
+    
+    If you need a newer version use the flake. Use the cachix if you want to avoid building WezTerm from source.
+
+    The flake is in the `nix` directory, so the url will be something like `github:wez/wezterm?dir=nix`
+
+    Here's an example for NixOS configurations:
+    
+    ```nix
+    {
+        inputs.wezterm.url = "github:wez/wezterm?dir=nix";
+        # ...
+
+        outputs = inputs @ {nixpkgs, ...}:{
+            nixosConfigurations.HOSTNAME = nixpkgs.lib.nixosSystem {
+                specialArgs = { inherit inputs; }; # Make sure you pass inputs through to your nixosConfiguration like this
+                modules = [
+                    # ...
+                ];
+            };
+        };
+    }
+    ```
+    And for home-manager you can do the following:
+
+    ```nix
+    # flake.nix
+    
+    {
+        inputs.wezterm.url = "github:wez/wezterm?dir=nix";
+        # ...
+
+        outputs = inputs @ {nixpkgs, home-manager, ...}:{
+            homeConfigurations."user@HOSTNAME" = home-manager.lib.homeManagerConfiguration {
+                pkgs = nixpkgs.legacyPackages.x86_64-linux;
+                extraSpecialArgs = { inherit inputs; }; # Pass inputs to homeManagerConfiguration
+                modules = [
+                    ./home.nix
+                ];
+            };        
+        };
+    }
+    ```
+    ```nix
+    # home.nix
+    
+    {inputs, pkgs, ...}:{
+        programs.wezterm = {
+            enable = true;
+            package = inputs.wezterm.packages.${pkgs.system}.default;
+        };
+    }
+    ```
+
+
+    ### Cachix
+
+    Successful builds of the nightly nix action are pushed to this binary cache.
+
+    ```nix
+    # nixosConfiguration module
+    {
+        nix.settings = {
+            substituters = ["https://wezterm.cachix.org"];
+            trusted-public-keys = ["wezterm.cachix.org-<UPDATE_WITH_PUBLIC_KEY>"];
+        };
+    }
+    ```
+    
 
 === "Raw"
     ## Raw Linux Binary

--- a/docs/install/linux.md
+++ b/docs/install/linux.md
@@ -366,7 +366,7 @@ hide:
     {
         nix.settings = {
             substituters = ["https://wezterm.cachix.org"];
-            trusted-public-keys = ["wezterm.cachix.org-<UPDATE_WITH_PUBLIC_KEY>"];
+            trusted-public-keys = ["wezterm.cachix.org-1:kAbhjYUC9qvblTE+s7S+kl5XM1zVa4skO+E/1IDWdH0="];
         };
     }
     ```


### PR DESCRIPTION
## Summary

I've created an action that does a scheduled build of WezTerm with the Nix flake, and pushes the outputs to a binary cache.

## The Problem

I find myself having to build WezTerm from source on occasion when Hyprland releases updates. The version of WezTerm currently in nixpkgs doesn't include various Hyprland/Wayland bugfixes because there hasn't been a release in a while.

## My Solution

We can push to a Cachix with a scheduled build of WezTerm using the flake. People can add this binary cache to their configurations to avoid building WezTerm from source if they're using the flake. There's a couple more things that need to be done before this action will work though.

- Setup [https://wezterm.cachix.org](https://wezterm.cachix.org) (This is a super quick process, and the login is just read email access for your GitHub account.)
- Generate an auth token for that cache and add it to WezTerm's repo secrets so it can be used in the GitHub action 
 
I've got a working version here https://github.com/thomascft/wezterm-nightly-flake/blob/main/flake.nix. The actions are a touch more complicated because I wanted nightly lockfile updates as well. 

Here are some examples of Cachix being used for other projects

- [Neovim](https://github.com/nix-community/neovim-nightly-overlay)
- [Firefox](https://github.com/nix-community/flake-firefox-nightly)
- [Hyprland](https://wiki.hyprland.org/Nix/Cachix/)

I've also added some basic install documentation for Nix/NixOS which can be improved on if you'd like.