### PR TITLE
fix(windows): publish full socket path for CLI discovery

### DIFF
--- a/wezterm-client/src/discovery.rs
+++ b/wezterm-client/src/discovery.rs
@@ -184,11 +184,12 @@ mod windows {
         }
 
         /// Publish path as the path for class_name.
+        /// Note: We publish the full path (not just filename) so that CLI tools
+        /// running from external terminals can connect to the socket.
+        /// See: https://github.com/wezterm/wezterm/issues/4456
         pub fn new(path: &Path, class_name: &str) -> anyhow::Result<Self> {
             let (mutex_name, map_name) = Self::compute_names(class_name);
             let path = path
-                .file_name()
-                .ok_or_else(|| anyhow::anyhow!("path has no file_name!?"))?
                 .to_str()
                 .ok_or_else(|| anyhow::anyhow!("path is not UTF8!"))?
                 .to_string();


### PR DESCRIPTION
## Summary

Fix Windows CLI socket discovery by publishing the full socket path instead of just the filename.

## Problem

On Windows, running `wezterm cli` commands from external terminals (PowerShell, CMD, Git Bash) fails with:
```
ERROR wezterm > failed to connect to Socket("gui-sock-12345"): connecting to gui-sock-12345; terminating
```

The CLI can identify the correct socket filename but cannot connect because the directory path is missing.

## Root Cause

In `wezterm-client/src/discovery.rs`, the `NameHolder::new()` function for Windows was calling `.file_name()` on the path before publishing it to shared memory:

```rust
let path = path
    .file_name()  // <-- This strips the directory!
    .ok_or_else(|| ...)?
```

This meant only `gui-sock-12345` was published instead of the full path like `C:\Users\user\.local\share\wezterm\gui-sock-12345`.

## Fix

Remove the `.file_name()` call so the complete path is published:

```rust
let path = path
    .to_str()
    .ok_or_else(|| ...)?
```

## Testing

- Before fix: `wezterm cli list` from external terminal → fails
- After fix: `wezterm cli list` from external terminal → succeeds
- Commands within WezTerm continue to work (they use `$WEZTERM_UNIX_SOCKET`)

## Workaround (for users on current versions)

Until this is released, users can set the environment variable manually:
```powershell
$env:WEZTERM_UNIX_SOCKET = "$HOME/.local/share/wezterm/gui-sock-$((Get-Process wezterm-gui).Id)"
```

Fixes #4456