### PR TITLE
Add CopyMode overlay to TermwizTerminalPane overlays

### DIFF
--- a/mux/src/termwiztermtab.rs
+++ b/mux/src/termwiztermtab.rs
@@ -6,7 +6,7 @@
 use crate::domain::{alloc_domain_id, Domain, DomainId, DomainState};
 use crate::pane::{
     alloc_pane_id, CachePolicy, CloseReason, ForEachPaneLogicalLine, LogicalLine, Pane, PaneId,
-    WithPaneLines,
+    Pattern, SearchResult, WithPaneLines,
 };
 use crate::renderable::*;
 use crate::tab::Tab;
@@ -16,10 +16,13 @@ use anyhow::bail;
 use async_trait::async_trait;
 use config::keyassignment::ScrollbackEraseMode;
 use crossbeam::channel::{unbounded as channel, Receiver, Sender};
+use fancy_regex::Regex;
 use filedescriptor::{FileDescriptor, Pipe};
 use parking_lot::{MappedMutexGuard, Mutex, MutexGuard};
 use portable_pty::*;
 use rangeset::RangeSet;
+use std::borrow::Cow;
+use std::collections::HashMap;
 use std::io::{BufWriter, Write};
 use std::ops::Range;
 use std::sync::Arc;
@@ -125,6 +128,7 @@ impl TermWizTerminalPane {
     }
 }
 
