### PR TITLE
Remove initial_value param from an example of PromptInputLine.md

### DIFF
--- a/docs/config/lua/keyassignment/PromptInputLine.md
+++ b/docs/config/lua/keyassignment/PromptInputLine.md
@@ -42,7 +42,6 @@ config.keys = {
     mods = 'CTRL|SHIFT',
     action = act.PromptInputLine {
       description = 'Enter new name for tab',
-      initial_value = 'My Tab Name',
       action = wezterm.action_callback(function(window, pane, line)
         -- line will be `nil` if they hit escape without entering anything
         -- An empty string if they just hit enter


### PR DESCRIPTION
Since initial_value is only available in nightly builds the example in the current form errors out for regular builds