### PR TITLE
fix kitty keyboard protocol not work in mux mode

### DIFF
--- a/docs/config/key-encoding.md
+++ b/docs/config/key-encoding.md
@@ -62,6 +62,22 @@ keys (notably: `CMD`/`Super`/`Windows`) to be reported to the application.
 [enable_kitty_keyboard](lua/config/enable_kitty_keyboard.md) controls whether
 wezterm will honor the application requests to modify the keyboard encoding.
 
+### Multiplexing and Kitty keyboard
+
+- **Local panes (default domain):** Kitty keyboard protocol is fully supported.
+  The application’s CSI sequences set the encoding; key events are encoded
+  accordingly and written to the PTY.
+
+- **`wezterm connect` (remote client):** The client sends **SendKeyDown** (raw
+  key + modifiers); the server encodes and writes to the PTY based on the
+  encoding requested by the application (when `enable_kitty_keyboard = true`
+  on the server).
+
+- **attach to tmux:** Kitty keyboard protocol is **not** supported
+  in panes that are attached to a tmux session. Those panes always use Xterm
+  encoding so that keys are passed through to tmux in a compatible way.
+
+- 
 ## Windows
 
 On Windows, [allow_win32_input_mode](lua/config/allow_win32_input_mode.md)

--- a/docs/config/lua/config/enable_kitty_keyboard.md
+++ b/docs/config/lua/config/enable_kitty_keyboard.md
@@ -6,7 +6,8 @@ tags:
 
 {{since('20220624-141144-bd1b7c5d')}}
 
-When set to `true`, wezterm will honor kitty keyboard protocol escape
-sequences that modify the [keyboard encoding](../../key-encoding.md).
+When set to `true`, wezterm will honor kitty keyboard protocol escape sequences
+that modify the [keyboard encoding](../../key-encoding.md), if you want kitty
+keyboard protocol work in mux pane, setting to mux server.
 
 

--- a/docs/multiplexing.md
+++ b/docs/multiplexing.md
@@ -20,6 +20,17 @@ the mouse, clipboard and scrollback features of the terminal.
 Key bindings allow you to spawn new tabs in the default local domain,
 the domain of the current tab, or a specific numbered domain.
 
+Keyboard encoding (including the [Kitty keyboard
+protocol](config/key-encoding.md#kitty-keyboard-protocol)) behaves differently
+per domain: local panes honor Kitty when enabled; `wezterm connect` sessions
+encode on the server side when Kitty is enabled there(`enable_kitty_keyboard =
+true` on the server) 
+
+- panes attached to a tmux session use Xterm encoding only, not possible to
+  enable Kitty Keyboard Protocol.
+- [zellij](https://zellij.dev) support Kitty Keyboard Protocol in wezterm local
+  pane and mux pane
+
 ## SSH Domains
 
 *wezterm also supports [regular ad-hoc ssh connections](ssh.md).


### PR DESCRIPTION
relate issue https://github.com/wezterm/wezterm/issues/7097

Local panes can encode kkp, but mux do not encode properly, 
they are in defferent code path, so this patch fix that.

and add related doc.
