### PR TITLE
ringlog: make printing to stderr faster

### DIFF
--- a/env-bootstrap/src/ringlog.rs
+++ b/env-bootstrap/src/ringlog.rs
@@ -188,8 +188,9 @@ impl log::Log for Logger {
                 // to a device that is out of disk space.
                 // <https://github.com/wezterm/wezterm/issues/1839>
                 let mut stderr = std::io::stderr();
-                let _ = writeln!(
-                    stderr,
+                // Direct `write!` will `write()` every single padding space as individual syscall
+                // which makes terminal with tracing logs enabled unusably slow.
+                let logline = format!(
                     "{}  {level_color}{:6}{reset} {target_color}{:padding$}{reset} > {}",
                     ts,
                     level,
@@ -200,6 +201,7 @@ impl log::Log for Logger {
                     reset = reset,
                     target_color = target_color
                 );
+                let _ = stderr.write_all(logline.as_bytes());
                 let _ = stderr.flush();
             }
 


### PR DESCRIPTION
I was trying to debug an issue I'm seeing with wezterm last night and figured I would try to use the terminal for my day-to-day with trace logs enabled while I try to figure it out.

Unfortunately it turned out to be disruptive enough to make the terminal almost unusable. I narrowed at least *that* part down to the fact that printing out each log message would result in about screenful worth of `write(2)` syscalls, many of them printing just one space character each (padding? debug structure identation?)

Although it would be ideal to use a line-based buffered writer here, pre-formatting the log string to a String before printing seemed like a straightforward quick solution and it works amazingly well!