### PR TITLE
Add support for ProxyUseFdPass to ssh

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3657,6 +3657,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "passfd"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b332c50e4d07c0011fff51ea305374408319908908bc1dbed7a0ffaaf63a8151"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6479,6 +6488,7 @@ dependencies = [
  "libssh-rs",
  "log",
  "once_cell",
+ "passfd",
  "portable-pty",
  "predicates",
  "regex",

--- a/wezterm-ssh/Cargo.toml
+++ b/wezterm-ssh/Cargo.toml
@@ -40,6 +40,9 @@ wezterm-uds = { path = "../wezterm-uds" }
 # Not used directly, but is used to centralize the openssl vendor feature selection
 async_ossl = { path = "../async_ossl" }
 
+[target.'cfg(unix)'.dependencies]
+passfd = "0.1.6"
+
 [dev-dependencies]
 assert_fs = "1.0.4"
 clap = {version="4.0", features=["derive"]}

--- a/wezterm-ssh/src/sessioninner.rs
+++ b/wezterm-ssh/src/sessioninner.rs
@@ -205,8 +205,7 @@ impl SessionInner {
             sess.set_option(libssh_rs::SshOption::HostKeys(host_key.to_string()))?;
         }
 
-        let (sock, _child) =
-            self.connect_to_host(&hostname, port, verbose, self.config.get("proxycommand"))?;
+        let (sock, _child) = self.connect_to_host(&hostname, port, verbose)?;
         let raw = {
             #[cfg(unix)]
             {
@@ -288,8 +287,7 @@ impl SessionInner {
             ))))
             .context("notifying user of banner")?;
 
-        let (sock, _child) =
-            self.connect_to_host(&hostname, port, verbose, self.config.get("proxycommand"))?;
+        let (sock, _child) = self.connect_to_host(&hostname, port, verbose)?;
 
         let mut sess = ssh2::Session::new()?;
         if verbose {
@@ -331,9 +329,8 @@ impl SessionInner {
         hostname: &str,
         port: u16,
         verbose: bool,
-        proxy_command: Option<&String>,
     ) -> anyhow::Result<(Socket, Option<KillOnDropChild>)> {
-        match proxy_command.map(|s| s.as_str()) {
+        match self.config.get("proxycommand").map(|s| s.as_str()) {
             Some("none") | None => {}
             Some(proxy_command) => {
                 let mut cmd;

--- a/wezterm-ssh/src/sessioninner.rs
+++ b/wezterm-ssh/src/sessioninner.rs
@@ -337,10 +337,10 @@ impl SessionInner {
                 if cfg!(windows) {
                     let comspec = std::env::var("COMSPEC").unwrap_or_else(|_| "cmd".to_string());
                     cmd = std::process::Command::new(comspec);
-                    cmd.args(&["/c", proxy_command]);
+                    cmd.args(["/c", proxy_command]);
                 } else {
                     cmd = std::process::Command::new("sh");
-                    cmd.args(&["-c", &format!("exec {}", proxy_command)]);
+                    cmd.args(["-c", &format!("exec {}", proxy_command)]);
                 }
 
                 let (a, b) = socketpair()?;
@@ -378,8 +378,7 @@ impl SessionInner {
 
         let addr = (hostname, port)
             .to_socket_addrs()?
-            .filter(|addr| self.filter_sock_addr(addr))
-            .next()
+            .find(|addr| self.filter_sock_addr(addr))
             .with_context(|| format!("resolving address for {}", hostname))?;
         if verbose {
             log::info!("resolved {hostname}:{port} -> {addr:?}");
@@ -388,8 +387,7 @@ impl SessionInner {
         if let Some(bind_addr) = self.config.get("bindaddress") {
             let bind_addr = (bind_addr.as_str(), 0)
                 .to_socket_addrs()?
-                .filter(|addr| self.filter_sock_addr(addr))
-                .next()
+                .find(|addr| self.filter_sock_addr(addr))
                 .with_context(|| format!("resolving bind address {bind_addr:?}"))?;
             if verbose {
                 log::info!("binding to {bind_addr:?}");


### PR DESCRIPTION
As per https://github.com/wez/wezterm/issues/6093

Utilizes a small, 3rd party crate (passfd) which allows the proxy
command to return a connected FD, instead of copying data.
This support is not implemented on Microsoft, and the crate
was marked as a dependency on unix-like systems only.

Some, associated code cleanup and reorg changes are included
in a trailing commit, and can be safely dropped if not wanted.
