### PR TITLE
Introduce sequencing for 'pane focus' related events (Recreated)

### DIFF
--- a/codec/src/lib.rs
+++ b/codec/src/lib.rs
@@ -16,6 +16,7 @@ use config::keyassignment::{PaneDirection, ScrollbackEraseMode};
 use mux::client::{ClientId, ClientInfo};
 use mux::pane::PaneId;
 use mux::renderable::{RenderableDimensions, StableCursorPosition};
+use mux::serial::InputSerial;
 use mux::tab::{PaneNode, SerdeUrl, SplitRequest, TabId};
 use mux::window::WindowId;
 use portable_pty::CommandBuilder;
@@ -24,7 +25,6 @@ use serde::{Deserialize, Serialize};
 use smol::io::AsyncWriteExt;
 use smol::prelude::*;
 use std::collections::HashMap;
-use std::convert::TryInto;
 use std::io::Cursor;
 use std::ops::Range;
 use std::path::PathBuf;
@@ -594,7 +594,7 @@ impl Pdu {
             | Pdu::SetPalette(SetPalette { pane_id, .. })
             | Pdu::NotifyAlert(NotifyAlert { pane_id, .. })
             | Pdu::SetClipboard(SetClipboard { pane_id, .. })
-            | Pdu::PaneFocused(PaneFocused { pane_id })
+            | Pdu::PaneFocused(PaneFocused { pane_id, .. })
             | Pdu::PaneRemoved(PaneRemoved { pane_id }) => Some(*pane_id),
             _ => None,
         }
@@ -722,40 +722,6 @@ pub struct SendKeyDown {
     pub input_serial: InputSerial,
 }
 
-/// InputSerial is used to sequence input requests with output events.
-/// It started life as a monotonic sequence number but evolved into
-/// the number of milliseconds since the unix epoch.
-#[derive(Deserialize, Serialize, PartialEq, Eq, Debug, Clone, Copy, PartialOrd, Ord)]
-pub struct InputSerial(u64);
-
-impl InputSerial {
-    pub const fn empty() -> Self {
-        Self(0)
-    }
-
-    pub fn now() -> Self {
-        std::time::SystemTime::now().into()
-    }
-
-    pub fn elapsed_millis(&self) -> u64 {
-        let now = InputSerial::now();
-        now.0 - self.0
-    }
-}
-
-impl From<std::time::SystemTime> for InputSerial {
-    fn from(val: std::time::SystemTime) -> Self {
-        let duration = val
-            .duration_since(std::time::SystemTime::UNIX_EPOCH)
-            .expect("SystemTime before unix epoch?");
-        let millis: u64 = duration
-            .as_millis()
-            .try_into()
-            .expect("millisecond count to fit in u64");
-        InputSerial(millis)
-    }
-}
-
 #[derive(Deserialize, Serialize, PartialEq, Debug)]
 pub struct SendMouseEvent {
     pub pane_id: PaneId,
@@ -822,6 +788,7 @@ pub struct WindowTitleChanged {
 #[derive(Deserialize, Serialize, PartialEq, Debug)]
 pub struct PaneFocused {
     pub pane_id: PaneId,
+    pub pane_focus_serial: Option<InputSerial>,
 }
 
 #[derive(Deserialize, Serialize, PartialEq, Debug)]
@@ -839,6 +806,7 @@ pub struct SetClientId {
 #[derive(Deserialize, Serialize, PartialEq, Debug)]
 pub struct SetFocusedPane {
     pub pane_id: PaneId,
+    pub pane_focus_serial: Option<InputSerial>,
 }
 
 #[derive(Deserialize, Serialize, PartialEq, Debug)]

--- a/codec/src/lib.rs
+++ b/codec/src/lib.rs
@@ -441,7 +441,7 @@ macro_rules! pdu {
 /// The overall version of the codec.
 /// This must be bumped when backwards incompatible changes
 /// are made to the types and protocol.
-pub const CODEC_VERSION: usize = 45;
+pub const CODEC_VERSION: usize = 46;
 
 // Defines the Pdu enum.
 // Each struct has an explicit identifying number.

--- a/mux/src/lib.rs
+++ b/mux/src/lib.rs
@@ -1,5 +1,6 @@
 use crate::client::{ClientId, ClientInfo};
 use crate::pane::{CachePolicy, Pane, PaneId};
+use crate::serial::InputSerial;
 use crate::ssh_agent::AgentProxy;
 use crate::tab::{SplitRequest, Tab, TabId};
 use crate::window::{Window, WindowId};
@@ -40,6 +41,7 @@ pub mod domain;
 pub mod localpane;
 pub mod pane;
 pub mod renderable;
+pub mod serial;
 pub mod ssh;
 pub mod ssh_agent;
 pub mod tab;
@@ -81,7 +83,10 @@ pub enum MuxNotification {
         tab_id: TabId,
         window_id: WindowId,
     },
-    PaneFocused(PaneId),
+    PaneFocused {
+        pane_id: PaneId,
+        pane_focus_serial: Option<InputSerial>,
+    },
     TabResized(TabId),
     TabTitleChanged {
         tab_id: TabId,
@@ -113,6 +118,7 @@ pub struct Mux {
     num_panes_by_workspace: RwLock<HashMap<String, usize>>,
     main_thread_id: std::thread::ThreadId,
     agent: Option<AgentProxy>,
+    pane_focus_serial: RwLock<InputSerial>,
 }
 
 const BUFSIZE: usize = 1024 * 1024;
@@ -448,6 +454,7 @@ impl Mux {
             num_panes_by_workspace: RwLock::new(HashMap::new()),
             main_thread_id: std::thread::current().id(),
             agent,
+            pane_focus_serial: RwLock::new(InputSerial::empty()),
         }
     }
 
@@ -1396,6 +1403,16 @@ impl Mux {
         }
 
         Ok((tab, pane, window_id))
+    }
+
+    pub fn current_pane_focus_serial(&self) -> InputSerial {
+        *self.pane_focus_serial.read()
+    }
+
+    pub fn increment_pane_focus_serial(&self) -> InputSerial {
+        let mut pane_focus_serial = self.pane_focus_serial.write();
+        *pane_focus_serial = InputSerial::now();
+        *pane_focus_serial
     }
 }
 

--- a/mux/src/lib.rs
+++ b/mux/src/lib.rs
@@ -535,6 +535,7 @@ impl Mux {
             }
         }
         if let Some(pane) = self.get_pane(pane_id) {
+            Mux::get().increment_pane_focus_serial();
             pane.focus_changed(true);
         }
     }

