### PR TITLE
Add support for OSC 22 control sequence to change mouse shape

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6827,6 +6827,7 @@ dependencies = [
  "wezterm-color-types",
  "wezterm-font",
  "wezterm-input-types",
+ "wezterm-term",
  "winapi",
  "windows 0.33.0",
  "winreg",

--- a/mux/src/localpane.rs
+++ b/mux/src/localpane.rs
@@ -31,8 +31,8 @@ use url::Url;
 use wezterm_dynamic::Value;
 use wezterm_term::color::ColorPalette;
 use wezterm_term::{
-    Alert, AlertHandler, Clipboard, DownloadHandler, KeyCode, KeyModifiers, MouseEvent,
-    SemanticZone, StableRowIndex, Terminal, TerminalConfiguration, TerminalSize,
+    Alert, AlertHandler, Clipboard, DownloadHandler, KeyCode, KeyModifiers, MouseCursor,
+    MouseEvent, SemanticZone, StableRowIndex, Terminal, TerminalConfiguration, TerminalSize,
 };
 
 const PROC_INFO_CACHE_TTL: Duration = Duration::from_millis(300);
@@ -137,6 +137,10 @@ pub struct LocalPane {
 
 #[async_trait(?Send)]
 impl Pane for LocalPane {
+    fn get_mouse_cursor_shape(&self) -> MouseCursor {
+        self.terminal.lock().get_mouse_cursor_shape()
+    }
+
     fn pane_id(&self) -> PaneId {
         self.pane_id
     }

--- a/mux/src/pane.rs
+++ b/mux/src/pane.rs
@@ -553,6 +553,10 @@ mod test {
     }
 
     impl Pane for FakePane {
+        fn get_mouse_cursor_shape(&self) -> MouseCursor {
+            unimplemented!()
+        }
+
         fn pane_id(&self) -> PaneId {
             unimplemented!()
         }

--- a/mux/src/pane.rs
+++ b/mux/src/pane.rs
@@ -16,6 +16,7 @@ use termwiz::surface::{Line, SequenceNo};
 use url::Url;
 use wezterm_dynamic::Value;
 use wezterm_term::color::ColorPalette;
+pub use wezterm_term::MouseCursor;
 use wezterm_term::{
     Clipboard, DownloadHandler, KeyCode, KeyModifiers, MouseEvent, SemanticZone, StableRowIndex,
     TerminalConfiguration, TerminalSize,
@@ -230,6 +231,8 @@ pub trait Pane: Downcast + Send + Sync {
 
     /// Returns render related dimensions
     fn get_dimensions(&self) -> RenderableDimensions;
+
+    fn get_mouse_cursor_shape(&self) -> MouseCursor;
 
     fn get_title(&self) -> String;
     fn send_paste(&self, text: &str) -> anyhow::Result<()>;

--- a/mux/src/tab.rs
+++ b/mux/src/tab.rs
@@ -2222,6 +2222,10 @@ mod test {
     }
 
     impl Pane for FakePane {
+        fn get_mouse_cursor_shape(&self) -> MouseCursor {
+            unimplemented!();
+        }
+
         fn pane_id(&self) -> PaneId {
             self.id
         }

--- a/mux/src/termwiztermtab.rs
+++ b/mux/src/termwiztermtab.rs
@@ -32,7 +32,8 @@ use termwiz::Context;
 use url::Url;
 use wezterm_term::color::ColorPalette;
 use wezterm_term::{
-    KeyCode, KeyModifiers, MouseEvent, StableRowIndex, TerminalConfiguration, TerminalSize,
+    KeyCode, KeyModifiers, MouseCursor, MouseEvent, StableRowIndex, TerminalConfiguration,
+    TerminalSize,
 };
 
 struct TermWizTerminalDomain {
@@ -126,6 +127,10 @@ impl TermWizTerminalPane {
 }
 
 impl Pane for TermWizTerminalPane {
+    fn get_mouse_cursor_shape(&self) -> MouseCursor {
+        MouseCursor::Arrow
+    }
+
     fn pane_id(&self) -> PaneId {
         self.pane_id
     }

--- a/term/src/terminal.rs
+++ b/term/src/terminal.rs
@@ -51,6 +51,8 @@ pub enum Alert {
     TabTitleChanged(Option<String>),
     /// When the color palette has been updated
     PaletteChanged,
+    /// When the mouse cursor shape has been updated
+    MouseCursorShapeChanged,
     /// A UserVar has changed value
     SetUserVar {
         name: String,

--- a/term/src/terminalstate/performer.rs
+++ b/term/src/terminalstate/performer.rs
@@ -678,6 +678,7 @@ impl<'a> Performer<'a> {
                 self.focus_tracking = false;
                 self.mouse_tracking = false;
                 self.mouse_encoding = MouseEncoding::X10;
+                self.mouse_cursor_shape = String::from("");
                 self.keyboard_encoding = KeyboardEncoding::Xterm;
                 self.sixel_scrolls_right = false;
                 self.any_event_mouse = false;
@@ -704,6 +705,7 @@ impl<'a> Performer<'a> {
                 self.erase_in_display(EraseInDisplay::EraseScrollback);
                 self.erase_in_display(EraseInDisplay::EraseDisplay);
                 self.palette_did_change();
+                self.mouse_cursor_shape_did_change();
             }
 
             _ => {
@@ -718,6 +720,10 @@ impl<'a> Performer<'a> {
         self.pop_tmux_title_state();
         self.flush_print();
         match osc {
+            OperatingSystemCommand::SetMouseCursorShape(mouse_shape) => {
+                self.mouse_cursor_shape = mouse_shape;
+                self.mouse_cursor_shape_did_change();
+            }
             OperatingSystemCommand::SetIconNameSun(title)
             | OperatingSystemCommand::SetIconName(title) => {
                 if title.is_empty() {

--- a/termwiz/src/escape/osc.rs
+++ b/termwiz/src/escape/osc.rs
@@ -38,6 +38,7 @@ pub enum OperatingSystemCommand {
     QuerySelection(Selection),
     SetSelection(Selection, String),
     SystemNotification(String),
+    SetMouseCursorShape(String),
     ITermProprietary(ITermProprietary),
     FinalTermSemanticPrompt(FinalTermSemanticPrompt),
     ChangeColorNumber(Vec<ChangeColorPair>),
@@ -312,6 +313,7 @@ impl OperatingSystemCommand {
             SetHyperlink => Ok(OperatingSystemCommand::SetHyperlink(Hyperlink::parse(osc)?)),
             ManipulateSelectionData => Self::parse_selection(osc),
             SystemNotification => single_string!(SystemNotification),
+            SetMouseCursorShape => single_string!(SetMouseCursorShape),
             SetCurrentWorkingDirectory => single_string!(CurrentWorkingDirectory),
             ITermProprietary => {
                 self::ITermProprietary::parse(osc).map(OperatingSystemCommand::ITermProprietary)
@@ -419,6 +421,7 @@ osc_entries!(
     SetHighlightBackgroundColor = "17",
     SetTektronixCursorColor = "18",
     SetHighlightForegroundColor = "19",
+    SetMouseCursorShape = "22",
     SetLogFileName = "46",
     SetFont = "50",
     EmacsShell = "51",
@@ -509,6 +512,7 @@ impl Display for OperatingSystemCommand {
             QuerySelection(s) => write!(f, "52;{};?", s)?,
             SetSelection(s, val) => write!(f, "52;{};{}", s, base64_encode(val))?,
             SystemNotification(s) => write!(f, "9;{}", s)?,
+            SetMouseCursorShape(s) => write!(f, "22;{}", s)?,
             ITermProprietary(i) => i.fmt(f)?,
             FinalTermSemanticPrompt(i) => i.fmt(f)?,
             ResetColors(colors) => {

--- a/wezterm-client/src/pane/clientpane.rs
+++ b/wezterm-client/src/pane/clientpane.rs
@@ -27,7 +27,7 @@ use url::Url;
 use wezterm_dynamic::Value;
 use wezterm_term::color::ColorPalette;
 use wezterm_term::{
-    Alert, Clipboard, KeyCode, KeyModifiers, Line, MouseEvent, StableRowIndex,
+    Alert, Clipboard, KeyCode, KeyModifiers, Line, MouseCursor, MouseEvent, StableRowIndex,
     TerminalConfiguration, TerminalSize,
 };
 
@@ -245,6 +245,10 @@ impl ClientPane {
 
 #[async_trait(?Send)]
 impl Pane for ClientPane {
+    fn get_mouse_cursor_shape(&self) -> MouseCursor {
+        MouseCursor::Arrow
+    }
+
     fn pane_id(&self) -> PaneId {
         self.local_pane_id
     }

--- a/wezterm-gui/src/frontend.rs
+++ b/wezterm-gui/src/frontend.rs
@@ -143,6 +143,7 @@ impl GuiFrontEnd {
                     alert:
                         Alert::OutputSinceFocusLost
                         | Alert::PaletteChanged
+                        | Alert::MouseCursorShapeChanged
                         | Alert::CurrentWorkingDirectoryChanged
                         | Alert::WindowTitleChanged(_)
                         | Alert::TabTitleChanged(_)

--- a/wezterm-gui/src/overlay/copy.rs
+++ b/wezterm-gui/src/overlay/copy.rs
@@ -27,8 +27,8 @@ use unicode_segmentation::*;
 use url::Url;
 use wezterm_term::color::ColorPalette;
 use wezterm_term::{
-    unicode_column_width, Clipboard, KeyCode, KeyModifiers, Line, MouseEvent, SemanticType,
-    StableRowIndex, TerminalSize,
+    unicode_column_width, Clipboard, KeyCode, KeyModifiers, Line, MouseCursor, MouseEvent,
+    SemanticType, StableRowIndex, TerminalSize,
 };
 use window::{KeyCode as WKeyCode, Modifiers, WindowOps};
 
@@ -1101,6 +1101,10 @@ impl CopyRenderable {
 }
 
 impl Pane for CopyOverlay {
+    fn get_mouse_cursor_shape(&self) -> MouseCursor {
+        MouseCursor::Arrow
+    }
+
     fn pane_id(&self) -> PaneId {
         self.delegate.pane_id()
     }

--- a/wezterm-gui/src/overlay/quickselect.rs
+++ b/wezterm-gui/src/overlay/quickselect.rs
@@ -19,7 +19,7 @@ use termwiz::surface::{SequenceNo, SEQ_ZERO};
 use url::Url;
 use wezterm_term::color::ColorPalette;
 use wezterm_term::{
-    Clipboard, KeyCode, KeyModifiers, Line, MouseEvent, StableRowIndex, TerminalSize,
+    Clipboard, KeyCode, KeyModifiers, Line, MouseCursor, MouseEvent, StableRowIndex, TerminalSize,
 };
 use window::WindowOps;
 
@@ -317,6 +317,10 @@ impl QuickSelectOverlay {
 }
 
 impl Pane for QuickSelectOverlay {
+    fn get_mouse_cursor_shape(&self) -> MouseCursor {
+        MouseCursor::Arrow
+    }
+
     fn pane_id(&self) -> PaneId {
         self.delegate.pane_id()
     }

--- a/wezterm-gui/src/termwindow/mod.rs
+++ b/wezterm-gui/src/termwindow/mod.rs
@@ -1210,6 +1210,13 @@ impl TermWindow {
                     self.update_title();
                 }
                 MuxNotification::Alert {
+                    alert: Alert::MouseCursorShapeChanged,
+                    pane_id,
+                } => {
+                    // FIXME: Is there a cache that needs to be invalidated like for PaletteChanged?
+                    self.mux_pane_output_event(pane_id);
+                }
+                MuxNotification::Alert {
                     alert: Alert::PaletteChanged,
                     pane_id,
                 } => {
@@ -1515,6 +1522,12 @@ impl TermWindow {
             | MuxNotification::WindowWorkspaceChanged(_) => return true,
             MuxNotification::Alert {
                 alert: Alert::PaletteChanged { .. },
+                ..
+            } => {
+                // fall through
+            }
+            MuxNotification::Alert {
+                alert: Alert::MouseCursorShapeChanged { .. },
                 ..
             } => {
                 // fall through

--- a/wezterm-gui/src/termwindow/mouseevent.rs
+++ b/wezterm-gui/src/termwindow/mouseevent.rs
@@ -3,8 +3,8 @@ use crate::termwindow::{
     GuiWin, MouseCapture, PositionedSplit, ScrollHit, TermWindowNotif, UIItem, UIItemType, TMB,
 };
 use ::window::{
-    MouseButtons as WMB, MouseCursor, MouseEvent, MouseEventKind as WMEK, MousePress,
-    WindowDecorations, WindowOps, WindowState,
+    MouseButtons as WMB, MouseEvent, MouseEventKind as WMEK, MousePress, WindowDecorations,
+    WindowOps, WindowState,
 };
 use config::keyassignment::{KeyAssignment, MouseEventTrigger, SpawnTabDomain};
 use config::MouseEventAltScreen;
@@ -21,7 +21,7 @@ use termwiz::hyperlink::Hyperlink;
 use termwiz::surface::Line;
 use wezterm_dynamic::ToDynamic;
 use wezterm_term::input::{MouseButton, MouseEventKind as TMEK};
-use wezterm_term::{ClickPosition, LastMouseClick, StableRowIndex};
+use wezterm_term::{ClickPosition, LastMouseClick, MouseCursor, StableRowIndex};
 
 impl super::TermWindow {
     fn resolve_ui_item(&self, event: &MouseEvent) -> Option<UIItem> {
@@ -842,6 +842,11 @@ impl super::TermWindow {
         } else {
             MouseCursor::Text
         }));
+
+        if let Some(pane) = self.get_active_pane_or_overlay() {
+            // let pane = self.get_active_pane_no_overlay().unwrap();
+            context.set_cursor(Some(pane.get_mouse_cursor_shape()));
+        }
 
         let event_trigger_type = match &event.kind {
             WMEK::Press(press) => {

--- a/window/Cargo.toml
+++ b/window/Cargo.toml
@@ -46,6 +46,7 @@ wezterm-bidi = { path = "../bidi" }
 wezterm-color-types = { path = "../color-types" }
 wezterm-font = { path = "../wezterm-font" }
 wezterm-input-types = { path = "../wezterm-input-types" }
+wezterm-term = { path = "../term", features=["use_serde"] }
 
 [target."cfg(windows)".dependencies]
 clipboard-win = "2.2"

--- a/window/examples/async.rs
+++ b/window/examples/async.rs
@@ -4,6 +4,7 @@ use promise::spawn::spawn;
 use std::cell::RefCell;
 use std::rc::Rc;
 use wezterm_font::FontConfiguration;
+use wezterm_term::MouseCursor;
 
 struct MyWindow {
     allow_close: bool,

--- a/window/src/lib.rs
+++ b/window/src/lib.rs
@@ -16,6 +16,8 @@ pub mod os;
 pub mod screen;
 mod spawn;
 
+use wezterm_term::MouseCursor;
+
 pub use raw_window_handle;
 
 #[cfg(target_os = "macos")]
@@ -63,15 +65,6 @@ pub type RectF = euclid::Rect<f32, PixelUnit>;
 pub type Size = euclid::Size2D<isize, PixelUnit>;
 pub type SizeF = euclid::Size2D<f32, PixelUnit>;
 pub type ScreenRect = euclid::Rect<isize, ScreenPixelUnit>;
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum MouseCursor {
-    Arrow,
-    Hand,
-    Text,
-    SizeUpDown,
-    SizeLeftRight,
-}
 
 /// Represents the preferred appearance of the windowing
 /// environment.

--- a/window/src/os/macos/window.rs
+++ b/window/src/os/macos/window.rs
@@ -9,7 +9,7 @@ use crate::os::macos::menu::{MenuItem, RepresentedItem};
 use crate::parameters::{Border, Parameters, TitleBar};
 use crate::{
     Clipboard, Connection, DeadKeyStatus, Dimensions, Handled, KeyCode, KeyEvent, Modifiers,
-    MouseButtons, MouseCursor, MouseEvent, MouseEventKind, MousePress, Point, RawKeyEvent, Rect,
+    MouseButtons, MouseEvent, MouseEventKind, MousePress, Point, RawKeyEvent, Rect,
     RequestedWindowGeometry, ResizeIncrement, ResolvedGeometry, ScreenPoint, Size, ULength,
     WindowDecorations, WindowEvent, WindowEventSender, WindowOps, WindowState,
 };
@@ -52,6 +52,7 @@ use std::str::FromStr;
 use std::time::Instant;
 use wezterm_font::FontConfiguration;
 use wezterm_input_types::{is_ascii_control, IntegratedTitleButtonStyle, KeyboardLedStatus};
+use wezterm_term::MouseCursor;
 
 #[allow(non_upper_case_globals)]
 const NSViewLayerContentsPlacementTopLeft: NSInteger = 11;

--- a/window/src/os/windows/window.rs
+++ b/window/src/os/windows/window.rs
@@ -3,7 +3,7 @@ use crate::connection::ConnectionOps;
 use crate::parameters::{self, Parameters};
 use crate::{
     Appearance, Clipboard, DeadKeyStatus, Dimensions, Handled, KeyCode, KeyEvent, Modifiers,
-    MouseButtons, MouseCursor, MouseEvent, MouseEventKind, MousePress, Point, RawKeyEvent, Rect,
+    MouseButtons, MouseEvent, MouseEventKind, MousePress, Point, RawKeyEvent, Rect,
     RequestedWindowGeometry, ResolvedGeometry, ScreenPoint, ScreenRect, ULength, WindowDecorations,
     WindowEvent, WindowEventSender, WindowOps, WindowState,
 };
@@ -32,6 +32,7 @@ use std::sync::Mutex;
 use wezterm_color_types::LinearRgba;
 use wezterm_font::FontConfiguration;
 use wezterm_input_types::KeyboardLedStatus;
+use wezterm_term::MouseCursor;
 use winapi::shared::minwindef::*;
 use winapi::shared::ntdef::*;
 use winapi::shared::windef::*;

--- a/window/src/os/x11/cursor.rs
+++ b/window/src/os/x11/cursor.rs
@@ -1,6 +1,5 @@
 use crate::os::x11::xcb_util::*;
 use crate::x11::XConnection;
-use crate::MouseCursor;
 use anyhow::{ensure, Context};
 use config::ConfigHandle;
 use std::collections::{HashMap, HashSet};
@@ -10,6 +9,7 @@ use std::io::prelude::*;
 use std::io::SeekFrom;
 use std::path::PathBuf;
 use std::rc::{Rc, Weak};
+use wezterm_term::MouseCursor;
 use xcb::x::Cursor;
 use xcb::Xid;
 

--- a/window/src/os/x11/window.rs
+++ b/window/src/os/x11/window.rs
@@ -3,10 +3,10 @@ use crate::bitmaps::*;
 use crate::connection::ConnectionOps;
 use crate::os::{xkeysyms, Connection, Window};
 use crate::{
-    Appearance, Clipboard, DeadKeyStatus, Dimensions, MouseButtons, MouseCursor, MouseEvent,
-    MouseEventKind, MousePress, Point, Rect, RequestedWindowGeometry, ResizeIncrement,
-    ResolvedGeometry, ScreenPoint, ScreenRect, WindowDecorations, WindowEvent, WindowEventSender,
-    WindowOps, WindowState,
+    Appearance, Clipboard, DeadKeyStatus, Dimensions, MouseButtons, MouseEvent, MouseEventKind,
+    MousePress, Point, Rect, RequestedWindowGeometry, ResizeIncrement, ResolvedGeometry,
+    ScreenPoint, ScreenRect, WindowDecorations, WindowEvent, WindowEventSender, WindowOps,
+    WindowState,
 };
 use anyhow::{anyhow, Context as _};
 use async_trait::async_trait;
@@ -26,6 +26,7 @@ use std::sync::{Arc, Mutex};
 use url::Url;
 use wezterm_font::FontConfiguration;
 use wezterm_input_types::{KeyCode, KeyEvent, KeyboardLedStatus, Modifiers};
+use wezterm_term::MouseCursor;
 use xcb::x::{Atom, PropMode};
 use xcb::{Event, Xid};
 

--- a/window/src/os/x_and_wayland.rs
+++ b/window/src/os/x_and_wayland.rs
@@ -9,8 +9,8 @@ use crate::os::x11::connection::XConnection;
 use crate::os::x11::window::XWindow;
 use crate::screen::Screens;
 use crate::{
-    Appearance, Clipboard, MouseCursor, Rect, RequestedWindowGeometry, ResizeIncrement,
-    ScreenPoint, WindowEvent, WindowOps,
+    Appearance, Clipboard, Rect, RequestedWindowGeometry, ResizeIncrement, ScreenPoint,
+    WindowEvent, WindowOps,
 };
 use async_trait::async_trait;
 use config::ConfigHandle;
@@ -21,6 +21,7 @@ use raw_window_handle::{
 use std::any::Any;
 use std::rc::Rc;
 use wezterm_font::FontConfiguration;
+use wezterm_term::MouseCursor;
 
 pub enum Connection {
     X11(Rc<XConnection>),


### PR DESCRIPTION
## Description

> [!NOTE]
> Opening this as a draft PR for now because there are some kinks I need to work through and I'm not sure how. I'll describe the problems in a review on this PR. I'm also not at all sure if the approach here is correct.

* Adds handling for the [OSC 22](https://invisible-island.net/xterm/ctlseqs/ctlseqs.html#h4-Operating-System-Commands:OSC-Ps;Pt-ST:Ps-=-2-2.1018) control sequence.
* Follows [the example set by Kitty](https://github.com/kovidgoyal/kitty/blob/2efa394dea2ec72aa60d6f94bc9ac241c3cc0037/gen/cursors.py#L15-L57) to support [CSS cursor](https://developer.mozilla.org/en-US/docs/Web/CSS/cursor) values for the OSC 22 parameter.
* Currently only supports `pointer`, `text`, `row-resize`, `ns-resize`, `col-resize`, and `ew-resize`, based on the currently available `MouseCursor` options in the codebase. Any other value defaults to `MouseCursor::Arrow`.

### Videos

Running [comlink](https://github.com/rockorager/comlink/tree/main) (terminal IRC client) before and after:

| Before (9ddca7bde92090792dbcdc65c1e9897c362196d7) | After |
|:---:|:---:|
| <video src="https://github.com/user-attachments/assets/58af48cc-c5a0-4ed4-a53b-ff6b18f2b7e8"> | <video src="https://github.com/user-attachments/assets/bb3237d1-1361-44ea-9cc6-a3f0ed5f7829"> |

## Testing

This requires a terminal program that makes use of OSC 22 codes to change the mouse cursor. The only one I know of and actively use is comlink, but I'm sure there are other TUIs out there that do use the codes, I'm just not aware of them.

Run a terminal program that uses OSC 22 codes and check if they work.

I'll try to make a terminal program to demonstrate at least some of them as I work on this PR. It should make testing easier.

