### PR TITLE
Fixed cursor blinking on transparent backgrounds

### DIFF
--- a/wezterm-gui/src/glyph-frag.glsl
+++ b/wezterm-gui/src/glyph-frag.glsl
@@ -148,7 +148,7 @@ void main() {
     // and we need to tint with the fg_color
     color = fg_color;
     if (!subpixel_aa) {
-      color.a = colorMask.a;
+      color.a *= colorMask.a;
     }
     color = apply_hsv(color, foreground_text_hsb);
   }


### PR DESCRIPTION
Fixes #3886

Hi, 
It seems the mask was completely overriding the alpha values which means that any opacity stuff was getting thrown out - in case of bug above, the proper color with alpha 0 was being passed but then still rendered. Now it should take the alpha of the color into account.
