### PR TITLE
Disable libpng VSX_OPT flag for PowerPC 64

### DIFF
--- a/deps/freetype/build.rs
+++ b/deps/freetype/build.rs
@@ -93,6 +93,9 @@ fn libpng() {
     cfg.define("HAVE_STDINT_H", None);
     cfg.define("HAVE_STDDEF_H", None);
     let target = env::var("TARGET").unwrap();
+    if target.contains("powerpc64") {
+        cfg.define("PNG_POWERPC_VSX_OPT", Some("0"));
+    }
     if !target.contains("windows") {
         cfg.define("_LARGEFILE64_SOURCE", Some("1"));
     }


### PR DESCRIPTION
Fix a linker error in wezterm-gui due to a missing libpng feature on modern PowerPC 64-bit platforms.

Tested build on RHEL8.8 running on IBM POWER9 platform.
![image](https://github.com/user-attachments/assets/031e0c49-ac1c-4871-a52a-9212d210dec5)
