### PR TITLE
FIX: propagate --attach flag when delegating to existing GUI

### DIFF
--- a/codec/src/lib.rs
+++ b/codec/src/lib.rs
@@ -441,7 +441,7 @@ macro_rules! pdu {
 /// The overall version of the codec.
 /// This must be bumped when backwards incompatible changes
 /// are made to the types and protocol.
-pub const CODEC_VERSION: usize = 45;
+pub const CODEC_VERSION: usize = 46;
 
 // Defines the Pdu enum.
 // Each struct has an explicit identifying number.
@@ -683,6 +683,9 @@ pub struct SpawnV2 {
     pub command_dir: Option<String>,
     pub size: TerminalSize,
     pub workspace: String,
+    /// If true, attach to the domain and reuse existing panes
+    /// rather than unconditionally spawning a new tab.
+    pub attach: bool,
 }
 
 #[derive(Deserialize, Serialize, PartialEq, Debug)]

--- a/wezterm-client/src/domain.rs
+++ b/wezterm-client/src/domain.rs
@@ -836,6 +836,7 @@ impl Domain for ClientDomain {
                 command,
                 command_dir,
                 workspace,
+                attach: false,
             })
             .await?;
 

--- a/wezterm-gui/src/main.rs
+++ b/wezterm-gui/src/main.rs
@@ -539,6 +539,7 @@ impl Publish {
         workspace: Option<&str>,
         domain: SpawnTabDomain,
         new_tab: bool,
+        attach: bool,
     ) -> anyhow::Result<bool> {
         if let Publish::TryPathOrPublish(gui_sock) = &self {
             let dom = config::UnixDomain {
@@ -612,6 +613,7 @@ impl Publish {
                                         .as_deref()
                                         .unwrap_or(mux::DEFAULT_WORKSPACE)
                                 ).to_string(),
+                                attach,
                             })
                             .await
                     }));
@@ -771,6 +773,7 @@ fn run_terminal_gui(opts: StartCommand, default_domain_name: Option<String>) -> 
             None => SpawnTabDomain::DefaultDomain,
         },
         opts.new_tab,
+        opts.attach,
     )? {
         return Ok(());
     }

--- a/wezterm-mux-server-impl/src/sessionhandler.rs
+++ b/wezterm-mux-server-impl/src/sessionhandler.rs
@@ -3,7 +3,7 @@ use anyhow::{anyhow, Context};
 use codec::*;
 use config::TermConfig;
 use mux::client::ClientId;
-use mux::domain::SplitSource;
+use mux::domain::{DomainState, SplitSource};
 use mux::pane::{CachePolicy, Pane, PaneId};
 use mux::renderable::{RenderableDimensions, StableCursorPosition};
 use mux::tab::TabId;
@@ -1072,6 +1072,31 @@ async fn split_pane(split: SplitPane, client_id: Option<Arc<ClientId>>) -> anyho
 async fn domain_spawn_v2(spawn: SpawnV2, client_id: Option<Arc<ClientId>>) -> anyhow::Result<Pdu> {
     let mux = Mux::get();
     let _identity = mux.with_identity(client_id);
+
+    if spawn.attach {
+        let domain = mux.resolve_spawn_tab_domain(None, &spawn.domain)?;
+
+        if domain.state() == DomainState::Detached {
+            domain.attach(None).await?;
+        }
+
+        let domain_id = domain.domain_id();
+        if let Some(pane) = mux.iter_panes().iter().find(|p| p.domain_id() == domain_id) {
+            let pane_id = pane.pane_id();
+            if let Some((_dom_id, window_id, tab_id)) = mux.resolve_pane_id(pane_id) {
+                let size = mux
+                    .get_tab(tab_id)
+                    .map(|tab| tab.get_size())
+                    .unwrap_or_default();
+                return Ok(Pdu::SpawnResponse(SpawnResponse {
+                    pane_id,
+                    tab_id,
+                    window_id,
+                    size,
+                }));
+            }
+        }
+    }
 
     let (tab, pane, window_id) = mux
         .spawn_tab_or_window(

--- a/wezterm/src/cli/spawn_command.rs
+++ b/wezterm/src/cli/spawn_command.rs
@@ -113,6 +113,7 @@ impl SpawnCommand {
                 command_dir: resolve_relative_cwd(self.cwd)?,
                 size,
                 workspace,
+                attach: false,
             })
             .await?;
 


### PR DESCRIPTION
  Fixes #7582 

- Add `attach: bool` field to `SpawnV2` (codec version 45 → 46)
- Propagate `opts.attach` through `Publish::try_spawn()` into the `SpawnV2` message
- Implement attach semantics in `domain_spawn_v2`: if `attach` is true, resolve and attach to the domain if detached, then return existing pane info if panes are found (mirroring `spawn_tab_in_domain_if_mux_is_empty`), otherwise fall through to spawn as before
- Add `attach: false` to other `SpawnV2` construction sites