### PR TITLE
shell-integration: be resilient to nounset

### DIFF
--- a/assets/shell-integration/wezterm.sh
+++ b/assets/shell-integration/wezterm.sh
@@ -15,12 +15,12 @@
 #                                about running programs
 
 # shellcheck disable=SC2166
-if [ -z "${BASH_VERSION}" -a -z "${ZSH_NAME}" ] ; then
+if [ -z "${BASH_VERSION-}" -a -z "${ZSH_NAME-}" ] ; then
   # Only for bash or zsh
   return 0
 fi
 
-if [ "${WEZTERM_SHELL_SKIP_ALL}" = "1" ] ; then
+if [ "${WEZTERM_SHELL_SKIP_ALL-}" = "1" ] ; then
   return 0
 fi
 
@@ -425,7 +425,7 @@ fi;
 
 # blesh provides it's own preexec mechanism which is recommended over bash-preexec
 # See https://github.com/akinomyoga/ble.sh/wiki/Manual-%C2%A71-Introduction#user-content-fn-blehook for more details
-if [[ ! -n "$BLE_VERSION" ]]; then
+if [[ ! -n "${BLE_VERSION-}" ]]; then
   __wezterm_install_bash_prexec
 fi
 
@@ -434,7 +434,7 @@ fi
 # It requires the `base64` utility to be available in the path.
 __wezterm_set_user_var() {
   if hash base64 2>/dev/null ; then
-    if [[ -z "${TMUX}" ]] ; then
+    if [[ -z "${TMUX-}" ]] ; then
       printf "\033]1337;SetUserVar=%s=%s\007" "$1" `echo -n "$2" | base64`
     else
       # <https://github.com/tmux/tmux/wiki/FAQ#what-is-the-passthrough-escape-sequence-and-how-do-i-use-it>
@@ -499,7 +499,7 @@ __wezterm_user_vars_precmd() {
   __wezterm_set_user_var "WEZTERM_USER" "$(id -un)"
 
   # Indicate whether this pane is running inside tmux or not
-  if [[ -n "${TMUX}" ]] ; then
+  if [[ -n "${TMUX-}" ]] ; then
     __wezterm_set_user_var "WEZTERM_IN_TMUX" "1"
   else
     __wezterm_set_user_var "WEZTERM_IN_TMUX" "0"
@@ -526,8 +526,8 @@ __wezterm_user_vars_preexec() {
 # Register the various functions; take care to perform osc7 after
 # the semantic zones as we don't want to perturb the last command
 # status before we've had a chance to report it to the terminal
-if [[ -z "${WEZTERM_SHELL_SKIP_SEMANTIC_ZONES}" ]]; then
-  if [[ -n "$BLE_VERSION" ]]; then
+if [[ -z "${WEZTERM_SHELL_SKIP_SEMANTIC_ZONES-}" ]]; then
+  if [[ -n "${BLE_VERSION-}" ]]; then
     blehook PRECMD+=__wezterm_semantic_precmd
     blehook PREEXEC+=__wezterm_semantic_preexec
   else
@@ -536,8 +536,8 @@ if [[ -z "${WEZTERM_SHELL_SKIP_SEMANTIC_ZONES}" ]]; then
   fi
 fi
 
-if [[ -z "${WEZTERM_SHELL_SKIP_USER_VARS}" ]]; then
-  if [[ -n "$BLE_VERSION" ]]; then
+if [[ -z "${WEZTERM_SHELL_SKIP_USER_VARS-}" ]]; then
+  if [[ -n "${BLE_VERSION-}" ]]; then
     blehook PRECMD+=__wezterm_user_vars_precmd
     blehook PREEXEC+=__wezterm_user_vars_preexec
   else
@@ -546,8 +546,8 @@ if [[ -z "${WEZTERM_SHELL_SKIP_USER_VARS}" ]]; then
   fi
 fi
 
-if [[ -z "${WEZTERM_SHELL_SKIP_CWD}" ]] ; then
-  if [[ -n "$BLE_VERSION" ]]; then
+if [[ -z "${WEZTERM_SHELL_SKIP_CWD-}" ]] ; then
+  if [[ -n "${BLE_VERSION-}" ]]; then
     blehook PRECMD+=__wezterm_osc7
   else
     precmd_functions+=(__wezterm_osc7)


### PR DESCRIPTION
In a shell started with the `nounset` option set (e.g. `zsh -u`), WezTerm's shell integration fails with noisy errors such as `.wezterm.sh:18: BASH_VERSION: parameter not set`.

This can be trivially avoided by using `${parameter-}` substitutions, which is supported in all the shells supported by WezTerm. (In fact, substitutions were already used in a few places.)