### PR TITLE
Avoid potential panic, when starting in Wayland.

### DIFF
--- a/window/src/os/wayland/connection.rs
+++ b/window/src/os/wayland/connection.rs
@@ -204,7 +204,10 @@ impl ConnectionOps for WaylandConnection {
         let output_state = &self.wayland_state.borrow().output;
 
         for output in output_state.outputs() {
-            let info = output_state.info(&output).unwrap();
+            let info = match output_state.info(&output) {
+                Some(i) => i,
+                None => continue,
+            };
             let name = match info.name {
                 Some(n) => n.clone(),
                 None => format!("{} {}", info.model, info.make),


### PR DESCRIPTION
As per the documentation for the OutputState info method:

/// This may be none if the output has been destroyed or the
/// compositor has not sent information about the output yet.

Unwrapping its return has lead to crashes at startup, which to
the user can appear as WezTerm refusing to start.