### PR TITLE
feat(macos): add services for opening folders

### DIFF
--- a/assets/macos/WezTerm.app/Contents/Info.plist
+++ b/assets/macos/WezTerm.app/Contents/Info.plist
@@ -86,9 +86,11 @@
 			<string>Folders</string>
 			<key>CFBundleTypeRole</key>
 			<string>Editor</string>
-			<key>CFBundleTypeOSTypes</key>
+			<key>LSHandlerRank</key>
+			<string>Alternate</string>
+			<key>LSItemContentTypes</key>
 			<array>
-				<string>fold</string>
+				<string>public.directory</string>
 			</array>
 		</dict>
 		<dict>
@@ -97,6 +99,47 @@
 			<key>LSItemContentTypes</key>
 			<array>
 				<string>public.unix-executable</string>
+			</array>
+		</dict>
+	</array>
+	<key>NSServices</key>
+	<array>
+		<dict>
+			<key>NSMenuItem</key>
+			<dict>
+				<key>default</key>
+				<string>New WezTerm Window Here</string>
+			</dict>
+			<key>NSMessage</key>
+			<string>openWindow</string>
+			<key>NSRequiredContext</key>
+			<dict>
+				<key>NSTextContent</key>
+				<string>FilePath</string>
+			</dict>
+			<key>NSSendTypes</key>
+			<array>
+				<string>NSFilenamesPboardType</string>
+				<string>public.plain-text</string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSMenuItem</key>
+			<dict>
+				<key>default</key>
+				<string>New WezTerm Tab Here</string>
+			</dict>
+			<key>NSMessage</key>
+			<string>openTab</string>
+			<key>NSRequiredContext</key>
+			<dict>
+				<key>NSTextContent</key>
+				<string>FilePath</string>
+			</dict>
+			<key>NSSendTypes</key>
+			<array>
+				<string>NSFilenamesPboardType</string>
+				<string>public.plain-text</string>
 			</array>
 		</dict>
 	</array>

--- a/wezterm-gui/src/frontend.rs
+++ b/wezterm-gui/src/frontend.rs
@@ -4,7 +4,7 @@ use crate::termwindow::TermWindowNotif;
 use crate::TermWindow;
 use ::window::*;
 use anyhow::{Context, Error};
-use config::keyassignment::{KeyAssignment, SpawnCommand};
+use config::keyassignment::{KeyAssignment, SpawnCommand, SpawnTabDomain};
 use config::{ConfigSubscription, NotificationHandling};
 use mux::client::ClientId;
 use mux::window::WindowId as MuxWindowId;
@@ -230,7 +230,6 @@ impl GuiFrontEnd {
                     }
                 };
                 promise::spawn::spawn(async move {
-                    use config::keyassignment::SpawnTabDomain;
                     use wezterm_term::TerminalSize;
 
                     // We send the script to execute to the shell on stdin, rather than ask the
@@ -268,6 +267,49 @@ impl GuiFrontEnd {
                             log::error!("Failed to spawn {file_name}: {err:#?}");
                         }
                     };
+                })
+                .detach();
+            }
+            ApplicationEvent::OpenDirectory { path, target } => {
+                promise::spawn::spawn(async move {
+                    use wezterm_term::TerminalSize;
+
+                    let mux = Mux::get();
+                    let mut window_id = None;
+                    let pane_id = None;
+                    let cmd = None;
+                    let cwd = Some(path);
+                    let workspace = mux.active_workspace();
+                    let existing_windows = mux.iter_windows_in_workspace(&workspace);
+
+                    if target == OpenTarget::Tab {
+                        if let Some((_domain, focused_window, _tab, _pane)) =
+                            mux.resolve_focused_pane(&front_end().client_id)
+                        {
+                            window_id = Some(focused_window);
+                        } else if let Some(&first) = existing_windows.first() {
+                            window_id = Some(first);
+                        }
+                    }
+
+                    match mux
+                        .spawn_tab_or_window(
+                            window_id,
+                            SpawnTabDomain::DomainName("local".to_string()),
+                            cmd,
+                            cwd,
+                            TerminalSize::default(),
+                            pane_id,
+                            workspace,
+                            None, // optional position
+                        )
+                        .await
+                    {
+                        Ok((_tab, _pane, _new_window_id)) => {}
+                        Err(err) => {
+                            log::error!("Failed to open directory: {err:#?}");
+                        }
+                    }
                 })
                 .detach();
             }

