### PR TITLE
adds movement for start of word, regardless of stop characters

### DIFF
--- a/config/src/keyassignment.rs
+++ b/config/src/keyassignment.rs
@@ -672,6 +672,7 @@ pub enum CopyModeAssignment {
     MoveToStartOfNextLine,
     MoveToSelectionOtherEnd,
     MoveToSelectionOtherEndHoriz,
+    MoveBackwardWordStart,
     MoveBackwardWord,
     MoveForwardWord,
     MoveForwardWordEnd,


### PR DESCRIPTION
regarding #195 https://github.com/wez/wezterm/issues/1954#issuecomment-1568451852

```
Sample test/with-characters that cause stopps
                    -(cursor)
       -(after hitting MoveBackwardWordStart)

otherwise would need 2 MoveBackwardWord actions.
```