### PR TITLE
docs(config/launch): use vswhere for Visual Studio launch_menu example (works with VS 2026 / 18.x layout)

### DIFF
--- a/docs/config/launch.md
+++ b/docs/config/launch.md
@@ -179,24 +179,56 @@ if wezterm.target_triple == 'x86_64-pc-windows-msvc' then
     args = { 'powershell.exe', '-NoLogo' },
   })
 
-  -- Find installed visual studio version(s) and add their compilation
-  -- environment command prompts to the menu
-  for _, vsvers in
-    ipairs(
-      wezterm.glob('Microsoft Visual Studio/20*', 'C:/Program Files (x86)')
-    )
-  do
-    local year = vsvers:gsub('Microsoft Visual Studio/', '')
-    table.insert(launch_menu, {
-      label = 'x64 Native Tools VS ' .. year,
-      args = {
-        'cmd.exe',
-        '/k',
-        'C:/Program Files (x86)/'
-          .. vsvers
-          .. '/BuildTools/VC/Auxiliary/Build/vcvars64.bat',
-      },
-    })
+  -- Find installed visual studio version(s) using vswhere.exe and add
+  -- Developer Command Prompt / Developer PowerShell entries.
+  local pf86 = os.getenv('ProgramFiles(x86)') or 'C:/Program Files (x86)'
+  local vswhere = pf86 .. '/Microsoft Visual Studio/Installer/vswhere.exe'
+
+  local ok, stdout, stderr = wezterm.run_child_process({
+    vswhere,
+    '-products',
+    '*',
+    '-requires',
+    'Microsoft.VisualStudio.Component.VC.Tools.x86.x64',
+    '-format',
+    'json',
+  })
+
+  if ok then
+    local installations = wezterm.json_parse(stdout)
+    for _, inst in ipairs(installations) do
+      local install_path = inst.installationPath
+      local label_suffix = inst.displayName or 'Visual Studio'
+
+      -- Developer Command Prompt
+      local vsdevcmd = install_path .. '\\Common7\\Tools\\VsDevCmd.bat'
+      table.insert(launch_menu, {
+        label = 'Developer Command Prompt for ' .. label_suffix,
+        args = { 'cmd.exe', '/k', vsdevcmd, '-arch=amd64', '-host_arch=amd64' },
+      })
+
+      -- Developer PowerShell
+      local devshell = install_path .. '\\Common7\\Tools\\Launch-VsDevShell.ps1'
+      table.insert(launch_menu, {
+        label = 'Developer PowerShell for ' .. label_suffix,
+        args = {
+          'powershell.exe',
+          '-NoLogo',
+          '-NoExit',
+          '-ExecutionPolicy',
+          'Bypass',
+          '-File',
+          devshell,
+          '-SkipAutomaticLocation',
+          '-Arch',
+          'amd64',
+          '-HostArch',
+          'amd64',
+        },
+      })
+    end
+  else
+    wezterm.log_info('vswhere failed: ' .. (stderr or ''))
   end
 end
 


### PR DESCRIPTION
**Problem**

The current windows fancy example in `docs/config/launch.md` discovers vs installations by globbing `wezterm.glob('Microsoft Visual Studio/20*', 'C:/Program Files (x86)')` and then building paths to `vcvars64.bat`. Which is kind of brittle cus 1. it assumes a year-based folder layout (`...\2019\...`, `...\2022\...`) and a specific root (`Program Files (x86)`), which no longer holds consistently for newer installs (at least in vs2026 / 18.x); 2. it also only creates a `cmd.exe` entry, while vs provides both Developer Command Prompt and Developer PowerShell entry points.

**Changes**

Update the snippet to use `vswhere.exe` (as recommended by microsoft) to enumerate vs instances and then add launcher entries for:

- **Developer Command Prompt** via `Common7\Tools\VsDevCmd.bat` with `-arch=amd64 -host_arch=amd64`
- **Developer PowerShell** via `Common7\Tools\Launch-VsDevShell.ps1` with `-SkipAutomaticLocation -Arch amd64 -HostArch amd64`

This uses the `installationPath` returned by vswhere so it should work across versions/editions and across folder layouts.

**References**

- Microsoft Learn: "Tools for detecting and managing Visual Studio instances" (vswhere)  
- Microsoft Learn: “Visual Studio Developer Command Prompt and Developer PowerShell” (VsDevCmd.bat / Launch-VsDevShell.ps1 + supported args)

**Testing**

I tested this on my machine (Windows 11 25H2 Build 26200.7462; wezterm 20240203-110809-5046fc22) and it worked.