### PR TITLE
Validate scrollback_lines to avoid crashes

### DIFF
--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -185,7 +185,10 @@ pub struct Config {
     pub color_schemes: HashMap<String, Palette>,
 
     /// How many lines of scrollback you want to retain
-    #[dynamic(default = "default_scrollback_lines")]
+    #[dynamic(
+        default = "default_scrollback_lines",
+        validate = "validate_scrollback_lines"
+    )]
     pub scrollback_lines: usize,
 
     /// If no `prog` is specified on the command line, use this
@@ -1636,6 +1639,17 @@ fn default_swap_backspace_and_delete() -> bool {
 
 fn default_scrollback_lines() -> usize {
     3500
+}
+
+const MAX_SCROLLBACK_LINES: usize = 999_999_999;
+fn validate_scrollback_lines(value: &usize) -> Result<(), String> {
+    if *value > MAX_SCROLLBACK_LINES {
+        Err(format!(
+            "Illegal value {value} for scrollback_size; it must be <= {MAX_SCROLLBACK_LINES}!"
+        ))
+    } else {
+        Ok(())
+    }
 }
 
 fn default_initial_rows() -> u16 {

--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -1644,12 +1644,11 @@ fn default_scrollback_lines() -> usize {
 const MAX_SCROLLBACK_LINES: usize = 999_999_999;
 fn validate_scrollback_lines(value: &usize) -> Result<(), String> {
     if *value > MAX_SCROLLBACK_LINES {
-        Err(format!(
+        return Err(format!(
             "Illegal value {value} for scrollback_size; it must be <= {MAX_SCROLLBACK_LINES}!"
-        ))
-    } else {
-        Ok(())
+        ));
     }
+    Ok(())
 }
 
 fn default_initial_rows() -> u16 {


### PR DESCRIPTION
I started using wezterm today, and I immediately tried to configure it to use "infinite scrollback", as I use in iTerm2. From the configuration I couldn't tell if there was a way to do this, so I just set it to a really large number, hoping that would work. Interestingly this works for very large numbers when the config is just being reloaded while the terminal is running, but if you then try to restart the application it crashes (tried to allocate like 100PB or something).

I then came across #1342 and thought "that's seems a bit too involved", and decided that I probably don't need infinite scrollback, but just kind of a large number. Through fair dice roll I determined `one billion - 1` will probably suffice.

Now, this might not be the best solution, so I'm happy to get some feedback. I was also thinking that it would be nice if one could just set it to `0`, and then the applicatio determines a suitably large number for the amount of RAM available, but a) I wasn't sure how this would be best implemented in the confines of the current architecture, and b) I wasn't sure if it would be well received.

Long story short, happy to hear your feedback.

PS: I'm happy to add documentation, etc. as needed, just wanted to get some feedback first before I invest that time 🙂 