### PR TITLE
fix: only change stable row offset if screen has scrollback

### DIFF
--- a/term/src/screen.rs
+++ b/term/src/screen.rs
@@ -724,7 +724,7 @@ impl Screen {
             self.lines.remove(remove_idx);
         }
 
-        if remove_idx == 0 {
+        if remove_idx == 0 && self.allow_scrollback {
             self.stable_row_index_offset += lines_removed;
         }
 


### PR DESCRIPTION
I noticed, that in specific circumstances some lines are moving in a way they are not supposed to in alternate screen mode. Particularly noticeable in neovim.

https://github.com/user-attachments/assets/ed7a9cdd-a858-4bfe-beab-b3b7a8d66774

Turns out, when scrolling in a mux window, the viewport is moved down even if there is not supposed to be a scrollback (like in altenate screen mode). I added a check in the corresponding scroll method.

Together with https://github.com/wez/wezterm/pull/5981 this was part of the issues described in https://github.com/wez/wezterm/issues/4607.