### PR TITLE
nix: output WezTerm.app on Mac

### DIFF
--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -127,6 +127,13 @@
             --add-needed "${pkgs.libGL}/lib/libEGL.so.1" \
             --add-needed "${pkgs.vulkan-loader}/lib/libvulkan.so.1" \
             $out/bin/wezterm-gui
+        '' + lib.optionalString stdenv.isDarwin ''
+            mkdir -p "$out/Applications"
+            OUT_APP="$out/Applications/WezTerm.app"
+            cp -r assets/macos/WezTerm.app "$OUT_APP"
+            rm $OUT_APP/*.dylib
+            cp -r assets/shell-integration/* "$OUT_APP"
+            ln -s $out/bin/{wezterm,wezterm-mux-server,wezterm-gui,strip-ansi-escapes} "$OUT_APP"
         '';
 
         postInstall = ''


### PR DESCRIPTION
currently only the binaries are output. Build and output the .app dir so that users can launch the app as-normal on Mac

Added code is taken from [nixos](https://github.com/NixOS/nixpkgs/blob/nixos-unstable/pkgs/applications/terminal-emulators/wezterm/default.nix#L116-L123) where it seems to be working fine. Confirmed working on my system.