### PR TITLE
Fix COPR build: expand TAR_NAME variable in BUILD_REQUIRES

### DIFF
--- a/ci/deploy.sh
+++ b/ci/deploy.sh
@@ -160,7 +160,7 @@ cargo build --release \
       -p strip-ansi-escapes
 BUILDEOFEOF
 )
-          BUILD_REQUIRES=$(cat <<'BREQEOF'
+          BUILD_REQUIRES=$(cat <<BREQEOF
 BuildRequires: gcc, gcc-c++, make, curl, fontconfig-devel, openssl-devel, libxcb-devel, libxkbcommon-devel, libxkbcommon-x11-devel, wayland-devel, xcb-util-devel, xcb-util-keysyms-devel, xcb-util-image-devel, xcb-util-wm-devel, git
 %if 0%{?suse_version}
 BuildRequires: Mesa-libEGL-devel


### PR DESCRIPTION
The BUILD_REQUIRES heredoc was using a quoted delimiter ('BREQEOF'), which prevented shell variable expansion of ${TAR_NAME}. This caused RPM build errors when the spec file received the literal string "wezterm-${TAR_NAME}.tar.gz" instead of the expanded filename.

Changed to an unquoted delimiter (BREQEOF) to enable variable expansion.

Fixes #7480 