--- a/window/src/connection.rs
+++ b/window/src/connection.rs
@@ -24,6 +24,17 @@ pub enum ApplicationEvent {
     /// The system wants to open a command in the terminal
     OpenCommandScript(String),
     PerformKeyAssignment(KeyAssignment),
+    /// Open a directory via application services
+    OpenDirectory {
+        path: String,
+        target: OpenTarget,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OpenTarget {
+    Window,
+    Tab,
 }
 
 pub trait ConnectionOps {

--- a/window/src/os/macos/app.rs
+++ b/window/src/os/macos/app.rs
@@ -2,8 +2,8 @@ use crate::connection::ConnectionOps;
 use crate::macos::menu::RepresentedItem;
 use crate::macos::{nsstring, nsstring_to_str};
 use crate::menu::{Menu, MenuItem};
-use crate::{ApplicationEvent, Connection};
-use cocoa::appkit::NSApplicationTerminateReply;
+use crate::{ApplicationEvent, Connection, OpenTarget};
+use cocoa::appkit::{NSApp, NSApplicationTerminateReply, NSFilenamesPboardType, NSPasteboard};
 use cocoa::base::id;
 use cocoa::foundation::NSInteger;
 use config::keyassignment::KeyAssignment;
@@ -93,6 +93,35 @@ extern "C" fn application_open_untitled_file(
     NO
 }
 
+extern "C" fn init_service_provider(_this: &mut Object, _sel: Sel) -> *mut Object {
+    unsafe {
+        if let Some(existing) = Class::get("WezTermServiceProvider") {
+            let provider: *mut Object = msg_send![existing, new];
+            return provider;
+        }
+
+        let mut cls = ClassDecl::new("WezTermServiceProvider", class!(NSObject))
+            .expect("Unable to register service provider class");
+        cls.add_method(
+            sel!(openWindow:userData:error:),
+            service_open_window
+                as extern "C" fn(&mut Object, Sel, *mut Object, *mut Object, *mut Object),
+        );
+        cls.add_method(
+            sel!(openTab:userData:error:),
+            service_open_tab
+                as extern "C" fn(&mut Object, Sel, *mut Object, *mut Object, *mut Object),
+        );
+        cls.add_method(
+            sel!(dealloc),
+            service_provider_dealloc as extern "C" fn(&mut Object, Sel),
+        );
+        let provider_class = cls.register();
+        let provider: *mut Object = msg_send![provider_class, new];
+        provider
+    }
+}
+
 extern "C" fn wezterm_perform_key_assignment(
     _self: &mut Object,
     _sel: Sel,
@@ -125,6 +154,90 @@ extern "C" fn application_open_file(
             log::debug!("application_open_file {file_name}");
             conn.dispatch_app_event(ApplicationEvent::OpenCommandScript(file_name));
         }
+    }
+}
+
+extern "C" fn service_open_window(
+    _this: &mut Object,
+    _sel: Sel,
+    pasteboard: *mut Object,
+    _user_data: *mut Object,
+    error: *mut Object,
+) {
+    if let Err(err) = std::panic::catch_unwind(|| {
+        dispatch_service_open(pasteboard, error, OpenTarget::Window);
+    }) {
+        log::error!("service_open_window panicked: {err:?}");
+        unsafe {
+            let msg = nsstring("Service failed. Check logs for details.");
+            let () = msg_send![error, setString: *msg];
+        }
+    }
+}
+
+extern "C" fn service_open_tab(
+    _this: &mut Object,
+    _sel: Sel,
+    pasteboard: *mut Object,
+    _user_data: *mut Object,
+    error: *mut Object,
+) {
+    if let Err(err) = std::panic::catch_unwind(|| {
+        dispatch_service_open(pasteboard, error, OpenTarget::Tab);
+    }) {
+        log::error!("service_open_tab panicked: {err:?}");
+        unsafe {
+            let msg = nsstring("Service failed. Check logs for details.");
+            let () = msg_send![error, setString: *msg];
+        }
+    }
+}
+
+fn dispatch_service_open(pasteboard: *mut Object, error: *mut Object, target: OpenTarget) {
+    unsafe {
+        let plist = NSPasteboard::propertyListForType(pasteboard, NSFilenamesPboardType);
+        if plist.is_null() {
+            let msg = nsstring("Could not load any paths from the clipboard.");
+            let () = msg_send![error, setString: *msg];
+            return;
+        }
+
+        let count: usize = msg_send![plist, count];
+        if count == 0 {
+            let msg = nsstring("Could not load any paths from the clipboard.");
+            let () = msg_send![error, setString: *msg];
+            return;
+        }
+
+        let mut paths = Vec::with_capacity(count);
+        for idx in 0..count {
+            let item: id = msg_send![plist, objectAtIndex: idx];
+            let mut path = nsstring_to_str(item).to_string();
+            let url: id = msg_send![class!(NSURL), fileURLWithPath: item];
+            let is_dir: BOOL = msg_send![url, hasDirectoryPath];
+            if is_dir == NO {
+                let path_ns: id = msg_send![item, stringByDeletingLastPathComponent];
+                path = nsstring_to_str(path_ns).to_string();
+            }
+            paths.push(path);
+        }
+
+        if let Some(conn) = Connection::get() {
+            dispatch_service_paths(paths, target, &conn);
+        }
+    }
+}
+
+fn dispatch_service_paths(paths: Vec<String>, target: OpenTarget, conn: &Connection) {
+    for path in paths {
+        conn.dispatch_app_event(ApplicationEvent::OpenDirectory { path, target });
+    }
+}
+
+extern "C" fn service_provider_dealloc(this: &mut Object, _sel: Sel) {
+    unsafe {
+        let superclass = class!(NSObject);
+        let () = msg_send![super(this, superclass), dealloc];
     }
 }
 
@@ -180,6 +293,10 @@ fn get_class() -> &'static Class {
                 application_open_untitled_file
                     as extern "C" fn(&mut Object, Sel, *mut Object) -> BOOL,
             );
+            cls.add_method(
+                sel!(initServiceProvider),
+                init_service_provider as extern "C" fn(&mut Object, Sel) -> *mut Object,
+            );
         }
 
         cls.register()
@@ -192,6 +309,10 @@ pub fn create_app_delegate() -> StrongPtr {
         let delegate: *mut Object = msg_send![cls, alloc];
         let delegate: *mut Object = msg_send![delegate, init];
         (*delegate).set_ivar("launched", NO);
+
+        let provider: *mut Object = msg_send![delegate, initServiceProvider];
+        let () = msg_send![NSApp(), setServicesProvider: provider];
+
         StrongPtr::new(delegate)
     }
 }


### PR DESCRIPTION
**Summary**: add macOS Services for “New WezTerm Window Here” and “New WezTerm Tab Here”.

**Notes**: current behavior is like Kitty – on first launch via Services it can open two windows. One comes from the normal auto‑spawn `spawn_tab_in_domain_if_mux_is_empty` on startup, and the other comes from the Services handler dispatching `OpenDirectory`. I wanted Ghostty‑style single‑window startup, but that would require restructuring the main startup flow, so I didn’t change it here.

I’m still happy with the current functionality and think it’s useful for macOS users.

<img width="1101" height="705" alt="CleanShot 2026-01-11 at 05 54 11@2x" src="https://github.com/user-attachments/assets/468123ae-573d-4258-a02f-1fc883ca4e1e" />

#3944 

