### PR TITLE
Fix COPR virtual package installation on Fedora 43

### DIFF
--- a/ci/deploy.sh
+++ b/ci/deploy.sh
@@ -193,6 +193,7 @@ License: MIT
 URL: https://wezterm.org/
 Summary: Wez's Terminal Emulator.
 ${BUILD_REQUIRES}
+Requires: wezterm-common, wezterm-gui, wezterm-mux-server
 
 %global debug_package %{nil}
 
@@ -231,9 +232,6 @@ Requires: openssl
 wezterm-mux-server is a headless terminal multiplexer that can be used
 as a session manager for terminal sessions, without requiring X11,
 Wayland, or other GUI libraries.
-
-# Main package (metapackage)
-Requires: wezterm-common, wezterm-gui, wezterm-mux-server
 
 ${BUILD_SECTION}
 


### PR DESCRIPTION
Move the main package Requires directive before subpackage definitions in the RPM spec file. The Requires statement for the main 'wezterm' metapackage must appear before any %package subpackage sections to be properly recognized by RPM. This fixes the issue where installing the 'wezterm' virtual package would install nothing, while installing wezterm-common and wezterm-mux-server separately worked correctly.

Fixes #7502