### PR TITLE
Alter copr spec file for Fedora 41 and Rawhide

### DIFF
--- a/ci/deploy.sh
+++ b/ci/deploy.sh
@@ -171,6 +171,9 @@ BuildRequires: Mesa-libEGL-devel
 %else
 BuildRequires: mesa-libEGL-devel
 %endif
+%if 0%{?fedora} >= 41
+BuildRequires: openssl-devel-engine
+%endif
 Source0: wezterm-${TAR_NAME}.tar.gz
 
 %global debug_package %{nil}


### PR DESCRIPTION
SlouchyButton mentioned in #6015 that a Fedora Openssl packaging change was likely causing a problem for the copr build.

The deprecated engine header has been broken out into its own package.  Add a dependency on it for Fedora 41 and Rawhide.