### PR TITLE
Align with_phys_lines()'s implementation with with_phys_lines_mut()

### DIFF
--- a/term/src/screen.rs
+++ b/term/src/screen.rs
@@ -932,6 +932,7 @@ impl Screen {
         F: FnMut(&[&Line]),
     {
         let (first, second) = self.lines.as_slices();
+        let first_len = first.len();
         let first_range = 0..first.len();
         let second_range = first.len()..first.len() + second.len();
         let first_range = phys_intersection(&first_range, &phys_range);
@@ -941,7 +942,9 @@ impl Screen {
         for line in &first[first_range] {
             lines.push(line);
         }
-        for line in &second[second_range] {
+        for line in &second[second_range.start.saturating_sub(first_len)
+            ..second_range.end.saturating_sub(first_len)]
+        {
             lines.push(line);
         }
         func(&lines)


### PR DESCRIPTION
Hi!

`Screen::with_phys_lines()` calculates the wrong offsets for accessing the second `VecDeque` range. This can be reproduced when the scrollback part of `.lines` get trimmed. `Screen::with_phys_mines_mut()` (which is used by the rest of the codebase) does subtract the length of the first `VecDeque` range and therefore prevents the out of range access. 

This MR aligns the implementations.
