### PR TITLE
#5518: handling panic in copy_and_paste.rs line 105

### DIFF
--- a/window/src/os/wayland/copy_and_paste.rs
+++ b/window/src/os/wayland/copy_and_paste.rs
@@ -106,9 +106,6 @@ impl WaylandState {
         let active_surface_id = active_surface_id.as_ref()?;
         let pending = self.surface_to_pending.get(&active_surface_id)?;
         Some(Arc::clone(&pending.lock().unwrap().copy_and_paste))
-        } else {
-            None
-        }
     }
 }
 

--- a/window/src/os/wayland/copy_and_paste.rs
+++ b/window/src/os/wayland/copy_and_paste.rs
@@ -102,7 +102,6 @@ impl CopyAndPaste {
 impl WaylandState {
     pub(super) fn resolve_copy_and_paste(&mut self) -> Option<Arc<Mutex<CopyAndPaste>>> {
         let active_surface_id = self.active_surface_id.borrow();
-        let active_surface_id = self.active_surface_id.borrow();
         let active_surface_id = active_surface_id.as_ref()?;
         let pending = self.surface_to_pending.get(&active_surface_id)?;
         Some(Arc::clone(&pending.lock().unwrap().copy_and_paste))

--- a/window/src/os/wayland/copy_and_paste.rs
+++ b/window/src/os/wayland/copy_and_paste.rs
@@ -102,9 +102,12 @@ impl CopyAndPaste {
 impl WaylandState {
     pub(super) fn resolve_copy_and_paste(&mut self) -> Option<Arc<Mutex<CopyAndPaste>>> {
         let active_surface_id = self.active_surface_id.borrow();
-        let active_surface_id = active_surface_id.as_ref().unwrap();
-        if let Some(pending) = self.surface_to_pending.get(&active_surface_id) {
-            Some(Arc::clone(&pending.lock().unwrap().copy_and_paste))
+        if let Some(active_surface_id) = active_surface_id.as_ref() {
+            if let Some(pending) = self.surface_to_pending.get(&active_surface_id) {
+                Some(Arc::clone(&pending.lock().unwrap().copy_and_paste))
+            } else {
+                None
+            }
         } else {
             None
         }

--- a/window/src/os/wayland/copy_and_paste.rs
+++ b/window/src/os/wayland/copy_and_paste.rs
@@ -102,12 +102,10 @@ impl CopyAndPaste {
 impl WaylandState {
     pub(super) fn resolve_copy_and_paste(&mut self) -> Option<Arc<Mutex<CopyAndPaste>>> {
         let active_surface_id = self.active_surface_id.borrow();
-        if let Some(active_surface_id) = active_surface_id.as_ref() {
-            if let Some(pending) = self.surface_to_pending.get(&active_surface_id) {
-                Some(Arc::clone(&pending.lock().unwrap().copy_and_paste))
-            } else {
-                None
-            }
+        let active_surface_id = self.active_surface_id.borrow();
+        let active_surface_id = active_surface_id.as_ref()?;
+        let pending = self.surface_to_pending.get(&active_surface_id)?;
+        Some(Arc::clone(&pending.lock().unwrap().copy_and_paste))
         } else {
             None
         }


### PR DESCRIPTION
Handling panic error. 
The function returns `None` when there is no pending surface.
The PR handles panic when there is no `active surface` instead panic.