### PR TITLE
fix crashes when hb_buffer_get_glyph_* return null pointers

### DIFF
--- a/wezterm-font/src/hbwrap.rs
+++ b/wezterm-font/src/hbwrap.rs
@@ -1056,7 +1056,11 @@ impl Buffer {
         unsafe {
             let mut len: u32 = 0;
             let info = hb_buffer_get_glyph_infos(self.buf, &mut len as *mut _);
-            slice::from_raw_parts(info, len as usize)
+            if info.is_null() && len == 0 {
+                &[]
+            } else {
+                slice::from_raw_parts(info, len as usize)
+            }
         }
     }
 
@@ -1066,7 +1070,11 @@ impl Buffer {
         unsafe {
             let mut len: u32 = 0;
             let pos = hb_buffer_get_glyph_positions(self.buf, &mut len as *mut _);
-            slice::from_raw_parts(pos, len as usize)
+            if pos.is_null() && len == 0 {
+                &[]
+            } else {
+                slice::from_raw_parts(pos, len as usize)
+            }
         }
     }
 


### PR DESCRIPTION
Fix #6336 