### PR TITLE
chore: remove redundant words in comment

### DIFF
--- a/docs/config/keyboard-concepts.md
+++ b/docs/config/keyboard-concepts.md
@@ -121,7 +121,7 @@ WezTerm is now able to perform dead-key expansion when `use_ime = false`.  Dead
 keys are treated as composition effects, so with the default settings of
 `send_composed_key_when_left_alt_is_pressed` and
 `send_composed_key_when_right_alt_is_pressed` above, in a US layout, `Left-Opt
-n` will produce `Alt N` and `Right-Opt n` will will for a subsequent key press
+n` will produce `Alt N` and `Right-Opt n` will for a subsequent key press
 before generating an event; `Right-Opt n SPACE` will emit `~` whereas `Right-Opt n
 n` will emit `ñ`.
 

--- a/docs/config/lua/config/serial_ports.md
+++ b/docs/config/lua/config/serial_ports.md
@@ -13,7 +13,7 @@ Each entry defines a `SerialDomain` with the following fields:
   all multiplexer domains in your configuration.
 * `port` - the name of the serial device. On Windows systems this can be
   a name like `COM0`. On Posix systems this will be a device path something
-  like `/dev/ttyUSB0`.  If omitted, the `name` field be be interpreted as
+  like `/dev/ttyUSB0`.  If omitted, the `name` field be interpreted as
   the port name.
 * `baud` - the communication speed to assign to the port. If omitted,
   the default baud rate will be 9600.

--- a/docs/config/lua/config/window_decorations.md
+++ b/docs/config/lua/config/window_decorations.md
@@ -8,7 +8,7 @@ tags:
 
 Configures whether the window has a title bar and/or resizable border.
 
-The value is a set of of flags:
+The value is a set of flags:
 
 * `window_decorations = "NONE"` - disables titlebar and border (borderless
   mode), but causes problems with resizing and minimizing the window, so you


### PR DESCRIPTION
remove redundant words in comment