--- a/mux/src/localpane.rs
+++ b/mux/src/localpane.rs
@@ -486,11 +486,6 @@ impl Pane for LocalPane {
     }
 
     fn focus_changed(&self, focused: bool) {
-        if focused {
-            let mux = Mux::get();
-            mux.increment_pane_focus_serial();
-        }
-
         self.terminal.lock().focus_changed(focused);
     }
 

--- a/mux/src/localpane.rs
+++ b/mux/src/localpane.rs
@@ -486,6 +486,11 @@ impl Pane for LocalPane {
     }
 
     fn focus_changed(&self, focused: bool) {
+        if focused {
+            let mux = Mux::get();
+            mux.increment_pane_focus_serial();
+        }
+
         self.terminal.lock().focus_changed(focused);
     }
 

--- a/mux/src/serial.rs
+++ b/mux/src/serial.rs
@@ -1,0 +1,36 @@
+use serde::{Deserialize, Serialize};
+use std::convert::TryInto;
+
+/// InputSerial is used to sequence input requests with output events.
+/// It started life as a monotonic sequence number but evolved into
+/// the number of milliseconds since the unix epoch.
+#[derive(Deserialize, Serialize, PartialEq, Eq, Debug, Clone, Copy, PartialOrd, Ord)]
+pub struct InputSerial(u64);
+
+impl InputSerial {
+    pub const fn empty() -> Self {
+        Self(0)
+    }
+
+    pub fn now() -> Self {
+        std::time::SystemTime::now().into()
+    }
+
+    pub fn elapsed_millis(&self) -> u64 {
+        let now = InputSerial::now();
+        now.0 - self.0
+    }
+}
+
+impl From<std::time::SystemTime> for InputSerial {
+    fn from(val: std::time::SystemTime) -> Self {
+        let duration = val
+            .duration_since(std::time::SystemTime::UNIX_EPOCH)
+            .expect("SystemTime before unix epoch?");
+        let millis: u64 = duration
+            .as_millis()
+            .try_into()
+            .expect("millisecond count to fit in u64");
+        InputSerial(millis)
+    }
+}

