### PR TITLE
Fix: config max_fps

### DIFF
--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -817,7 +817,7 @@ pub struct Config {
     pub unzoom_on_switch_pane: bool,
 
     #[dynamic(default = "default_max_fps")]
-    pub max_fps: u8,
+    pub max_fps: u64,
 
     #[dynamic(default = "default_shape_cache_size")]
     pub shape_cache_size: usize,
@@ -1802,7 +1802,7 @@ fn default_anim_fps() -> u8 {
     10
 }
 
-fn default_max_fps() -> u8 {
+fn default_max_fps() -> u64 {
     60
 }
 


### PR DESCRIPTION
Fixes https://github.com/wezterm/wezterm/issues/5500

We are already using it as u64 here and there:

<img width="1815" height="450" alt="image" src="https://github.com/user-attachments/assets/f29a67bb-5320-4195-a7e1-80d6607145a4" />

Now gaming monitors can use their desired refresh rate.