+#[async_trait(?Send)]
 impl Pane for TermWizTerminalPane {
     fn pane_id(&self) -> PaneId {
         self.pane_id
@@ -303,6 +307,187 @@ impl Pane for TermWizTerminalPane {
                 self.terminal.lock().erase_scrollback_and_viewport();
             }
         }
+    }
+
+    async fn search(
+        &self,
+        pattern: Pattern,
+        range: Range<StableRowIndex>,
+        limit: Option<u32>,
+    ) -> anyhow::Result<Vec<SearchResult>> {
+        let term = self.terminal.lock();
+        let screen = term.screen();
+
+        enum CompiledPattern {
+            CaseSensitiveString(String),
+            CaseInSensitiveString(String),
+            Regex(Regex),
+        }
+
+        let pattern = match pattern {
+            Pattern::CaseSensitiveString(s) => CompiledPattern::CaseSensitiveString(s),
+            Pattern::CaseInSensitiveString(s) => {
+                // normalize the case so we match everything lowercase
+                CompiledPattern::CaseInSensitiveString(s.to_lowercase())
+            }
+            Pattern::Regex(r) => CompiledPattern::Regex(Regex::new(&r)?),
+        };
+
+        let mut results = vec![];
+        let mut uniq_matches: HashMap<String, usize> = HashMap::new();
+
+        screen.for_each_logical_line_in_stable_range(range, |sr, lines| {
+            if let Some(limit) = limit {
+                if results.len() == limit as usize {
+                    // We've reach the limit, stop iteration.
+                    return false;
+                }
+            }
+
+            if lines.is_empty() {
+                // Nothing to do on this iteration, carry on with the next.
+                return true;
+            }
+            let haystack = if lines.len() == 1 {
+                lines[0].as_str()
+            } else {
+                let mut s = String::new();
+                for line in lines {
+                    s.push_str(&line.as_str());
+                }
+                Cow::Owned(s)
+            };
+            let stable_idx = sr.start;
+
+            if haystack.is_empty() {
+                return true;
+            }
+
+            let haystack = match &pattern {
+                CompiledPattern::CaseInSensitiveString(_) => Cow::Owned(haystack.to_lowercase()),
+                _ => haystack,
+            };
+            let mut coords = None;
+
+            match &pattern {
+                CompiledPattern::CaseInSensitiveString(s)
+                | CompiledPattern::CaseSensitiveString(s) => {
+                    for (idx, s) in haystack.match_indices(s) {
+                        found_match(
+                            s,
+                            idx,
+                            lines,
+                            stable_idx,
+                            &mut uniq_matches,
+                            &mut coords,
+                            &mut results,
+                        );
+                    }
+                }
+                CompiledPattern::Regex(re) => {
+                    // Allow for the regex to contain captures
+                    for capture_res in re.captures_iter(&haystack) {
+                        if let Ok(c) = capture_res {
+                            // Look for the captures in reverse order, as index==0 is
+                            // the whole matched string.  We can't just call
+                            // `c.iter().rev()` as the capture iterator isn't double-ended.
+                            for idx in (0..c.len()).rev() {
+                                if let Some(m) = c.get(idx) {
+                                    found_match(
+                                        m.as_str(),
+                                        m.start(),
+                                        lines,
+                                        stable_idx,
+                                        &mut uniq_matches,
+                                        &mut coords,
+                                        &mut results,
+                                    );
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Keep iterating
+            true
+        });
+
+        #[derive(Copy, Clone, Debug)]
+        struct Coord {
+            byte_idx: usize,
+            grapheme_idx: usize,
+            stable_row: StableRowIndex,
+        }
+
+        fn found_match(
+            text: &str,
+            byte_idx: usize,
+            lines: &[&Line],
+            stable_idx: StableRowIndex,
+            uniq_matches: &mut HashMap<String, usize>,
+            coords: &mut Option<Vec<Coord>>,
+            results: &mut Vec<SearchResult>,
+        ) {
+            if coords.is_none() {
+                coords.replace(make_coords(lines, stable_idx));
+            }
+            let coords = coords.as_ref().unwrap();
+
+            let match_id = match uniq_matches.get(text).copied() {
+                Some(id) => id,
+                None => {
+                    let id = uniq_matches.len();
+                    uniq_matches.insert(text.to_owned(), id);
+                    id
+                }
+            };
+            let (start_x, start_y) = haystack_idx_to_coord(byte_idx, coords);
+            let (end_x, end_y) = haystack_idx_to_coord(byte_idx + text.len(), coords);
+            results.push(SearchResult {
+                start_x,
+                start_y,
+                end_x,
+                end_y,
+                match_id,
+            });
+        }
+
+        fn make_coords(lines: &[&Line], stable_row: StableRowIndex) -> Vec<Coord> {
+            let mut byte_idx = 0;
+            let mut coords = vec![];
+
+            for (row_idx, line) in lines.iter().enumerate() {
+                for cell in line.visible_cells() {
+                    coords.push(Coord {
+                        byte_idx,
+                        grapheme_idx: cell.cell_index(),
+                        stable_row: stable_row + row_idx as StableRowIndex,
+                    });
+                    byte_idx += cell.str().len();
+                }
+            }
+
+            coords
+        }
+
+        fn haystack_idx_to_coord(idx: usize, coords: &[Coord]) -> (usize, StableRowIndex) {
+            let c = coords
+                .binary_search_by(|ele| ele.byte_idx.cmp(&idx))
+                .or_else(|i| -> Result<usize, usize> { Ok(i) })
+                .unwrap();
+            let coord = coords.get(c).map(|c| *c).unwrap_or_else(|| {
+                let last = coords.last().unwrap();
+                Coord {
+                    grapheme_idx: last.grapheme_idx + 1,
+                    ..*last
+                }
+            });
+            (coord.grapheme_idx, coord.stable_row)
+        }
+
+        Ok(results)
     }
 }
 

--- a/wezterm-gui/src/overlay/copy.rs
+++ b/wezterm-gui/src/overlay/copy.rs
@@ -119,9 +119,14 @@ impl CopyOverlay {
         cursor.shape = termwiz::surface::CursorShape::SteadyBlock;
         cursor.visibility = CursorVisibility::Visible;
 
-        let (_domain, _window, tab_id) = mux::Mux::get()
-            .resolve_pane_id(pane.pane_id())
-            .ok_or_else(|| anyhow::anyhow!("no tab contains the current pane"))?;
+        let tab_id = match term_window.get_active_pane_or_overlay_with_tab_id() {
+            Some((active_pane_or_overlay, tab_id))
+                if active_pane_or_overlay.pane_id() == pane.pane_id() =>
+            {
+                tab_id
+            }
+            _ => return Err(anyhow::anyhow!("no tab contains the current pane")),
+        };
 
         let window = term_window
             .window

--- a/wezterm-gui/src/termwindow/mod.rs
+++ b/wezterm-gui/src/termwindow/mod.rs
@@ -3370,6 +3370,15 @@ impl TermWindow {
         self.pane_state(pane.pane_id()).viewport = None;
     }
 
+    fn get_tab_overlay(&self, tab_id: TabId) -> Option<Arc<dyn Pane>> {
+        self.tab_state(tab_id).overlay.as_ref().map(|overlay| {
+            self.pane_state(overlay.pane.pane_id())
+                .overlay
+                .as_ref()
+                .map_or_else(|| overlay.pane.clone(), |nested| nested.pane.clone())
+        })
+    }
+
     fn get_active_pane_no_overlay(&self) -> Option<Arc<dyn Pane>> {
         let mux = Mux::get();
         mux.get_active_tab_for_window(self.mux_window_id)
@@ -3391,12 +3400,7 @@ impl TermWindow {
 
         let tab_id = tab.tab_id();
 
-        if let Some(tab_overlay) = self
-            .tab_state(tab_id)
-            .overlay
-            .as_ref()
-            .map(|overlay| overlay.pane.clone())
-        {
+        if let Some(tab_overlay) = self.get_tab_overlay(tab_id) {
             Some(tab_overlay)
         } else {
             let pane = tab.get_active_pane()?;
@@ -3406,6 +3410,28 @@ impl TermWindow {
                 .as_ref()
                 .map(|overlay| overlay.pane.clone())
                 .or_else(|| Some(pane))
+        }
+    }
+
+    pub fn get_active_pane_or_overlay_with_tab_id(&self) -> Option<(Arc<dyn Pane>, TabId)> {
+        let mux = Mux::get();
+        let tab = match mux.get_active_tab_for_window(self.mux_window_id) {
+            Some(tab) => tab,
+            None => return None,
+        };
+
+        let tab_id = tab.tab_id();
+
+        if let Some(tab_overlay) = self.get_tab_overlay(tab_id) {
+            Some((tab_overlay, tab_id))
+        } else {
+            let pane = tab.get_active_pane()?;
+            let pane_id = pane.pane_id();
+            self.pane_state(pane_id)
+                .overlay
+                .as_ref()
+                .map(|overlay| (overlay.pane.clone(), tab_id))
+                .or_else(|| Some((pane, tab_id)))
         }
     }
 
@@ -3487,12 +3513,7 @@ impl TermWindow {
     fn get_pos_panes_for_tab(&self, tab: &Arc<Tab>) -> Vec<PositionedPane> {
         let tab_id = tab.tab_id();
 
-        if let Some(pane) = self
-            .tab_state(tab_id)
-            .overlay
-            .as_ref()
-            .map(|overlay| overlay.pane.clone())
-        {
+        if let Some(pane) = self.get_tab_overlay(tab_id) {
             let size = tab.get_size();
             vec![PositionedPane {
                 index: 0,


### PR DESCRIPTION
We can activate CopyMode on all TermwizTerminalPane overlays for tab such as `PromptInputLine`, `InputSelector`, `WindowCloseConfirmation`, `QuitApplication`, `CloseCurrentTab`, `ShowTabNavigator`, `ShowLauncher`, `ShowLauncherArgs`, `ShowDebugOverlay`, `Confirmation`