### PR TITLE
Linux install guide: Better place to save APT key

### DIFF
--- a/docs/install/linux.md
+++ b/docs/install/linux.md
@@ -100,9 +100,9 @@ hide:
     steps:
 
     ```console
-    $ curl -fsSL https://apt.fury.io/wez/gpg.key | sudo gpg --yes --dearmor -o /usr/share/keyrings/wezterm-fury.gpg
-    $ echo 'deb [signed-by=/usr/share/keyrings/wezterm-fury.gpg] https://apt.fury.io/wez/ * *' | sudo tee /etc/apt/sources.list.d/wezterm.list
-    $ sudo chmod 644 /usr/share/keyrings/wezterm-fury.gpg
+    $ wget -qO- https://apt.fury.io/wez/gpg.key | sudo gpg --yes --dearmor -o /etc/apt/keyrings/wezterm-fury.gpg
+    $ echo 'deb [signed-by=/etc/apt/keyrings/wezterm-fury.gpg] https://apt.fury.io/wez/ * *' | sudo tee /etc/apt/sources.list.d/wezterm.list
+    $ sudo chmod 644 /etc/apt/keyrings/wezterm-fury.gpg
     ```
 
     Update your dependencies:


### PR DESCRIPTION
This PR improves the installation guides for Debian / Ubuntu.
The key should be saved to _/etc/apt/_, instead of _/usr/share/_, because by convention, the _/usr/share/_ is for files installed by OS package manager. Files added by administrators should be in _/etc/_.
For downloading keys, I also change from `curl` to `wget` because `wget` comes pre-installed on Debian and derivaties, whereas `curl` needs to be installed by users.