### PR TITLE
fix: docs typos

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -996,7 +996,7 @@ As features stabilize some brief notes about them will accumulate here.
   reduces the render latency due to decoding frames; animations now render as
   soon as the first frame is decoded.
   [#3263](https://github.com/wez/wezterm/issues/3263)
-* Improved compatiblity with the Kitty Image Protocol
+* Improved compatibility with the Kitty Image Protocol
   [#2716](https://github.com/wez/wezterm/issues/2716)
 * [wezterm.time.call_after](config/lua/wezterm.time/call_after.md) would not
   work when used in an event callback.
@@ -1349,7 +1349,7 @@ As features stabilize some brief notes about them will accumulate here.
 * Mux: `wezterm.mux.set_active_workspace` didn't update the current window to match the newly activated workspace. [#2248](https://github.com/wez/wezterm/issues/2248)
 * Overlays such as debug and launcher menu now handle resize better
 * Shift-F1 through F4 generated different encoding than xterm [#2263](https://github.com/wez/wezterm/issues/2263)
-* X11/Wayland: apps that extract the `Exec` field from wezterm.desktop (such as thunar, Dolphin and others) can now simply concatenate the command line they want to invoke, and it will spawn in the their current working directory. Thanks to [@Anomalocaridid](https://github.com/Anomalocaridid)! [#2271](https://github.com/wez/wezterm/pull/2271) [#2103](https://github.com/wez/wezterm/issues/2103) 
+* X11/Wayland: apps that extract the `Exec` field from wezterm.desktop (such as thunar, Dolphin and others) can now simply concatenate the command line they want to invoke, and it will spawn in the their current working directory. Thanks to [@Anomalocaridid](https://github.com/Anomalocaridid)! [#2271](https://github.com/wez/wezterm/pull/2271) [#2103](https://github.com/wez/wezterm/issues/2103)
 * [gui-startup](config/lua/gui-events/gui-startup.md) now passes a [SpawnCommand](config/lua/SpawnCommand.md) parameter representing the `wezterm start` command arguments.
 * Tab `x` button is no longer obscured by tab title text for long tab titles [#2269](https://github.com/wez/wezterm/issues/2269)
 * Cursor position could end up in the wrong place when rewrapping lines and the cursor was on the rewrap boundary [#2162](https://github.com/wez/wezterm/issues/2162)
@@ -1388,7 +1388,7 @@ As features stabilize some brief notes about them will accumulate here.
 * Search Mode: the default `CTRL-SHIFT-F` key assignment now defaults to the new `CurrentSelectionOrEmptyString` mode to search for the current selection text, if any.  See [Search](config/lua/keyassignment/Search.md) for more info.
 * Copy Mode and Search Mode can be toggled and remember search results and cursor positioning, making it easier to locate and select text without using the mouse [#1592](https://github.com/wez/wezterm/issues/1592)
 * In the Launcher Menu, you may now use `CTRL-G` to cancel/exit the launcher [#1977](https://github.com/wez/wezterm/issues/1977)
-* [cell_width](config/lua/config/cell_width.md) option to adjust the horizontal spacing when the availble font stretches are insufficient. [#1979](https://github.com/wez/wezterm/issues/1979)
+* [cell_width](config/lua/config/cell_width.md) option to adjust the horizontal spacing when the available font stretches are insufficient. [#1979](https://github.com/wez/wezterm/issues/1979)
 * [min_scroll_bar_height](config/lua/config/min_scroll_bar_height.md) to control the minimum size of the scroll bar thumb [#1936](https://github.com/wez/wezterm/issues/1936)
 * [RotatePanes](config/lua/keyassignment/RotatePanes.md) key assignment for re-arranging the panes in a tab
 * [SplitPane](config/lua/keyassignment/SplitPane.md) key assignment that allows specifying the size and location of the split, as well as top-level (full width/height) splits. `wezterm cli split-pane --help` shows equivalent options you can use from the cli. [#578](https://github.com/wez/wezterm/issues/578)
@@ -1480,7 +1480,7 @@ As features stabilize some brief notes about them will accumulate here.
 * X11: workaround i3-gaps not sending initial CONFIGURE_NOTIFY or FOCUS events, leading to weird initial window size and broken focus status. [#1710](https://github.com/wez/wezterm/issues/1710) [#1757](https://github.com/wez/wezterm/issues/1757)
 * Hyperlink rules with more captures than replacements could panic wezterm when text matched. [#1780](https://github.com/wez/wezterm/issues/1780)
 * Malformed XTGETTCAP response. [#1781](https://github.com/wez/wezterm/issues/1781)
-* Multiplexer performance with images was unusuable for all but tiny images. [#1237](https://github.com/wez/wezterm/issues/1237)
+* Multiplexer performance with images was unusable for all but tiny images. [#1237](https://github.com/wez/wezterm/issues/1237)
 * `CloseCurrentPane{confirm=false}` would leave behind a phantom tab/pane when used with the multiplexer. [#1277](https://github.com/wez/wezterm/issues/1277)
 * `CloseCurrentPane{confirm=true}` artifacts when used with the multiplexer. [#783](https://github.com/wez/wezterm/issues/783)
 * Scrollbar thumb could jump around/move out of bounds. Thanks to [@davidrios](https://github.com/davidrios)! [#1525](https://github.com/wez/wezterm/issues/1525)
@@ -1575,7 +1575,7 @@ As features stabilize some brief notes about them will accumulate here.
 * [harfbuzz_features](config/font-shaping.md), [freetype_load_target](config/lua/config/freetype_load_target.md), [freetype_render_target](config/lua/config/freetype_render_target.md) and [freetype_load_flags](config/lua/config/freetype_load_flags.md) can now be overridden on a per-font basis as described in [wezterm.font](config/lua/wezterm/font.md) and [wezterm.font_with_fallback](config/lua/wezterm/font_with_fallback.md).
 * [ActivateTabRelativeNoWrap](config/lua/keyassignment/ActivateTabRelativeNoWrap.md) key assignment [#1414](https://github.com/wez/wezterm/issues/1414)
 * [QuickSelectArgs](config/lua/keyassignment/QuickSelectArgs.md) key assignment [#846](https://github.com/wez/wezterm/issues/846) [#1362](https://github.com/wez/wezterm/issues/1362)
-* [wezterm.open_wth](config/lua/wezterm/open_with.md) function for opening URLs/documents with the default or a specific application [#1362](https://github.com/wez/wezterm/issues/1362)
+* [wezterm.open_with](config/lua/wezterm/open_with.md) function for opening URLs/documents with the default or a specific application [#1362](https://github.com/wez/wezterm/issues/1362)
 * [pane:get_foreground_process_name()](config/lua/pane/get_foreground_process_name.md) method, [PaneInformation](config/lua/PaneInformation.md) now has `foreground_process_name` and `current_working_dir` fields, and [pane:get_current_working_dir](config/lua/pane/get_current_working_dir.md) is now supported on Windows for local processes, even without using OSC 7. [#1421](https://github.com/wez/wezterm/discussions/1421) [#915](https://github.com/wez/wezterm/issues/915) [#876](https://github.com/wez/wezterm/issues/876)
 * [ActivatePaneDirection](config/lua/keyassignment/ActivatePaneDirection.md) now also supports `"Next"` and `"Prev"` to cycle through panes [#976](https://github.com/wez/wezterm/issues/976)
 * [pane:get_logical_lines_as_text](config/lua/pane/get_logical_lines_as_text.md) to retrieve unwrapped logical lines from a pane [#1468](https://github.com/wez/wezterm/issues/1468)
@@ -1880,7 +1880,7 @@ As features stabilize some brief notes about them will accumulate here.
 
 ### 20210314-114017-04b7cedd
 
-* New: [tab_bar_style](config/lua/config/tab_bar_style.md) allows customizing the appearance of the rest of tha tab bar.
+* New: [tab_bar_style](config/lua/config/tab_bar_style.md) allows customizing the appearance of the rest of the tab bar.
 * New: animated gif and png images displayed via `wezterm imgcat` (the iTerm2 image protocol), or attached to the window background via [window_background_image](config/appearance.md#window-background-image) will now animate while the window has focus.
 * New: added [foreground_text_hsb](config/lua/config/foreground_text_hsb.md) setting to adjust hue, saturation and brightness when text is rendered.
 * New: added [ResetFontAndWindowSize](config/lua/keyassignment/ResetFontAndWindowSize.md) key assignment.
@@ -1897,7 +1897,7 @@ As features stabilize some brief notes about them will accumulate here.
 * New: [window:set_right_status](config/lua/window/set_right_status.md) allows setting additional status information in the tab bar. [#500](https://github.com/wez/wezterm/issues/500)
 * New: Search Mode: Added `CTRL-u` key assignment to clear the current search pattern. Thanks to [@bew](https://github.com/bew)! [#465](https://github.com/wez/wezterm/pull/465)
 * Fonts: `font_antialias` and `font_hinting` are now deprecated in favor of the new [freetype_load_target](config/lua/config/freetype_load_target.md) and [freetype_load_flags](config/lua/config/freetype_load_flags.md) options.  The deprecated options have no effect and will be removed in a future release.  The new options provide more direct control over how freetype rasterizes text.
-* Fonts: when computing default `font_rules` for bold and italic fonts, strip italic and bold components from the family name. eg: if you set `font = wezterm.font("Source Code Pro Medium")` then the ` Medium` text will be stripped from the font name used to locate bold and italic variants so that we don't report an error loading a non-sensical `Source Code Pro Medium Bold`. [#456](https://github.com/wez/wezterm/issues/456)
+* Fonts: when computing default `font_rules` for bold and italic fonts, strip italic and bold components from the family name. eg: if you set `font = wezterm.font("Source Code Pro Medium")` then the `Medium` text will be stripped from the font name used to locate bold and italic variants so that we don't report an error loading a non-sensical `Source Code Pro Medium Bold`. [#456](https://github.com/wez/wezterm/issues/456)
 * Fonts: fix a regression where bright windows behind wezterm could "shine through" on the alpha channel, and adjust the tinting operation to avoid anti-aliased dark fringes [#470](https://github.com/wez/wezterm/issues/470) [#491](https://github.com/wez/wezterm/issues/491)
 * Fonts: macOS: fix an issue where wezterm could hang when loading a font located via Core Text [#475](https://github.com/wez/wezterm/issues/475)
 * Fonts: Changed the default [font_size](config/lua/config/font_size.md) to 12 points. [#517](https://github.com/wez/wezterm/discussions/517)

--- a/docs/config/appearance.md
+++ b/docs/config/appearance.md
@@ -410,7 +410,7 @@ To make it easier to see which pane is active, the inactive panes are dimmed
 and de-saturated slightly.
 
 You can specify your own transformation to the pane colors with a hue,
-saturation, brightness (HSB) multipler.
+saturation, brightness (HSB) multiplier.
 
 In this example, inactive panes will be slightly de-saturated and dimmed;
 this is the default configuration:
@@ -482,7 +482,7 @@ config.window_background_image_hsb = {
 ```
 
 See [Styling Inactive Panes](#styling-inactive-panes) for more information
-on hue, saturation, brigthness transformations.
+on hue, saturation, brightness transformations.
 
 If you'd like to have control over scaling, tiling/repeating, scrolling
 behavior and more, take a look at the more powerful

--- a/docs/config/lua/MuxTab/panes_with_info.md
+++ b/docs/config/lua/MuxTab/panes_with_info.md
@@ -8,7 +8,7 @@ contained by this tab.
 Each element is a lua table with the following fields:
 
 * `index` - the topological pane index
-* `is_active` - a boolean indicating whether this is the active pane withing the tab
+* `is_active` - a boolean indicating whether this is the active pane within the tab
 * `is_zoomed` - a boolean indicating whether this pane is zoomed
 * `left` - The offset from the top left corner of the containing tab to the top left corner of this pane, in cells.
 * `top` - The offset from the top left corner of the containing tab to the top left corner of this pane, in cells.
@@ -17,5 +17,3 @@ Each element is a lua table with the following fields:
 * `pixel_width` - The width of this pane in pixels
 * `pixel_height` - The height of this pane in pixels
 * `pane` - The [Pane](../pane/index.md) object
-
-

--- a/docs/config/lua/config/background.md
+++ b/docs/config/lua/config/background.md
@@ -59,7 +59,7 @@ A layer is a lua table with the following fields:
     * `"Right"`
 * `horizontal_offset` - like `vertical_offset` but applies to the x-direction.
 * `opacity` - a number in the range `0` through `1.0` inclusive that is multiplied with the alpha channel of the source to adjust the opacity of the layer. The default is `1.0` to use the source alpha channel as-is. Using a smaller value makes the layer less opaque/more transparent.
-* `hsb` - a hue, saturation, brightness tranformation that can be used to adjust those attributes of the layer. See [foreground_text_hsb](foreground_text_hsb.md) for more information about this kind of transform.
+* `hsb` - a hue, saturation, brightness transformation that can be used to adjust those attributes of the layer. See [foreground_text_hsb](foreground_text_hsb.md) for more information about this kind of transform.
 * `height` - controls the height of the image. The following values are accepted:
     * `"Cover"` (this is the default) - Scales the image, preserving aspect ratio, to the smallest possible size to fill the viewport, leaving no empty space.  If the aspect ratio of the viewport differs from the image, the image is cropped.
     * `"Contain"` - Scales the image as large as possible without cropping or stretching. If the viewport is larger than the image, tiles the image unless `repeat_y` is set to `"NoRepeat"`.

--- a/docs/config/lua/config/freetype_load_flags.md
+++ b/docs/config/lua/config/freetype_load_flags.md
@@ -19,9 +19,9 @@ Available flags are:
   anti-aliased modes, but that was written for rasterizing direct to bitmaps.
   In the context of wezterm where we are rasterizing to a texture that is then
   sampled and applied to a framebuffer through vertices on the GPU, the hinting
+  process can be counter-productive and result in unexpected visual artifacts.
 * `NO_BITMAP` - don't load any pre-rendered bitmap strikes
 * `FORCE_AUTOHINT` - Use the freetype auto-hinter rather than the font's
-  process can be counter-productive and result in unexpected visual artifacts.
   native hinter.
 * `MONOCHROME` - instructs renderer to use 1-bit monochrome rendering.
   This option doesn't impact the hinter.

--- a/docs/config/lua/config/freetype_load_flags.md
+++ b/docs/config/lua/config/freetype_load_flags.md
@@ -19,9 +19,9 @@ Available flags are:
   anti-aliased modes, but that was written for rasterizing direct to bitmaps.
   In the context of wezterm where we are rasterizing to a texture that is then
   sampled and applied to a framebuffer through vertices on the GPU, the hinting
-  process can be counter-productive and result in unexpect visual artifacts.
 * `NO_BITMAP` - don't load any pre-rendered bitmap strikes
 * `FORCE_AUTOHINT` - Use the freetype auto-hinter rather than the font's
+  process can be counter-productive and result in unexpected visual artifacts.
   native hinter.
 * `MONOCHROME` - instructs renderer to use 1-bit monochrome rendering.
   This option doesn't impact the hinter.

--- a/docs/config/lua/config/ime_preedit_rendering.md
+++ b/docs/config/lua/config/ime_preedit_rendering.md
@@ -27,7 +27,7 @@ WezTerm supports the following IME preedit rendering.
   to avoid the truncated displaying of IME preedit
   but has a worse look and feel compared to "Builtin" rendering.
 
-You can control IME preedit rendering in your configuraiton file:
+You can control IME preedit rendering in your configuration file:
 
 ```lua
 config.ime_preedit_rendering = 'System'

--- a/docs/config/lua/config/window_background_gradient.md
+++ b/docs/config/lua/config/window_background_gradient.md
@@ -91,7 +91,7 @@ that is moving from the top left corner down to the bottom right corner.
 ```lua
 config.window_background_gradient = {
   colors = { '#EEBD89', '#D13ABD' },
-  -- Specifices a Linear gradient starting in the top left corner.
+  -- Specifies a Linear gradient starting in the top left corner.
   orientation = { Linear = { angle = -45.0 } },
 }
 ```

--- a/docs/config/lua/gui-events/gui-startup.md
+++ b/docs/config/lua/gui-events/gui-startup.md
@@ -97,7 +97,7 @@ wezterm.on('gui-startup', function(cmd)
   build_pane:send_text 'cargo build\n'
 
   -- A workspace for interacting with a local machine that
-  -- runs some docker containners for home automation
+  -- runs some docker containers for home automation
   local tab, pane, window = mux.spawn_window {
     workspace = 'automation',
     args = { 'ssh', 'vault' },
@@ -111,5 +111,6 @@ return config
 ```
 
 See also:
+
 * [wezterm.mux](../wezterm.mux/index.md)
 * [gui-attached](gui-attached.md).

--- a/docs/config/lua/keyassignment/InputSelector.md
+++ b/docs/config/lua/keyassignment/InputSelector.md
@@ -16,7 +16,7 @@ upon the input.
   The label will be shown in the list, while the id can be a different
   string that is meaningful to your action. The label can be used together
   with [wezterm.format](../wezterm/format.md) to produce styled test.
-* `action` - and event callback registerd via `wezterm.action_callback`.  The
+* `action` - and event callback registered via `wezterm.action_callback`.  The
   callback's function signature is `(window, pane, id, label)` where `window` and
   `pane` are the [Window](../window/index.md) and [Pane](../pane/index.md)
   objects from the current pane and window, and `id` and `label` hold the

--- a/docs/config/lua/keyassignment/PromptInputLine.md
+++ b/docs/config/lua/keyassignment/PromptInputLine.md
@@ -12,7 +12,7 @@ upon the input.
 
 * `description` - the text to show at the top of the display area. You may
   embed escape sequences and/or use [wezterm.format](../wezterm/format.md).
-* `action` - and event callback registerd via `wezterm.action_callback`.  The
+* `action` - and event callback registered via `wezterm.action_callback`.  The
   callback's function signature is `(window, pane, line)` where `window` and
   `pane` are the [Window](../window/index.md) and [Pane](../pane/index.md)
   objects from the current pane and window, and `line` is the text that the

--- a/docs/config/lua/wezterm/glob.md
+++ b/docs/config/lua/wezterm/glob.md
@@ -9,8 +9,8 @@ tags:
 
 {{since('20200503-171512-b13ef15f')}}
 
-absolute file names of the matching results.  Due to limitations in the lua
 This function evaluates the glob `pattern` and returns an array containing the
+absolute file names of the matching results.  Due to limitations in the lua
 bindings, all of the paths must be able to be represented as UTF-8 or this
 function will generate an error.
 

--- a/docs/config/lua/wezterm/glob.md
+++ b/docs/config/lua/wezterm/glob.md
@@ -9,8 +9,8 @@ tags:
 
 {{since('20200503-171512-b13ef15f')}}
 
-This function evalutes the glob `pattern` and returns an array containing the
 absolute file names of the matching results.  Due to limitations in the lua
+This function evaluates the glob `pattern` and returns an array containing the
 bindings, all of the paths must be able to be represented as UTF-8 or this
 function will generate an error.
 

--- a/docs/escape-sequences.md
+++ b/docs/escape-sequences.md
@@ -31,8 +31,8 @@ applied to the terminal display using the following rules:
 * If DEC line drawing mode is active, graphemes `j-n`, `q`, `t-x` are translated
   to equivalent line drawing graphemes and processing continues.
 * If prior output/actions require it, the cursor position may be moved to a new line
-* An appropriate number of cells, starting at the current cursor position,
   and the terminal display may be scrolled to make accommodate it.
+* An appropriate number of cells, starting at the current cursor position,
   are allocated based on the column width of the current grapheme and are assigned
   to the grapheme.  The current current graphics rendition state (such as colors
   and other presentation attributes) is also applied to those cells.

--- a/docs/escape-sequences.md
+++ b/docs/escape-sequences.md
@@ -31,8 +31,8 @@ applied to the terminal display using the following rules:
 * If DEC line drawing mode is active, graphemes `j-n`, `q`, `t-x` are translated
   to equivalent line drawing graphemes and processing continues.
 * If prior output/actions require it, the cursor position may be moved to a new line
-  and the terminal display may be scrolled to make accomodate it.
 * An appropriate number of cells, starting at the current cursor position,
+  and the terminal display may be scrolled to make accommodate it.
   are allocated based on the column width of the current grapheme and are assigned
   to the grapheme.  The current current graphics rendition state (such as colors
   and other presentation attributes) is also applied to those cells.

--- a/docs/install/windows.md
+++ b/docs/install/windows.md
@@ -65,7 +65,7 @@ $ scoop install wezterm
 ### For `Chocolatey` users
 
 If you prefer to use [Chocolatey](https://chocolatey.org) to manage software,
-wezterm is availabe from the Community Repository.  It can be installed like
+wezterm is available from the Community Repository.  It can be installed like
 so:
 
 ```console

--- a/docs/multiplexing.md
+++ b/docs/multiplexing.md
@@ -120,7 +120,7 @@ config.unix_domains = {
     -- The name; must be unique amongst all domains
     name = 'unix',
 
-    -- The path to the socket.  If unspecified, a resonable default
+    -- The path to the socket.  If unspecified, a reasonable default
     -- value will be computed.
 
     -- socket_path = "/some/path",

--- a/docs/what-is-a-terminal.md
+++ b/docs/what-is-a-terminal.md
@@ -32,7 +32,7 @@ The kernel doesn't know any details of the connected device as there isn't
 a defined way for it to do that; it only knows how to transmit data over that
 serial line.
 
-To accomodate this the TTY interface in the kernel allows for some basic
+To accommodate this the TTY interface in the kernel allows for some basic
 stream operations such as line-buffering and canonicalization of unix newlines
 to carriage-return-line-feed as was needed for printer style output to
 correctly move to the first column and move down a line.
@@ -200,7 +200,7 @@ and continue.
 
 If your shell supports job control, the suspend signal that is typically
 associated with `CTRL-Z` will cause the foreground process to suspend which
-in turn will wakup the shell in a similar way to that of the child getting
+in turn will wakeup the shell in a similar way to that of the child getting
 terminated, but it can tell that it was suspended rather than terminated.
 
 ## Terminal Emulators and PTYs
@@ -288,4 +288,3 @@ but what it means for wezterm users is that they may wish to bypass ConPTY in
 some cases by using `wezterm ssh` to directly communicate with a "real" unix
 pty either on a remote system or inside a WSL or VM running on the local
 machine.
-


### PR DESCRIPTION
Fixing some typos I encountered in the docs.