### PR TITLE
fix(macos): enable dictation by returning valid selectedRange

### DIFF
--- a/window/src/os/macos/window.rs
+++ b/window/src/os/macos/window.rs
@@ -1978,8 +1978,15 @@ impl WindowView {
         }
     }
 
+    // Returns the selected text range. For proper macOS dictation support,
+    // this must return a valid range (not NSNotFound). Since terminals don't
+    // track document positions like text editors, we return position 0 with
+    // no selection (length 0), which signals "cursor at start, no selection".
     extern "C" fn selected_range(_this: &mut Object, _sel: Sel) -> NSRange {
-        NSRange::new(NSNotFound as _, 0)
+        // Return cursor position 0 with no selection (length 0).
+        // Returning NSNotFound breaks macOS dictation/voice input.
+        // See: https://github.com/wezterm/wezterm/issues/4592
+        NSRange::new(0, 0)
     }
 
     // Called by the IME when inserting composed text and/or emoji


### PR DESCRIPTION
## Summary
This PR enables macOS dictation/voice input support by returning a valid `NSRange(0, 0)` from `selectedRange` instead of `NSNotFound`.

## Problem
macOS dictation (voice input) doesn't work in WezTerm because the `selectedRange` method in the `NSTextInputClient` protocol implementation returns `NSNotFound`, which tells macOS there is no valid text cursor position.

## Solution
Return `NSRange::new(0, 0)` (cursor at position 0, no selection) instead of `NSNotFound`. This signals to macOS that there is a valid cursor position where dictated text can be inserted.

## References
- This is the same fix that resolved dictation in Emacs: https://xenodium.com/macos-dictation-returns-to-emacs-fix-merged/
- Tested on macOS - dictation now works correctly

Fixes #4592