### PR TITLE
log: add a missing newline

### DIFF
--- a/env-bootstrap/src/ringlog.rs
+++ b/env-bootstrap/src/ringlog.rs
@@ -191,7 +191,7 @@ impl log::Log for Logger {
                 // Direct `write!` will `write()` every single padding space as individual syscall
                 // which makes terminal with tracing logs enabled unusably slow.
                 let logline = format!(
-                    "{}  {level_color}{:6}{reset} {target_color}{:padding$}{reset} > {}",
+                    "{}  {level_color}{:6}{reset} {target_color}{:padding$}{reset} > {}\n",
                     ts,
                     level,
                     target,


### PR DESCRIPTION
Sorry, I botched up the previous PR and left out a newline between log messages! This restores the newline.