### PR TITLE
fix(mux): ensure runtime directory exists before creating ssh agent symlink

### DIFF
--- a/mux/src/ssh_agent.rs
+++ b/mux/src/ssh_agent.rs
@@ -84,6 +84,14 @@ impl AgentProxy {
         let pid = unsafe { libc::getpid() };
         let sock_path = config::RUNTIME_DIR.join(format!("agent.{pid}"));
 
+        // Ensure the runtime directory exists before creating the symlink
+        if let Err(err) = config::create_user_owned_dirs(&config::RUNTIME_DIR) {
+            log::error!(
+                "failed to create runtime directory {:?}: {err:#}",
+                *config::RUNTIME_DIR
+            );
+        }
+
         if let Some(inherited) = Self::default_ssh_auth_sock() {
             if let Err(err) = update_symlink(&inherited, &sock_path) {
                 log::error!("failed to set {sock_path:?} to initial inherited SSH_AUTH_SOCK value of {inherited:?}: {err:#}");


### PR DESCRIPTION
## Summary
  `AgentProxy::new()` attempts to create a symlink at `RUNTIME_DIR/agent.{pid}` without first ensuring
  that `RUNTIME_DIR` exists. This causes a "No such file or directory" error on startup when the directory
   hasn't been created yet by another component.

  ## Fix
  Call `create_user_owned_dirs()` to ensure the directory exists before attempting to create the symlink.

  ## Before
  ERROR mux::ssh_agent > failed to set "/run/user/1000/wezterm/agent.9458" to initial
  inherited SSH_AUTH_SOCK value of "/run/user/1000/keyring/ssh": failed to create symlink
  /run/user/1000/wezterm/agent.9458 -> /run/user/1000/keyring/ssh: No such file or
  directory (os error 2)

  ## After
  No error — directory is created if missing, symlink succeeds.

  Fixes #6547