### PR TITLE
Attempt to implement AccessKit inside the window crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 3
 
 [[package]]
+name = "accesskit"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4700bdc115b306d6c43381c344dc307f03b7f0460c304e4892c309930322bd7"
+
+[[package]]
 name = "addr2line"
 version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6721,6 +6727,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 name = "window"
 version = "0.1.0"
 dependencies = [
+ "accesskit",
  "anyhow",
  "async-channel",
  "async-io",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4700bdc115b306d6c43381c344dc307f03b7f0460c304e4892c309930322bd7"
 
 [[package]]
+name = "accesskit_consumer"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe3a07a32ab5837ad83db3230ac490c8504c2cd5b90ac8c00db6535f6ed65d0b"
+dependencies = [
+ "accesskit",
+ "immutable-chunkmap",
+]
+
+[[package]]
+name = "accesskit_windows"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "682d8c4fb425606f97408e7577793f32e96310b646fa77662eb4216293eddc7f"
+dependencies = [
+ "accesskit",
+ "accesskit_consumer",
+ "paste",
+ "static_assertions",
+ "windows 0.54.0",
+]
+
+[[package]]
 name = "addr2line"
 version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2486,6 +2509,15 @@ name = "imgref"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44feda355f4159a7c757171a77de25daf6411e217b4cabd03bd6650690468126"
+
+[[package]]
+name = "immutable-chunkmap"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4419f022e55cc63d5bbd6b44b71e1d226b9c9480a47824c706e9d54e5c40c5eb"
+dependencies = [
+ "arrayvec",
+]
 
 [[package]]
 name = "indexmap"
@@ -6728,6 +6760,7 @@ name = "window"
 version = "0.1.0"
 dependencies = [
  "accesskit",
+ "accesskit_windows",
  "anyhow",
  "async-channel",
  "async-io",
@@ -6833,6 +6866,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9252e5725dbed82865af151df558e754e4a3c2c30818359eb17465f1346a1b49"
+dependencies = [
+ "windows-core 0.54.0",
+ "windows-implement",
+ "windows-interface",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.51.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6846,6 +6891,47 @@ name = "windows-core"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12661b9c89351d684a50a8a643ce5f608e20243b9fb84687800163429f161d65"
+dependencies = [
+ "windows-result",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "942ac266be9249c84ca862f0a164a39533dc2f6f33dc98ec89c8da99b82ea0bd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.72",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da33557140a288fae4e1d5f8873aaf9eb6613a9cf82c3e070223ff177f598b60"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.72",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
 dependencies = [
  "windows-targets 0.52.6",
 ]

--- a/window/Cargo.toml
+++ b/window/Cargo.toml
@@ -18,6 +18,7 @@ gl_generator = "0.14"
 wayland = ["wayland-client", "smithay-client-toolkit", "wayland-egl", "wayland-protocols"]
 
 [dependencies]
+accesskit = "0.16"
 async-channel = "2.3"
 async-io = "2.3"
 async-task = "4.7"

--- a/window/Cargo.toml
+++ b/window/Cargo.toml
@@ -49,6 +49,7 @@ wezterm-font = { path = "../wezterm-font" }
 wezterm-input-types = { path = "../wezterm-input-types" }
 
 [target."cfg(windows)".dependencies]
+accesskit_windows = "0.22"
 clipboard-win = "2.2"
 shared_library = "0.1"
 winapi = { version = "0.3", features = [

--- a/window/src/lib.rs
+++ b/window/src/lib.rs
@@ -1,3 +1,4 @@
+use accesskit::{ActionRequest, TreeUpdate};
 use async_trait::async_trait;
 use bitflags::bitflags;
 use config::window::WindowLevel;
@@ -216,6 +217,10 @@ pub enum WindowEvent {
     PerformKeyAssignment(config::keyassignment::KeyAssignment),
 
     AdviseModifiersLedStatus(Modifiers, KeyboardLedStatus),
+
+    InitialAccessKitTreeRequested,
+    AccessKitActionRequested(ActionRequest),
+    AccessibilityDeactivated,
 }
 
 pub struct WindowEventSender {
@@ -348,6 +353,12 @@ pub trait WindowOps {
         _window_state: WindowState,
     ) -> anyhow::Result<Option<os::parameters::Parameters>> {
         Ok(None)
+    }
+
+    fn update_accesskit_if_active(
+        &self,
+        _update_factory: impl FnOnce() -> TreeUpdate + Send + 'static,
+    ) {
     }
 }
 


### PR DESCRIPTION
As the PR title suggests, this is neither fully working nor complete. I think it can be a starting point nonetheless.

Relates to #913 

## Current status

The `async` example is working correctly on Windows. I tested it on Windows 11 with NVDA and Narrator (two free assistive technologies).

## Issues encountered

- The `WindowEventSender` cannot be shared so when accessibility-related events come from the system, I had to place a message into the window loop so the event could be dispatched to the app later. Although not elegant, this approach can work on Windows, and probably on X11 as well, but I think there would be no way to replicate it under Wayland. I haven't really checked on macOS.
- There is no way for the app to respond to a `WindowEvent`: when accessibility is first requested, I had to instruct AccessKit to generate a placeholder accessibility tree, until I can push the real one later. Another option would be to have a dedicated callback on `Window` to build the initial accessibility tree, but then the entire app state must be shared.
- `WindowOp::update_accesskit_if_active` cannot take the app state in its closure because its signature impose new restrictions that clashes with, for instance, the `glium::Context` in the `async` example. This also mean that the `WindowOp` trait is not object safe anymore, which will be an issue with the real wezterm app.

Overall, adding accessibility support to the windowing crate of wezterm would first require some architectural changes. I hope that this proof of concept can help shape the future of a nice, accessible, terminal emulator.