### PR TITLE
feat: add a way to spawn populated LineEditor

### DIFF
--- a/config/src/keyassignment.rs
+++ b/config/src/keyassignment.rs
@@ -459,7 +459,7 @@ pub struct PromptInputLine {
     pub action: Box<KeyAssignment>,
     /// Optional label to pre-fill the input line with
     #[dynamic(default)]
-    pub with_content: String,
+    pub initial_value: Option<String>,
     /// Descriptive text to show ahead of prompt
     #[dynamic(default)]
     pub description: String,

--- a/config/src/keyassignment.rs
+++ b/config/src/keyassignment.rs
@@ -457,6 +457,9 @@ pub struct QuickSelectArguments {
 #[derive(Debug, Clone, PartialEq, FromDynamic, ToDynamic)]
 pub struct PromptInputLine {
     pub action: Box<KeyAssignment>,
+    /// Optional label to pre-fill the input line with
+    #[dynamic(default)]
+    pub with_content: String,
     /// Descriptive text to show ahead of prompt
     #[dynamic(default)]
     pub description: String,

--- a/docs/config/lua/keyassignment/PromptInputLine.md
+++ b/docs/config/lua/keyassignment/PromptInputLine.md
@@ -20,7 +20,7 @@ upon the input.
   anything, or CTRL-C to cancel the input.
 * `prompt` - the text to show as the prompt. You may embed escape sequences
   and/or use [wezterm.format](../wezterm/format.md).  Defaults to: `"> "`. {{since('nightly', inline=True)}}
-* `with_content` - optional.  If provided, the initial content of the input
+* `initial_value` - optional.  If provided, the initial content of the input
   field will be set to this value.  The user may edit it prior to submitting
   the input.
 
@@ -37,7 +37,7 @@ config.keys = {
     mods = 'CTRL|SHIFT',
     action = act.PromptInputLine {
       description = 'Enter new name for tab',
-      with_content = 'Tab: ',
+      initial_value = 'My Tab Name',
       action = wezterm.action_callback(function(window, pane, line)
         -- line will be `nil` if they hit escape without entering anything
         -- An empty string if they just hit enter

--- a/docs/config/lua/keyassignment/PromptInputLine.md
+++ b/docs/config/lua/keyassignment/PromptInputLine.md
@@ -8,7 +8,7 @@ from the user.
 When the user enters the line, emits an event that allows you to act
 upon the input.
 
-`PromptInputLine` accepts three fields:
+`PromptInputLine` accepts four fields:
 
 * `description` - the text to show at the top of the display area. You may
   embed escape sequences and/or use [wezterm.format](../wezterm/format.md).
@@ -20,6 +20,9 @@ upon the input.
   anything, or CTRL-C to cancel the input.
 * `prompt` - the text to show as the prompt. You may embed escape sequences
   and/or use [wezterm.format](../wezterm/format.md).  Defaults to: `"> "`. {{since('nightly', inline=True)}}
+* `with_content` - optional.  If provided, the initial content of the input
+  field will be set to this value.  The user may edit it prior to submitting
+  the input.
 
 ## Example of interactively renaming the current tab
 
@@ -34,6 +37,7 @@ config.keys = {
     mods = 'CTRL|SHIFT',
     action = act.PromptInputLine {
       description = 'Enter new name for tab',
+      with_content = 'Tab: ',
       action = wezterm.action_callback(function(window, pane, line)
         -- line will be `nil` if they hit escape without entering anything
         -- An empty string if they just hit enter

--- a/docs/config/lua/window-events/augment-command-palette.md
+++ b/docs/config/lua/window-events/augment-command-palette.md
@@ -39,6 +39,7 @@ wezterm.on('augment-command-palette', function(window, pane)
 
       action = act.PromptInputLine {
         description = 'Enter new name for tab',
+        with_content = 'Tab: ',
         action = wezterm.action_callback(function(window, pane, line)
           if line then
             window:active_tab():set_title(line)

--- a/docs/config/lua/window-events/augment-command-palette.md
+++ b/docs/config/lua/window-events/augment-command-palette.md
@@ -39,7 +39,7 @@ wezterm.on('augment-command-palette', function(window, pane)
 
       action = act.PromptInputLine {
         description = 'Enter new name for tab',
-        with_content = 'Tab: ',
+        initial_value = 'My Tab Name',
         action = wezterm.action_callback(function(window, pane, line)
           if line then
             window:active_tab():set_title(line)

--- a/termwiz/src/lineedit/mod.rs
+++ b/termwiz/src/lineedit/mod.rs
@@ -163,12 +163,6 @@ impl<'term> LineEditor<'term> {
         }
     }
 
-    pub fn with_text(terminal: &'term mut dyn Terminal, default: &str) -> Self {
-        let mut editor = Self::new(terminal);
-        editor.line.insert_text(default);
-        return editor;
-    }
-
     fn render(&mut self, host: &mut dyn LineEditorHost) -> Result<()> {
         let screen_size = self.terminal.get_screen_size()?;
 

--- a/termwiz/src/lineedit/mod.rs
+++ b/termwiz/src/lineedit/mod.rs
@@ -163,6 +163,12 @@ impl<'term> LineEditor<'term> {
         }
     }
 
+    pub fn with_text(terminal: &'term mut dyn Terminal, default: &str) -> Self {
+        let mut editor = Self::new(terminal);
+        editor.line.insert_text(default);
+        return editor;
+    }
+
     fn render(&mut self, host: &mut dyn LineEditorHost) -> Result<()> {
         let screen_size = self.terminal.get_screen_size()?;
 
@@ -811,7 +817,6 @@ impl<'term> LineEditor<'term> {
     }
 
     fn read_line_impl(&mut self, host: &mut dyn LineEditorHost) -> Result<Option<String>> {
-        self.line.clear();
         self.history_pos = None;
         self.bottom_line = None;
         self.clear_completion();

--- a/wezterm-gui/src/overlay/prompt.rs
+++ b/wezterm-gui/src/overlay/prompt.rs
@@ -68,6 +68,9 @@ pub fn show_line_prompt_overlay(
     let mut host = PromptHost::new();
     let mut editor = LineEditor::new(&mut term);
     editor.set_prompt(&args.prompt);
+    if let Some(value) = &args.initial_value {
+        editor.set_line_and_cursor(value, value.len());
+    }
     let line = editor.read_line(&mut host)?;
 
     promise::spawn::spawn_into_main_thread(async move {


### PR DESCRIPTION
Closes #6002

Adds a new constructor for `LineEditor`, that allows to specify text to pre-populate the input.
Also removes a call to line.clear() in a method to initiate editing, as it is currently only ever called after editor struct had been newly spawned.