### PR TITLE
Fix macOS notifications to display as toast popups

### DIFF
--- a/wezterm-toast-notification/src/macos.rs
+++ b/wezterm-toast-notification/src/macos.rs
@@ -47,8 +47,10 @@ define_class!(
             completion_handler: &block2::Block<dyn Fn(UNNotificationPresentationOptions)>,
         ) {
             log::debug!("will_present");
-            let options =
-                UNNotificationPresentationOptions::List | UNNotificationPresentationOptions::Sound;
+            let options = UNNotificationPresentationOptions::List
+                | UNNotificationPresentationOptions::Sound
+                | UNNotificationPresentationOptions::Badge
+                | UNNotificationPresentationOptions::Banner;
             completion_handler.call((options,));
         }
 


### PR DESCRIPTION
Add UNNotificationPresentationOptions::Banner and Badge flags to notification presentation options in macos.rs. This ensures that OSC 9 escape code notifications and window:toast_notification() calls display as visible toast popups on macOS with badge indicators, not just entries in the Notification Center.

Fixes issue where notifications were only shown in Notification Center with sound, but no visible banner popup appeared.

Thanks to @joshuataylor for identifying the issue and suggesting the fix: https://github.com/wezterm/wezterm/issues/5476#issuecomment-3652352095

Fixes #5476