### PR TITLE
wayland: reimplement maximize and restore

### DIFF
--- a/window/src/os/wayland/window.rs
+++ b/window/src/os/wayland/window.rs
@@ -466,6 +466,14 @@ impl WindowOps for WaylandWindow {
             Ok(())
         });
     }
+
+    fn maximize(&self) {
+        WaylandConnection::with_window_inner(self.0, move |inner| Ok(inner.maximize()));
+    }
+
+    fn restore(&self) {
+        WaylandConnection::with_window_inner(self.0, move |inner| Ok(inner.restore()));
+    }
 }
 #[derive(Default, Clone, Debug)]
 pub(crate) struct PendingEvent {
@@ -1206,6 +1214,18 @@ impl WaylandWindowInner {
             }
             FrameAction::Move => self.window.as_ref().unwrap().move_(seat, serial),
             _ => log::warn!("unhandled FrameAction: {:?}", action),
+        }
+    }
+
+    fn maximize(&mut self) {
+        if let Some(window) = self.window.as_mut() {
+            window.set_maximized();
+        }
+    }
+
+    fn restore(&mut self) {
+        if let Some(window) = self.window.as_mut() {
+            window.unset_maximized();
         }
     }
 }


### PR DESCRIPTION
Hi! 

Reimplement maximize and restore features for wayland.
It was removed with wayland reimplementation in #4777. I backported maximize and restore as before that PR was merged.

It partially fixes #6203, but I didn't check `toggle_fullscreen` behavior.

The only issue that I noticed is that sometimes after you invoke `win:restore()` wezterm window doesn't restore until you focus another application.

Configuration file for tests:
```lua
local wezterm = require "wezterm"

local config = {}

wezterm.on("gui-startup", function()
  local mux = wezterm.mux
  local tab, main_pane, main_window = mux.spawn_window {}
  main_window:gui_window():maximize()
end)

config.keys = {
  {
    key = "r",
    mods = "CTRL|SHIFT",
    action = wezterm.action_callback(function(win, pane)
      wezterm.log_info 'Restore window'
      win:restore()
    end),
  },
  {
    key = "m",
    mods = "CTRL|SHIFT",
    action = wezterm.action_callback(function(win, pane)
      wezterm.log_info 'Maximize window'
      win:maximize()
    end),
  },
}

return config
```

Tested on Ubuntu 24.04.1 with GNOME 46.