### PR TITLE
Start stable branch

### DIFF
--- a/get-deps
+++ b/get-deps
@@ -143,6 +143,7 @@ suse_deps() {
 debian_deps() {
   APT="$SUDO apt-get"
   apt-cache show 'libxcb-util-dev' > /dev/null 2>&1 && XCBUTIL="libxcb-util-dev" || XCBUTIL="libxcb-util0-dev"
+  $APT update
   $APT install -y \
     'bsdutils' \
     'cmake' \


### PR DESCRIPTION
Run `apt-get update` and start stable branch

Stable branch is needed to update dependencies and track regressions, such as failure to build from source (https://github.com/wezterm/wezterm/issues/81) occurring in fresh Ubutu 24.04.

This PR should not be merged to `main`. Instead a new branch `stable` needs to be created from the tag `20240203-110809-5046fc22` and the PR needs to be rebased against it.

(t can be used then to test and patch regressions such as https://github.com/flathub/org.wezfurlong.wezterm/pull/23#issuecomment-3761813698 without waiting for `main` to become stable.