### PR TITLE
Do not synthesize window size for MAXIMIZED/FULLSCREEN/TILED states

### DIFF
--- a/window/src/os/wayland/window.rs
+++ b/window/src/os/wayland/window.rs
@@ -1223,7 +1223,6 @@ impl WaylandState {
             .window_by_id(window_id)
             .expect("Inner Window should exist");
 
-        let is_frame_hidden = window_inner.borrow().window_frame.is_hidden();
         let p = window_inner.borrow().pending_event.clone();
         let mut pending_event = p.lock().unwrap();
 
@@ -1260,31 +1259,6 @@ impl WaylandState {
                     state |= WindowState::MAXIMIZED;
                 }
 
-                // For MAXIMIZED and FULL_SCREEN window configure contains Windowed size.
-                // Replacing it with Wayland suggested bounds.
-                if state.intersects(WindowState::MAXIMIZED | WindowState::FULL_SCREEN) {
-                    if let Some((w, h)) = configure.suggested_bounds {
-                        pending_event.configure.replace((w, h));
-                    }
-                } else if configure
-                    .state
-                    .contains(SCTKWindowState::TILED_TOP | SCTKWindowState::TILED_BOTTOM)
-                    && is_frame_hidden
-                {
-                    // Tiled window without borders will take exactly half of the screen.
-                    if let Some((w, h)) = configure.suggested_bounds {
-                        pending_event.configure.replace((w / 2, h));
-                    }
-                } else if configure
-                    .state
-                    .contains(SCTKWindowState::TILED_LEFT | SCTKWindowState::TILED_RIGHT)
-                    && is_frame_hidden
-                {
-                    // Tiled window without borders will take exactly half of the screen.
-                    if let Some((w, h)) = configure.suggested_bounds {
-                        pending_event.configure.replace((w, h / 2));
-                    }
-                }
                 log::debug!(
                     "Config: self.window_state={:?}, states: {:?} {:?}",
                     pending_event.window_state,


### PR DESCRIPTION
It is the responsibility of the Wayland compositor to set the correct size for the window when it is tiled or maximized.
https://wayland.app/protocols/xdg-shell#xdg_toplevel:enum:state also states that in the maximized case, the client needs to obey the geometry provided by the compositor.

Also, in the fullscreen case, with this code in place, Wezterm ends up not taking up the entire screen when there's some kind of bar/panel (easy to reproduce with the default Gnome desktop).

Since the code was added in response to https://github.com/wez/wezterm/issues/6108 I have tested this change against Gnome (47.0.1). The other compositors I've tested against are Niri and Sway; With both Niri and Sway, TILED_TOP/BOTTOM/LEFT/RIGHT are set. Sway isn't broken by this code because it doesn't provide suggested_bounds. With Niri, `pending_event.configure.replace((w / 2, h));` always runs, and it is completely impossible to resize the window (other than making it fullscreen).