### PR TITLE
add X11 xmonad to tiling_desktop_environments

### DIFF
--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -1766,6 +1766,7 @@ fn default_tiling_desktop_environments() -> Vec<String> {
         "X11 bspwm",
         "X11 dwm",
         "X11 i3",
+        "X11 xmonad",
     ]
     .iter()
     .map(|s| s.to_string())


### PR DESCRIPTION
Add the [XMonad](https://xmonad.org) tiling desktop environment name.