### PR TITLE
fix: disable shell integration inside a Neovim terminal

### DIFF
--- a/assets/shell-integration/wezterm.sh
+++ b/assets/shell-integration/wezterm.sh
@@ -36,6 +36,11 @@ case "$TERM" in
   ;;
 esac
 
+if [ -n "$NVIM" ] ; then
+  # Disable inside Neovim terminal to avoid issues #5007 and #5986
+  return 0
+fi
+
 # This function wraps bash-preexec.sh so that it can be included verbatim
 # in this file, even though it uses `return` to short-circuit in some cases.
 __wezterm_install_bash_prexec() {


### PR DESCRIPTION
Sourcing `/etc/profile.d/wezterm.sh` inside a Neovim `:terminal` causes spurious output to be printed before each prompt. Simplest solutions is to disable shell integration in such case.

Closes #5007 and closes #5986.