### PR TITLE
Abandon kitty's legacy key event encoding

### DIFF
--- a/wezterm-gui/src/termwindow/keyevent.rs
+++ b/wezterm-gui/src/termwindow/keyevent.rs
@@ -1,4 +1,5 @@
 use crate::termwindow::InputMap;
+use crate::KittyKeyboardFlags;
 use ::window::{
     DeadKeyStatus, KeyCode, KeyEvent, KeyboardLedStatus, Modifiers, RawKeyEvent, WindowOps,
 };
@@ -202,7 +203,11 @@ impl super::TermWindow {
             return None;
         }
         if let KeyboardEncoding::Kitty(flags) = pane.get_keyboard_encoding() {
-            Some(key.encode_kitty(flags))
+            if flags != KittyKeyboardFlags::NONE {
+                Some(key.encode_kitty(flags))
+            } else {
+                None
+            }
         } else {
             None
         }

--- a/wezterm-input-types/src/lib.rs
+++ b/wezterm-input-types/src/lib.rs
@@ -1896,6 +1896,9 @@ impl KeyEvent {
                 if use_legacy {
                     // Legacy text key
                     // https://sw.kovidgoyal.net/kitty/keyboard-protocol/#legacy-text-keys
+                    //
+                    // FIXME: for maximum compatibility, we should use WezTerm's default
+                    // mode here
                     let mut output = String::new();
                     if self.modifiers.contains(Modifiers::ALT) {
                         output.push('\x1b');
@@ -1957,10 +1960,10 @@ impl KeyEvent {
                 format!("\x1b[1;{modifiers}{event_type}{c}")
             }
             Function(n) if *n < 25 => {
-                // The spec says that kitty prefers an SS3 form for F1-F4,
-                // but then has some variance in the encoding and cites a
-                // compatibility issue with a cursor position report.
-                // Since it allows reporting these all unambiguously with
+                // The spec says that two different encodings are possible
+                // for F1, F2 and F4 (the second form is CSI 1 ; modifiers [PQS]),
+                // but cites a compatibility issue with a cursor position report
+                // for F3. Since it allows reporting these all unambiguously with
                 // the same general scheme, that is what we're using here.
                 let intro = match *n {
                     1 => "\x1b[11",


### PR DESCRIPTION
WezTerm incorrectly implements kitty's [Legacy key event encoding](https://sw.kovidgoyal.net/kitty/keyboard-protocol/#legacy-key-event-encoding). This section is not meant to be implemented as a protocol that can be activated. It merely describes the default plain behavior of kitty, which is simply general behavior that most terminals implement very similarly and which must conform to terminfo. As a consequence, there is no mechanism to turn this mode on or off in the kitty specification.

Therefore, WezTerm should not implement the legacy behavior of kitty at all, because its default behavior is already fully sufficient for that purpose. WezTerm (and other terminals) should implement only [Progressive enhancements](https://sw.kovidgoyal.net/kitty/keyboard-protocol/#legacy-key-event-encoding), which are fully switchable. Setting the progressive enhancement flags to 0 should disable the kitty protocol completely. Currently, setting the flags to 0 only switches WezTerm into this "kitty legacy mode", which can't be disabled in any other way than by sending the `pop` (`CSI < u`) sequence repeatedly until there is no pushed state left in the kitty enhancement flags stack.

This bug is reproducible, for example, when using vim: enable `config.enable_kitty_keyboard`, launch vim, and then exit vim.  After that, the arrow keys will not work in bash, producing incompatible kitty sequences. (To make it even worse, unlike kitty itself, WezTerm produces incompatible legacy sequences because it incorrectly sends Num Lock and Caps Lock modifier codes, which are not allowed in legacy mode, and it also sends modifier code even when no modifier is set, which also conflicts with kitty's legacy mode.)

This commit changes the behavior to treat progressive enhancement flags set to 0 as meaning the kitty is completely disabled, which is the correct behavior.

Closes: #3593
Closes: #6434