### PR TITLE
fix non-iTerm2 cursor position after sixel image

### DIFF
--- a/term/src/terminalstate/image.rs
+++ b/term/src/terminalstate/image.rs
@@ -217,7 +217,7 @@ impl TerminalState {
                 xpos += x_delta;
             }
             ypos += y_delta;
-            if !params.do_not_move_cursor && y < height_in_cells - 1 {
+            if !params.do_not_move_cursor && (params.style != ImageAttachStyle::Iterm || y < height_in_cells - 1) {
                 self.new_line(false);
             }
         }


### PR DESCRIPTION
Fixes #6110.

It seems the problem was introduced by a115fc0d to fix issue #3266. The fix was intended to address issues with cursor positioning when displaying iTerm images, but prevents the final newline from being emitted in other modes. 

This commit fixes the issue I had in #6110 for sixel display, producing behaviour that matches mlTerm and minTTY. That said, I'm not sure whether the additional test performed is the most appropriate - please advise either way.