### PR TITLE
add a few missing license files

### DIFF
--- a/wezterm-blob-leases/LICENSE.md
+++ b/wezterm-blob-leases/LICENSE.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021-Present Wez Furlong
+Copyright (c) 2023-Present Wez Furlong
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/wezterm-dynamic/LICENSE.md
+++ b/wezterm-dynamic/LICENSE.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018 Wez Furlong
+Copyright (c) 2018-Present Wez Furlong
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/wezterm-input-types/LICENSE.md
+++ b/wezterm-input-types/LICENSE.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021-Present Wez Furlong
+Copyright (c) 2020-Present Wez Furlong
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
I didn't symlink to the license file in the root because it mentions license that don't seem to apply to the crates I added license files to here.

I used the year each directory was created as the first copyright year.

I didn't add license files to all crates because I don't need them for what I'm working on right now, and I want to avoid having to figure out which licenses apply to which crates.

#2347