### PR TITLE
Mark wayland-backend as optional dependency

### DIFF
--- a/window/Cargo.toml
+++ b/window/Cargo.toml
@@ -82,7 +82,7 @@ zbus = "4.2"
 zvariant = "4.0"
 
 smithay-client-toolkit = {version = "0.19", default-features=false, optional=true}
-wayland-backend = {version="0.3.5", features=["client_system", "rwh_06"]}
+wayland-backend = {version="0.3.5", features=["client_system", "rwh_06"], optional=true}
 wayland-protocols = {version="0.32", optional=true}
 wayland-client = {version="0.31", optional=true}
 wayland-egl = {version="0.32", optional=true}


### PR DESCRIPTION
Fixes #6315

https://github.com/wez/wezterm/commit/09ac8c53777ac6de61b757292f5dc4da80322bbd introduced the `wayland-backend` dependency, but did not mark it as optional, this prevented the build from successfully completing on X11 systems without Wayland development libraries.

This marks it as optional like the other Wayland dependencies and allows the builds with `--no-default-features` on systems without Wayland to build successfully, as tested on my system.