### PR TITLE
Handle non-sRGB displays on macOS

### DIFF
--- a/window/src/os/macos/window.rs
+++ b/window/src/os/macos/window.rs
@@ -525,6 +525,10 @@ impl Window {
             window.setReleasedWhenClosed_(NO);
             window.setBackgroundColor_(cocoa::appkit::NSColor::clearColor(nil));
 
+            // Tell Cocoa that we output in sRGB, so it handles color space
+            // conversion for non-sRGB displays.
+            window.setColorSpace_(cocoa::appkit::NSColorSpace::sRGBColorSpace(nil));
+
             // We could set this, but it makes the entire window, including
             // its titlebar, opaque to this fixed degree.
             // window.setAlphaValue_(0.4);


### PR DESCRIPTION
Fixes https://github.com/wez/wezterm/issues/5824

Explicitly set the window's color space to sRGB, as the OpenGL output is always in sRGB.

If you don't set a color space on the NSWindow, macOS appears use the current display's color space by default. This causes colors to render incorrectly on non-sRGB displays (like the built-in LCD on some Macs).

I've tested this change on both the built-in LCD and an external sRGB monitor, and the colors now render the same as Safari:
<img width="785" src="https://github.com/user-attachments/assets/524190ae-3aec-459f-a480-3760673dc1fc">