### PR TITLE
docs: Put APT key into /etc/apt/keyrings

### DIFF
--- a/docs/install/linux.md
+++ b/docs/install/linux.md
@@ -100,8 +100,8 @@ hide:
     steps:
 
     ```console
-    $ curl -fsSL https://apt.fury.io/wez/gpg.key | sudo gpg --yes --dearmor -o /usr/share/keyrings/wezterm-fury.gpg
-    $ echo 'deb [signed-by=/usr/share/keyrings/wezterm-fury.gpg] https://apt.fury.io/wez/ * *' | sudo tee /etc/apt/sources.list.d/wezterm.list
+    $ curl -fsSL https://apt.fury.io/wez/gpg.key | sudo gpg --yes --dearmor -o /etc/apt/keyrings/wezterm-fury.gpg
+    $ echo 'deb [signed-by=/etc/apt/keyrings/wezterm-fury.gpg] https://apt.fury.io/wez/ * *' | sudo tee /etc/apt/sources.list.d/wezterm.list
     ```
 
     Update your dependencies:


### PR DESCRIPTION
sources.list(5) says:

> The recommended locations for keyrings are
> /usr/share/keyrings for keyrings managed by packages, and
> /etc/apt/keyrings for keyrings managed by the system operator.