### PR TITLE
wezterm-blob-leases: Use uuid v4 over v1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -358,15 +358,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "atomic"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a89cbf775b137e9b968e67227ef7f775587cde3fd31b0d8599dbd0f598a48340"
-dependencies = [
- "bytemuck",
-]
-
-[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3261,16 +3252,6 @@ checksum = "b3a8e7962a5368d5f264d045a5a255e90f9aa3fc1941ae15a8d2940d42cac671"
 dependencies = [
  "cc",
  "which",
-]
-
-[[package]]
-name = "mac_address"
-version = "1.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0aeb26bf5e836cc1c341c8106051b573f1766dfa05aa87f0b98be5e51b02303"
-dependencies = [
- "nix",
- "winapi",
 ]
 
 [[package]]
@@ -6344,7 +6325,6 @@ version = "1.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f87b8aa10b915a06587d0dec516c282ff295b475d94abf425d62b57710070a2"
 dependencies = [
- "atomic",
  "getrandom 0.3.4",
  "js-sys",
  "rand 0.9.2",
@@ -6710,7 +6690,6 @@ name = "wezterm-blob-leases"
 version = "0.1.1"
 dependencies = [
  "getrandom 0.3.4",
- "mac_address",
  "serde",
  "sha2",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -134,7 +134,6 @@ log = "0.4"
 logging = { path = "lua-api-crates/logging" }
 lru = "0.12"
 luahelper = { path = "luahelper" }
-mac_address = "1.1.8"
 maplit = "1.0"
 memmap2 = "0.9"
 memmem = "0.1"

--- a/wezterm-blob-leases/Cargo.toml
+++ b/wezterm-blob-leases/Cargo.toml
@@ -10,12 +10,11 @@ license = "MIT"
 
 [dependencies]
 getrandom.workspace = true
-mac_address.workspace = true
 serde = {workspace=true, features=["derive"], optional=true}
 sha2.workspace = true
 tempfile = {workspace=true, optional=true}
 thiserror.workspace = true
-uuid = {workspace=true, features=["v1", "rng"]}
+uuid = {workspace=true, features=["v4", "rng"]}
 
 [features]
 default = []

--- a/wezterm-blob-leases/src/lease_id.rs
+++ b/wezterm-blob-leases/src/lease_id.rs
@@ -1,4 +1,3 @@
-use std::sync::LazyLock;
 use uuid::Uuid;
 
 /// Represents an individual lease
@@ -14,21 +13,9 @@ impl std::fmt::Display for LeaseId {
     }
 }
 
-fn get_mac_address() -> [u8; 6] {
-    match mac_address::get_mac_address() {
-        Ok(Some(addr)) => addr.bytes(),
-        _ => {
-            let mut mac = [0u8; 6];
-            getrandom::fill(&mut mac).ok();
-            mac
-        }
-    }
-}
-
 impl LeaseId {
     pub fn new() -> Self {
-        static MAC: LazyLock<[u8; 6]> = LazyLock::new(get_mac_address);
-        let uuid = Uuid::now_v1(&*MAC);
+        let uuid = Uuid::new_v4();
         let pid = std::process::id();
         Self { uuid, pid }
     }


### PR DESCRIPTION
Greetings. I'm looking at how much effort it is to make an ipad build, and one issue is dependencies that don't support ios targets. One of those is mac_address, which seems only to be used for creating uuids.

Unless we really want v1 uuids for some reason (e.g. ordering... but the LeaseId doesn't implement Ord), changing to v4 seems like a good way to get rid of the mac_address dependency.

Alternatively, we can use v7 uuid which is random + timestamp instead of mac + timestamp.