### PR TITLE
nix/flake.nix: freetype -> 2.13.3; clean-ups

### DIFF
--- a/nix/flake.lock
+++ b/nix/flake.lock
@@ -21,17 +21,17 @@
     "freetype2": {
       "flake": false,
       "locked": {
-        "lastModified": 1687587065,
-        "narHash": "sha256-+Fh+/k+NWL5Ow9sDLtp8Cv/8rLNA1oByQQCIQS/bysY=",
-        "owner": "wez",
-        "repo": "freetype2",
-        "rev": "e4586d960f339cf75e2e0b34aee30a0ed8353c0d",
+        "lastModified": 1723459814,
+        "narHash": "sha256-4l90lDtpgm5xlh2m7ifrqNy373DTRTULRkAzicrM93c=",
+        "owner": "freetype",
+        "repo": "freetype",
+        "rev": "42608f77f20749dd6ddc9e0536788eaad70ea4b5",
         "type": "github"
       },
       "original": {
-        "owner": "wez",
-        "repo": "freetype2",
-        "rev": "e4586d960f339cf75e2e0b34aee30a0ed8353c0d",
+        "owner": "freetype",
+        "ref": "VER-2-13-3",
+        "repo": "freetype",
         "type": "github"
       }
     },
@@ -71,11 +71,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1735617354,
-        "narHash": "sha256-5zJyv66q68QZJZsXtmjDBazGnF0id593VSy+8eSckoo=",
+        "lastModified": 1735821806,
+        "narHash": "sha256-cuNapx/uQeCgeuhUhdck3JKbgpsml259sjUQnWM7zW8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "69b9a8c860bdbb977adfa9c5e817ccb717884182",
+        "rev": "d6973081434f88088e5321f83ebafe9a1167c367",
         "type": "github"
       },
       "original": {
@@ -103,11 +103,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1735784864,
-        "narHash": "sha256-tIl5p3ueaPw7T5T1UXkLc8ISMk6Y8CI/D/rd0msf73I=",
+        "lastModified": 1735871325,
+        "narHash": "sha256-6Ta5E4mhSfCP6LdkzkG2+BciLOCPeLKuYTJ6lOHW+mI=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "04d5f1836721461b256ec452883362c5edc5288e",
+        "rev": "a599f011db521766cbaf7c2f5874182485554f00",
         "type": "github"
       },
       "original": {

--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -21,7 +21,7 @@
     # (note: `git submodule status` in wezterm repo will show the `git describe` result for each
     # submodule, can help finding a tag if any)
     freetype2 = {
-      url = "github:wez/freetype2/e4586d960f339cf75e2e0b34aee30a0ed8353c0d";
+      url = "github:freetype/freetype/VER-2-13-3";
       flake = false;
     };
     harfbuzz = {

--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -108,17 +108,13 @@
             allowBuiltinFetchGit = true;
           };
 
-          env.NIX_CFLAGS_COMPILE = toString [ "-Wno-macro-redefined" ];
-
           prePatch = ''
             rm -rf deps/freetype/{freetype2,libpng,zlib} deps/harfbuzz/harfbuzz
 
-            mkdir -p deps/freetype/{freetype2,libpng,zlib} deps/harfbuzz/harfbuzz
-
-            cp -r ${inputs.freetype2}/* deps/freetype/freetype2
-            cp -r ${inputs.libpng}/* deps/freetype/libpng
-            cp -r ${inputs.zlib}/* deps/freetype/zlib
-            cp -r ${inputs.harfbuzz}/* deps/harfbuzz/harfbuzz
+            ln -s ${inputs.freetype2} deps/freetype/freetype2
+            ln -s ${inputs.libpng} deps/freetype/libpng
+            ln -s ${inputs.zlib} deps/freetype/zlib
+            ln -s ${inputs.harfbuzz} deps/harfbuzz/harfbuzz
           '';
 
           postPatch = ''


### PR DESCRIPTION
https://github.com/wez/wezterm/commit/0eaf755d2503000d8ae7e80c0bf973dc298740db.

Tested in both `aarch64-darwin` and `x86_64-darwin`. `x86_64-linux` should run in CI.