--- a/mux/src/tab.rs
+++ b/mux/src/tab.rs
@@ -1779,11 +1779,17 @@ impl TabInner {
             (Some(prior), Some(current)) if prior.pane_id() != current.pane_id() => {
                 prior.focus_changed(false);
                 current.focus_changed(true);
-                mux.notify(MuxNotification::PaneFocused(current.pane_id()));
+                mux.notify(MuxNotification::PaneFocused {
+                    pane_id: current.pane_id(),
+                    pane_focus_serial: None,
+                });
             }
             (None, Some(current)) => {
                 current.focus_changed(true);
-                mux.notify(MuxNotification::PaneFocused(current.pane_id()));
+                mux.notify(MuxNotification::PaneFocused {
+                    pane_id: current.pane_id(),
+                    pane_focus_serial: None,
+                });
             }
             (Some(prior), None) => {
                 prior.focus_changed(false);

--- a/mux/src/tmux_commands.rs
+++ b/mux/src/tmux_commands.rs
@@ -1,6 +1,7 @@
 use crate::domain::{DomainId, WriterWrapper};
 use crate::localpane::LocalPane;
 use crate::pane::{alloc_pane_id, PaneId};
+use crate::serial::InputSerial;
 use crate::tab::{SplitDirection, SplitRequest, SplitSize, Tab, TabId};
 use crate::tmux::{AttachState, TmuxDomain, TmuxDomainState, TmuxRemotePane, TmuxTab};
 use crate::tmux_pty::{TmuxChild, TmuxPty};
@@ -342,7 +343,10 @@ impl TmuxDomainState {
                     match mux.get_tab(local_tab.tab_id) {
                         Some(tab) => {
                             tab.set_active_pane(&local_pane);
-                            mux.notify(MuxNotification::PaneFocused(local_pane.pane_id()));
+                            mux.notify(MuxNotification::PaneFocused {
+                                pane_id: local_pane.pane_id(),
+                                pane_focus_serial: None,
+                            });
                         }
                         None => {}
                     }
@@ -567,7 +571,7 @@ impl TmuxDomainState {
                 }
 
                 match n {
-                    MuxNotification::PaneFocused(pane_id) => {
+                    MuxNotification::PaneFocused { pane_id, .. } => {
                         let tmux_pane_id = match tmux_domain
                             .inner
                             .remote_panes

--- a/wezterm-client/src/domain.rs
+++ b/wezterm-client/src/domain.rs
@@ -8,6 +8,7 @@ use config::{SshDomain, TlsDomainClient, UnixDomain};
 use mux::connui::{ConnectionUI, ConnectionUIParams};
 use mux::domain::{alloc_domain_id, Domain, DomainId, DomainState, SplitSource};
 use mux::pane::{Pane, PaneId};
+use mux::serial::InputSerial;
 use mux::tab::{SplitRequest, Tab, TabId};
 use mux::window::WindowId;
 use mux::{Mux, MuxNotification};

--- a/wezterm-client/src/pane/clientpane.rs
+++ b/wezterm-client/src/pane/clientpane.rs
@@ -12,6 +12,7 @@ use mux::pane::{
     Pattern, SearchResult, WithPaneLines,
 };
 use mux::renderable::{RenderableDimensions, StableCursorPosition};
+use mux::serial::InputSerial;
 use mux::tab::TabId;
 use mux::{Mux, MuxNotification};
 use parking_lot::{MappedMutexGuard, Mutex, MutexGuard};
@@ -214,7 +215,10 @@ impl ClientPane {
 
                 self.client.expire_stale_mappings();
             }
-            Pdu::PaneFocused(PaneFocused { pane_id }) => {
+            Pdu::PaneFocused(PaneFocused {
+                pane_id,
+                pane_focus_serial,
+            }) => {
                 // We get here whenever the pane focus is changed on the
                 // server. That might be due to the user here in the GUI
                 // doing things, or it may be due to a "remote"
@@ -227,8 +231,13 @@ impl ClientPane {
                 log::trace!("advised of remote pane focus: {pane_id}");
 
                 let mux = Mux::get();
-                if let Err(err) = mux.focus_pane_and_containing_tab(self.local_pane_id) {
-                    log::error!("Error reconciling remote PaneFocused notification: {err:#}");
+                let client_pane_focus_serial = mux.current_pane_focus_serial();
+                if pane_focus_serial.is_none_or(|server_pane_focus_serial| {
+                    server_pane_focus_serial >= client_pane_focus_serial
+                }) {
+                    if let Err(err) = mux.focus_pane_and_containing_tab(self.local_pane_id) {
+                        log::error!("Error reconciling remote PaneFocused notification: {err:#}");
+                    }
                 }
             }
             _ => bail!("unhandled unilateral pdu: {:?}", pdu),
@@ -580,13 +589,17 @@ impl Pane for ClientPane {
         let mut focused_pane = self.client.focused_remote_pane_id.lock().unwrap();
         if *focused_pane != Some(self.remote_pane_id) {
             focused_pane.replace(self.remote_pane_id);
+            let mux = Mux::get();
             let client = Arc::clone(&self.client);
             let remote_pane_id = self.remote_pane_id;
+            let pane_focus_serial = Some(mux.increment_pane_focus_serial());
+
             promise::spawn::spawn(async move {
                 client
                     .client
                     .set_focused_pane_id(SetFocusedPane {
                         pane_id: remote_pane_id,
+                        pane_focus_serial,
                     })
                     .await
             })

--- a/wezterm-client/src/pane/renderable.rs
+++ b/wezterm-client/src/pane/renderable.rs
@@ -6,6 +6,7 @@ use config::{configuration, ConfigHandle};
 use lru::LruCache;
 use mux::pane::PaneId;
 use mux::renderable::{RenderableDimensions, StableCursorPosition};
+use mux::serial::InputSerial;
 use mux::Mux;
 use promise::BrokenPromise;
 use rangeset::*;

--- a/wezterm-gui/src/frontend.rs
+++ b/wezterm-gui/src/frontend.rs
@@ -77,7 +77,7 @@ impl GuiFrontEnd {
                     })
                     .detach();
                 }
-                MuxNotification::PaneFocused(pane_id) => {
+                MuxNotification::PaneFocused { pane_id, .. } => {
                     promise::spawn::spawn_into_main_thread(async move {
                         let mux = Mux::get();
                         if let Err(err) = mux.focus_pane_and_containing_tab(pane_id) {

--- a/wezterm-gui/src/termwindow/mod.rs
+++ b/wezterm-gui/src/termwindow/mod.rs
@@ -1297,7 +1297,7 @@ impl TermWindow {
                 MuxNotification::SaveToDownloads { .. } => {
                     // Handled by frontend
                 }
-                MuxNotification::PaneFocused(_) => {
+                MuxNotification::PaneFocused { .. } => {
                     // Also handled by clientpane
                     self.update_title_post_status();
                 }
@@ -1464,7 +1464,7 @@ impl TermWindow {
                     | Alert::SetUserVar { .. }
                     | Alert::Bell,
             }
-            | MuxNotification::PaneFocused(pane_id)
+            | MuxNotification::PaneFocused { pane_id, .. }
             | MuxNotification::PaneRemoved(pane_id)
             | MuxNotification::PaneOutput(pane_id) => {
                 // Ideally we'd check to see if pane_id is part of this window,

--- a/wezterm-mux-server-impl/src/dispatch.rs
+++ b/wezterm-mux-server-impl/src/dispatch.rs
@@ -166,10 +166,16 @@ where
                     stream.flush().await.context("flushing PDU to client")?;
                 }
             }
-            Ok(Item::Notif(MuxNotification::PaneFocused(pane_id))) => {
-                Pdu::PaneFocused(codec::PaneFocused { pane_id })
-                    .encode_async(&mut stream, 0)
-                    .await?;
+            Ok(Item::Notif(MuxNotification::PaneFocused {
+                pane_id,
+                pane_focus_serial,
+            })) => {
+                Pdu::PaneFocused(codec::PaneFocused {
+                    pane_id,
+                    pane_focus_serial,
+                })
+                .encode_async(&mut stream, 0)
+                .await?;
                 stream.flush().await.context("flushing PDU to client")?;
             }
             Ok(Item::Notif(MuxNotification::TabResized(tab_id))) => {

--- a/wezterm-mux-server-impl/src/sessionhandler.rs
+++ b/wezterm-mux-server-impl/src/sessionhandler.rs
@@ -6,6 +6,7 @@ use mux::client::ClientId;
 use mux::domain::SplitSource;
 use mux::pane::{CachePolicy, Pane, PaneId};
 use mux::renderable::{RenderableDimensions, StableCursorPosition};
+use mux::serial::InputSerial;
 use mux::tab::TabId;
 use mux::{Mux, MuxNotification};
 use promise::spawn::spawn_into_main_thread;
@@ -328,7 +329,10 @@ impl SessionHandler {
                 }
                 send_response(Ok(Pdu::UnitResponse(UnitResponse {})))
             }
-            Pdu::SetFocusedPane(SetFocusedPane { pane_id }) => {
+            Pdu::SetFocusedPane(SetFocusedPane {
+                pane_id,
+                pane_focus_serial,
+            }) => {
                 let client_id = self.client_id.clone();
                 spawn_into_main_thread(async move {
                     catch(
@@ -361,7 +365,10 @@ impl SessionHandler {
                             tab.set_active_pane(&pane);
 
                             mux.record_focus_for_current_identity(pane_id);
-                            mux.notify(mux::MuxNotification::PaneFocused(pane_id));
+                            mux.notify(mux::MuxNotification::PaneFocused {
+                                pane_id,
+                                pane_focus_serial,
+                            });
 
                             Ok(Pdu::UnitResponse(UnitResponse {}))
                         },

--- a/wezterm/src/cli/activate_pane.rs
+++ b/wezterm/src/cli/activate_pane.rs
@@ -15,7 +15,10 @@ impl ActivatePane {
     pub async fn run(&self, client: Client) -> anyhow::Result<()> {
         let pane_id = client.resolve_pane_id(self.pane_id).await?;
         client
-            .set_focused_pane_id(codec::SetFocusedPane { pane_id })
+            .set_focused_pane_id(codec::SetFocusedPane {
+                pane_id,
+                pane_focus_serial: None,
+            })
             .await?;
         Ok(())
     }

--- a/wezterm/src/cli/activate_tab.rs
+++ b/wezterm/src/cli/activate_tab.rs
@@ -152,6 +152,7 @@ impl ActivateTab {
         client
             .set_focused_pane_id(codec::SetFocusedPane {
                 pane_id: target_pane,
+                pane_focus_serial: None,
             })
             .await?;
         Ok(())


### PR DESCRIPTION
This is a rebase and an attempt to take into account wez's comments for #6349:
It's been a year without updates from the original PR author, and this issue has been a consistent thorn in my side for a while now, so I took the liberty of recreating the PR and try to get this in.
> Switching between panes (especially over domains where large latencies are involved) can cause a loop where we get stuck repeatedly switching back and forth between two panes. This happens because handlers of PaneFocused events can also produce these events, causing us to get stuck in a loop if we let the GUI process stale PaneFocused events.
> 
> The solution is to introduce a 'serial' (AKA 'sequence number') for GUI-initiated pane focus changes. This will be echo'd back by the server, which allows the GUI to avoid processing the response if it has sent a new request in the mean time. CLI-initiated pane focus changes (eg. via wezterm cli activate-pane) will continue to be unconditionally handled by the client.
> 
> Inspired by https://github.com/wezterm/wezterm/pull/4737 and https://github.com/wezterm/wezterm/pull/4737#issuecomment-1876173247
> 
> Verified activate-pane-direction, activate-pane and activate-tab still work correctly
> 
> closes: https://github.com/wezterm/wezterm/issues/4390
> closes: https://github.com/wezterm/wezterm/issues/4693

Also closes #7388 