### PR TITLE
termwindow: emit tab-focus-changed window event (solves #3098)

### DIFF
--- a/docs/config/lua/window-events/tab-focus-changed.md
+++ b/docs/config/lua/window-events/tab-focus-changed.md
@@ -1,0 +1,31 @@
+# `tab-focus-changed`
+
+{{since('nightly')}}
+
+The `tab-focus-changed` event is emitted when switching to a different tab
+within a window.
+
+This event is fire-and-forget from the perspective of wezterm; it fires the
+event to advise of the tab change, but has no other expectations.
+
+The first event parameter is a [`window` object](../window/index.md) that
+represents the gui window.
+
+The second event parameter is a [`pane` object](../pane/index.md) that
+represents the active pane in the newly focused tab.
+
+```lua
+local wezterm = require 'wezterm'
+
+wezterm.on('tab-focus-changed', function(window, pane)
+  wezterm.log_info(
+    'switched to tab containing pane ',
+    pane:pane_id(),
+    ' in window ',
+    window:window_id()
+  )
+end)
+```
+
+See also [window-focus-changed](window-focus-changed.md) which is emitted when
+the window itself gains or loses focus.

--- a/wezterm-gui/src/termwindow/mod.rs
+++ b/wezterm-gui/src/termwindow/mod.rs
@@ -2203,6 +2203,7 @@ impl TermWindow {
 
             self.update_title();
             self.update_scrollbar();
+            self.emit_window_event("tab-focus-changed", None);
         }
         Ok(())
     }


### PR DESCRIPTION
## Summary

Emits a `tab-focus-changed` window event when a tab receives focus, enabling Lua scripts to respond to tab focus changes. For example, updating a diff viewer's working directory to match the newly focused tab.

Solves https://github.com/wezterm/wezterm/issues/3098

## Changes

- Emit tab-focus-changed window event in activate_tab() when switching to a different tab
- Added documentation for the new event

## Test plan

- Verified event fires when switching tabs via wezterm.on('tab-focus-changed', ...)
- Confirmed window and pane parameters are passed correctly to handler
- Verified event does not fire when clicking the already-active tab
