### PR TITLE
Update linux brew install instructions to use formula rather than cask

### DIFF
--- a/docs/install/linux.md
+++ b/docs/install/linux.md
@@ -281,13 +281,14 @@ hide:
 
     ```console
     $ brew tap wezterm/wezterm-linuxbrew
-    $ brew install wezterm
+    $ brew install wezterm/wezterm-linuxbrew/wezterm
+
     ```
 
     If you'd like to use a nightly build you can perform a head install:
 
     ```console
-    $ brew install --HEAD wezterm
+    $ brew install --HEAD wezterm/wezterm-linuxbrew/wezterm
     ```
 
     to upgrade to a newer nightly, it is simplest to remove then
@@ -295,7 +296,7 @@ hide:
 
     ```console
     $ brew rm wezterm
-    $ brew install --HEAD wezterm
+    $ brew install --HEAD wezterm/wezterm-linuxbrew/wezterm
     ```
 === "Nix/NixOS"
 


### PR DESCRIPTION
Correct the linux brew installation instructions to use the formula rather than the cask, as the cask fails to install as it requires MacOS