### PR TITLE
shell integration: check for saved PS1 value before using it

### DIFF
--- a/assets/shell-integration/wezterm.sh
+++ b/assets/shell-integration/wezterm.sh
@@ -486,9 +486,12 @@ __wezterm_semantic_precmd() {
 }
 
 function __wezterm_semantic_preexec() {
-  # Restore the original PS1/PS2
-  PS1="$__wezterm_save_ps1"
-  PS2="$__wezterm_save_ps2"
+  # Restore the original PS1/PS2 if set
+  if [ -n "${__wezterm_save_ps1+1}" ]; then
+	  PS1=$__wezterm_save_ps1"
+	  PS2="$__wezterm_save_ps2"
+	  unset __wezterm_save_ps1
+  fi
   # Indicate that the command output begins here
   printf "\033]133;C;\007"
   __wezterm_semantic_precmd_executing=1


### PR DESCRIPTION
On bash it's possible to hit ^C before we remembered the PS1 which would cause the shell to end up with an empty PS1, making it unclear that the ^C actually worked as there is no prompt left.

I'm not sure I understand the need to mess with the variable every time (could just add the OSC codes if not already present and never remove them?), but at least make it so we don't end up with an empty prompt line by checking the saved value isn't empty.

-----

This bit me after I installed the debian package and took me a while to understand what happened.

As written in commit message I think this could be a one-way operation, e.g. something like this (untested) could just always set prompt somewhere and be noop if it's correct:
```
osc_prefix='\[\e]133;P;k=i\a\]' # or zsh variant
osc_suffix='\[\e]133;B\a\]'
case "$PS1" in
"$osc_prefix"*"$osc_suffix")
    # already set
    ;;
*)
    # remove any oddly placed markups
    PS1="${PS1//$osc_prefix/}"
    PS1="${PS1//$osc_suffix/}"
    PS1="$osc_prefix$PS1$osc_suffix"
    ;;
esac
```

but for now just not reverting an empty value would be great, so going for the smaller change.

Let me know if you something needs adjusting.