### PR TITLE
 Don't draw window decorations in Wayland if `TITLE` is not enabled

### DIFF
--- a/window/src/os/wayland/window.rs
+++ b/window/src/os/wayland/window.rs
@@ -247,7 +247,7 @@ impl WaylandWindow {
         window.set_title(name.to_string());
         let decorations = config.window_decorations;
 
-        let decor_mode = if decorations == WindowDecorations::NONE {
+        let decor_mode = if !decorations.contains(WindowDecorations::TITLE) {
             None
         } else if decorations == WindowDecorations::default() {
             Some(DecorationMode::Server)


### PR DESCRIPTION
The idea of the `INTEGRATED_BUTTONS` is to replace the window close/minimize/maximize buttons in the window title bar. With this change the Wayland mode matches the X11 behaviour. 

