### PR TITLE
wezterm ssh: add `--assume-shell` argument

### DIFF
--- a/config/src/ssh.rs
+++ b/config/src/ssh.rs
@@ -47,6 +47,18 @@ impl Default for Shell {
     }
 }
 
+impl FromStr for Shell {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Posix" | "posix" => Ok(Self::Posix),
+            "Unknown" | "unknown" => Ok(Self::Unknown),
+            _ => anyhow::bail!("invalid `assume_shell` {s}"),
+        }
+    }
+}
+
 #[derive(Default, Debug, Clone, FromDynamic, ToDynamic)]
 pub struct SshDomain {
     /// The name of this specific domain.  Must be unique amongst

--- a/wezterm-gui-subcommands/src/lib.rs
+++ b/wezterm-gui-subcommands/src/lib.rs
@@ -1,6 +1,6 @@
 use clap::builder::ValueParser;
 use clap::{Parser, ValueHint};
-use config::{GuiPosition, SshParameters};
+use config::{GuiPosition, Shell, SshParameters};
 use std::ffi::OsString;
 use std::path::PathBuf;
 
@@ -135,6 +135,13 @@ pub struct SshCommand {
         value_parser=ValueParser::new(name_equals_value),
         number_of_values = 1)]
     pub config_override: Vec<(String, String)>,
+
+    /// Set the `SshDomain.assume_shell` field for the created domain.
+    ///
+    /// Setting this to `Posix` allows wezterm to open new panes in the same directory as the
+    /// currently-focused pane (as long as your shell emits OSC 7 sequences).
+    #[arg(long = "assume-shell")]
+    pub assume_shell: Option<Shell>,
 
     /// Enable verbose ssh protocol tracing.
     /// The trace information is printed to the stderr stream of

--- a/wezterm-gui/src/main.rs
+++ b/wezterm-gui/src/main.rs
@@ -148,6 +148,7 @@ async fn async_run_ssh(opts: SshCommand) -> anyhow::Result<()> {
         username: opts.user_at_host_and_port.username.clone(),
         multiplexing: SshMultiplexing::None,
         ssh_option,
+        assume_shell: opts.assume_shell.unwrap_or_default(),
         ..Default::default()
     };
 


### PR DESCRIPTION
This corresponds to the `SshDomain.assume_shell` field on `config.ssh_domains` entries, because `wezterm ssh` does not (currently) respect `config.ssh_domains`.

We'll likely want a more sophisticated configuration mechanism here in the future, but this makes it possible to change the assumed shell for `wezterm ssh` sessions.

Closes: #7376