### PR TITLE
RemoteSshDomain: Use `sh -c`, not `$SHELL -c`

### DIFF
--- a/mux/src/ssh.rs
+++ b/mux/src/ssh.rs
@@ -307,7 +307,7 @@ impl RemoteSshDomain {
                   case \"$SHELL\" in */zsh|*/bash|*/ksh ) exec -a \"-$(basename $SHELL)\" $SHELL ;; esac ; \
                   exec $SHELL";
 
-                format!("$SHELL -c {}", shell_words::quote(login_shell))
+                format!("sh -c {}", shell_words::quote(login_shell))
             } else {
                 cmd.as_unix_command_line()?
             };


### PR DESCRIPTION
This fixes remote SSH domains for `assume_shell = "Posix"` when the login shell is not a POSIX-compatible `sh`.

Fixes #7377