### PR TITLE
Remove $RUST_BACKTRACE from Nix devShell

### DIFF
--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -235,7 +235,6 @@
             ]);
 
           LD_LIBRARY_PATH = libPath;
-          RUST_BACKTRACE = 1;
         };
 
         formatter = pkgs.nixfmt-rfc-style;


### PR DESCRIPTION
Make ~two~ one change~s~ to the Nix devShell environment:
~1. Install `lldb`: this allows `rust-lldb` to run properly.~
2. Don't set `$RUST_BACKTRACE`: prevents two backtraces from being printed

env-bootstrap/src/lib.rs's [`register_panic_hook()`](https://github.com/wezterm/wezterm/blob/d1bdb8a350907d080af8914f938d70c9e80cf2bb/env-bootstrap/src/lib.rs#L166-L186) already prints a backtrace unconditionally, setting `RUST_BACKTRACE=1` causes a duplicate to be printed. (CC @happenslol who, I believe, added this setting originally.)

I found ~both of these~ this change~s~ useful when debugging #7081 and #7098 so I think it'll ~they'll~ be generally helpful.