### PR TITLE
Custom prompt for PromptInputLine

### DIFF
--- a/config/src/keyassignment.rs
+++ b/config/src/keyassignment.rs
@@ -460,6 +460,13 @@ pub struct PromptInputLine {
     /// Descriptive text to show ahead of prompt
     #[dynamic(default)]
     pub description: String,
+    /// Text to show for prompt
+    #[dynamic(default = "default_prompt")]
+    pub prompt: String,
+}
+
+fn default_prompt() -> String {
+    "> ".to_string()
 }
 
 #[derive(Debug, Clone, PartialEq, FromDynamic, ToDynamic)]

--- a/docs/config/lua/keyassignment/PromptInputLine.md
+++ b/docs/config/lua/keyassignment/PromptInputLine.md
@@ -19,7 +19,7 @@ upon the input.
   user entered. `line` may be `nil` if they hit Escape without entering
   anything, or CTRL-C to cancel the input.
 * `prompt` - the text to show as the prompt. You may embed escape sequences
-  and/or use [wezterm.format](../wezterm/format.md).  Defaults to: `"> "`
+  and/or use [wezterm.format](../wezterm/format.md).  Defaults to: `"> "`. {{since('nightly', inline=True)}}
 
 ## Example of interactively renaming the current tab
 

--- a/docs/config/lua/keyassignment/PromptInputLine.md
+++ b/docs/config/lua/keyassignment/PromptInputLine.md
@@ -8,7 +8,7 @@ from the user.
 When the user enters the line, emits an event that allows you to act
 upon the input.
 
-`PromptInputLine` accepts two fields:
+`PromptInputLine` accepts three fields:
 
 * `description` - the text to show at the top of the display area. You may
   embed escape sequences and/or use [wezterm.format](../wezterm/format.md).
@@ -18,6 +18,8 @@ upon the input.
   objects from the current pane and window, and `line` is the text that the
   user entered. `line` may be `nil` if they hit Escape without entering
   anything, or CTRL-C to cancel the input.
+* `prompt` - the text to show as the prompt. You may embed escape sequences
+  and/or use [wezterm.format](../wezterm/format.md).  Defaults to: `"> "`
 
 ## Example of interactively renaming the current tab
 

--- a/wezterm-gui/src/overlay/prompt.rs
+++ b/wezterm-gui/src/overlay/prompt.rs
@@ -67,7 +67,7 @@ pub fn show_line_prompt_overlay(
 
     let mut host = PromptHost::new();
     let mut editor = LineEditor::new(&mut term);
-    editor.set_prompt("> ");
+    editor.set_prompt(&args.prompt);
     let line = editor.read_line(&mut host)?;
 
     promise::spawn::spawn_into_main_thread(async move {


### PR DESCRIPTION
Hello @wez 

This change introduces an additional optional parameter to set the prompt in the PromptInputLine. If not passed, the default value of "> " is used.

I'm pretty new to rust, and not sure what test cases to add/modify for these.

Please suggest improvements if any