### PR TITLE
wezterm-ssh: make structs/fields public

### DIFF
--- a/wezterm-ssh/src/pty.rs
+++ b/wezterm-ssh/src/pty.rs
@@ -17,18 +17,18 @@ pub(crate) struct NewPty {
 }
 
 #[derive(Debug)]
-pub(crate) struct ResizePty {
+pub struct ResizePty {
     pub channel: ChannelId,
     pub size: PtySize,
 }
 
 #[derive(Debug)]
 pub struct SshPty {
-    pub(crate) channel: ChannelId,
-    pub(crate) tx: Option<SessionSender>,
-    pub(crate) reader: FileDescriptor,
-    pub(crate) writer: FileDescriptor,
-    pub(crate) size: Mutex<PtySize>,
+    pub channel: ChannelId,
+    pub tx: Option<SessionSender>,
+    pub reader: FileDescriptor,
+    pub writer: FileDescriptor,
+    pub size: Mutex<PtySize>,
 }
 
 impl std::io::Write for SshPty {

--- a/wezterm-ssh/src/session.rs
+++ b/wezterm-ssh/src/session.rs
@@ -22,7 +22,7 @@ pub enum SessionEvent {
 }
 
 #[derive(Debug, Clone)]
-pub(crate) struct SessionSender {
+pub struct SessionSender {
     pub tx: Sender<SessionRequest>,
     pub pipe: Arc<Mutex<FileDescriptor>>,
 }
@@ -51,7 +51,7 @@ impl SessionSender {
 pub struct DeadSession;
 
 #[derive(Debug)]
-pub(crate) enum SessionRequest {
+pub enum SessionRequest {
     NewPty(NewPty, Sender<anyhow::Result<(SshPty, SshChildProcess)>>),
     ResizePty(ResizePty, Option<Sender<anyhow::Result<()>>>),
     Exec(Exec, Sender<anyhow::Result<ExecResult>>),


### PR DESCRIPTION
I'm using `wezterm-ssh`, but some of its fields and structs are inaccessible from outside. I want to make their visibility public