### PR TITLE
Fix: flickering across multiple mux clients

### DIFF
--- a/lua-api-crates/mux/src/pane.rs
+++ b/lua-api-crates/mux/src/pane.rs
@@ -3,6 +3,7 @@ use luahelper::mlua::LuaSerdeExt;
 use luahelper::{dynamic_to_lua_value, from_lua, to_lua};
 use mlua::Value;
 use mux::pane::CachePolicy;
+use mux::tab::NotifyMux;
 use std::cmp::Ordering;
 use std::sync::Arc;
 use termwiz::cell::SemanticType;
@@ -424,7 +425,7 @@ impl UserData for MuxPane {
             let tab = mux
                 .get_tab(tab_id)
                 .ok_or_else(|| mlua::Error::external(format!("tab {tab_id} not found")))?;
-            tab.set_active_pane(&pane);
+            tab.set_active_pane(&pane, NotifyMux::Yes);
             Ok(())
         });
 

--- a/mux/src/lib.rs
+++ b/mux/src/lib.rs
@@ -1,15 +1,15 @@
 use crate::client::{ClientId, ClientInfo};
 use crate::pane::{CachePolicy, Pane, PaneId};
 use crate::ssh_agent::AgentProxy;
-use crate::tab::{SplitRequest, Tab, TabId};
+use crate::tab::{NotifyMux, SplitRequest, Tab, TabId};
 use crate::window::{Window, WindowId};
-use anyhow::{anyhow, Context, Error};
+use anyhow::{Context, Error, anyhow};
 use config::keyassignment::SpawnTabDomain;
-use config::{configuration, ExitBehavior, GuiPosition};
+use config::{ExitBehavior, GuiPosition, configuration};
 use domain::{Domain, DomainId, DomainState, SplitSource};
-use filedescriptor::{poll, pollfd, socketpair, AsRawSocketDescriptor, FileDescriptor, POLLIN};
+use filedescriptor::{AsRawSocketDescriptor, FileDescriptor, POLLIN, poll, pollfd, socketpair};
 #[cfg(unix)]
-use libc::{c_int, SOL_SOCKET, SO_RCVBUF, SO_SNDBUF};
+use libc::{SO_RCVBUF, SO_SNDBUF, SOL_SOCKET, c_int};
 use log::error;
 use metrics::histogram;
 use parking_lot::{
@@ -31,7 +31,7 @@ use termwiz::escape::{Action, CSI};
 use thiserror::*;
 use wezterm_term::{Clipboard, ClipboardSelection, DownloadHandler, TerminalSize};
 #[cfg(windows)]
-use winapi::um::winsock2::{SOL_SOCKET, SO_RCVBUF, SO_SNDBUF};
+use winapi::um::winsock2::{SO_RCVBUF, SO_SNDBUF, SOL_SOCKET};
 
 pub mod activity;
 pub mod client;
@@ -559,7 +559,7 @@ impl Mux {
             .get_tab(tab_id)
             .ok_or_else(|| anyhow::anyhow!("tab {tab_id} not found"))?;
 
-        tab.set_active_pane(&pane);
+        tab.set_active_pane(&pane, NotifyMux::No);
 
         Ok(())
     }

--- a/mux/src/tab.rs
+++ b/mux/src/tab.rs
@@ -20,6 +20,12 @@ pub type Cursor = bintree::Cursor<Arc<dyn Pane>, SplitDirectionAndSize>;
 static TAB_ID: ::std::sync::atomic::AtomicUsize = ::std::sync::atomic::AtomicUsize::new(0);
 pub type TabId = usize;
 
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum NotifyMux {
+    Yes,
+    No,
+}
+
 #[derive(Default)]
 struct Recency {
     count: usize,
@@ -698,8 +704,8 @@ impl Tab {
         self.inner.lock().get_active_idx()
     }
 
-    pub fn set_active_pane(&self, pane: &Arc<dyn Pane>) {
-        self.inner.lock().set_active_pane(pane)
+    pub fn set_active_pane(&self, pane: &Arc<dyn Pane>, notify: NotifyMux) {
+        self.inner.lock().set_active_pane(pane, notify)
     }
 
     pub fn set_active_idx(&self, pane_index: usize) {
@@ -1747,7 +1753,7 @@ impl TabInner {
         self.active
     }
 
-    fn set_active_pane(&mut self, pane: &Arc<dyn Pane>) {
+    fn set_active_pane(&mut self, pane: &Arc<dyn Pane>, notify: NotifyMux) {
         let prior = self.get_active_pane();
 
         if is_pane(pane, &prior.as_ref()) {
@@ -1768,22 +1774,26 @@ impl TabInner {
         {
             self.active = item.index;
             self.recency.tag(item.index);
-            self.advise_focus_change(prior);
+            self.advise_focus_change(prior, notify);
         }
     }
 
-    fn advise_focus_change(&mut self, prior: Option<Arc<dyn Pane>>) {
+    fn advise_focus_change(&mut self, prior: Option<Arc<dyn Pane>>, notify: NotifyMux) {
         let mux = Mux::get();
         let current = self.get_active_pane();
         match (prior, current) {
             (Some(prior), Some(current)) if prior.pane_id() != current.pane_id() => {
                 prior.focus_changed(false);
                 current.focus_changed(true);
-                mux.notify(MuxNotification::PaneFocused(current.pane_id()));
+                if notify == NotifyMux::Yes {
+                    mux.notify(MuxNotification::PaneFocused(current.pane_id()));
+                }
             }
             (None, Some(current)) => {
                 current.focus_changed(true);
-                mux.notify(MuxNotification::PaneFocused(current.pane_id()));
+                if notify == NotifyMux::Yes {
+                    mux.notify(MuxNotification::PaneFocused(current.pane_id()));
+                }
             }
             (Some(prior), None) => {
                 prior.focus_changed(false);
@@ -1798,7 +1808,7 @@ impl TabInner {
         let prior = self.get_active_pane();
         self.active = pane_index;
         self.recency.tag(pane_index);
-        self.advise_focus_change(prior);
+        self.advise_focus_change(prior, NotifyMux::Yes);
     }
 
     fn assign_pane(&mut self, pane: &Arc<dyn Pane>) {
@@ -1861,7 +1871,7 @@ impl TabInner {
         if keep_focus {
             self.set_active_idx(pane_index);
         } else {
-            self.advise_focus_change(Some(pane));
+            self.advise_focus_change(Some(pane), NotifyMux::Yes);
         }
         None
     }
@@ -2338,15 +2348,16 @@ mod test {
         assert_eq!(80, panes[0].width);
         assert_eq!(24, panes[0].height);
 
-        assert!(tab
-            .compute_split_size(
+        assert!(
+            tab.compute_split_size(
                 1,
                 SplitRequest {
                     direction: SplitDirection::Horizontal,
                     ..Default::default()
                 }
             )
-            .is_none());
+            .is_none()
+        );
 
         let horz_size = tab
             .compute_split_size(

--- a/mux/src/tmux_commands.rs
+++ b/mux/src/tmux_commands.rs
@@ -1,18 +1,18 @@
 use crate::domain::{DomainId, WriterWrapper};
 use crate::localpane::LocalPane;
-use crate::pane::{alloc_pane_id, PaneId};
-use crate::tab::{SplitDirection, SplitRequest, SplitSize, Tab, TabId};
+use crate::pane::{PaneId, alloc_pane_id};
+use crate::tab::{NotifyMux, SplitDirection, SplitRequest, SplitSize, Tab, TabId};
 use crate::tmux::{AttachState, TmuxDomain, TmuxDomainState, TmuxRemotePane, TmuxTab};
 use crate::tmux_pty::{TmuxChild, TmuxPty};
 use crate::{Mux, MuxNotification, Pane};
-use anyhow::{anyhow, Context};
+use anyhow::{Context, anyhow};
 use parking_lot::{Condvar, Mutex};
 use portable_pty::{MasterPty, PtySize};
 use std::collections::HashSet;
 use std::fmt::{Debug, Write};
 use std::io::Write as _;
 use std::sync::Arc;
-use termwiz::escape::csi::{Cursor, CSI};
+use termwiz::escape::csi::{CSI, Cursor};
 use termwiz::escape::{Action, OneBased};
 use termwiz::tmux_cc::*;
 use wezterm_term::TerminalSize;
@@ -341,7 +341,7 @@ impl TmuxDomainState {
 
                     match mux.get_tab(local_tab.tab_id) {
                         Some(tab) => {
-                            tab.set_active_pane(&local_pane);
+                            tab.set_active_pane(&local_pane, NotifyMux::No);
                             mux.notify(MuxNotification::PaneFocused(local_pane.pane_id()));
                         }
                         None => {}

--- a/wezterm-client/src/pane/clientpane.rs
+++ b/wezterm-client/src/pane/clientpane.rs
@@ -1,6 +1,6 @@
 use crate::domain::ClientInner;
 use crate::pane::mousestate::MouseState;
-use crate::pane::renderable::{hydrate_lines, RenderableInner, RenderableState};
+use crate::pane::renderable::{RenderableInner, RenderableState, hydrate_lines};
 use anyhow::bail;
 use async_trait::async_trait;
 use codec::*;
@@ -8,8 +8,8 @@ use config::configuration;
 use config::keyassignment::ScrollbackEraseMode;
 use mux::domain::DomainId;
 use mux::pane::{
-    alloc_pane_id, CachePolicy, CloseReason, ForEachPaneLogicalLine, LogicalLine, Pane, PaneId,
-    Pattern, SearchResult, WithPaneLines,
+    CachePolicy, CloseReason, ForEachPaneLogicalLine, LogicalLine, Pane, PaneId, Pattern,
+    SearchResult, WithPaneLines, alloc_pane_id,
 };
 use mux::renderable::{RenderableDimensions, StableCursorPosition};
 use mux::tab::TabId;
@@ -45,6 +45,7 @@ pub struct ClientPane {
     clipboard: Mutex<Option<Arc<dyn Clipboard>>>,
     mouse_grabbed: Mutex<bool>,
     ignore_next_kill: Mutex<bool>,
+    suppress_next_focus_advise: Mutex<bool>,
     user_vars: Mutex<HashMap<String, String>>,
     config: Mutex<Option<Arc<dyn TerminalConfiguration>>>,
     unseen_output: Mutex<bool>,
@@ -127,6 +128,7 @@ impl ClientPane {
             clipboard: Mutex::new(None),
             mouse_grabbed: Mutex::new(false),
             ignore_next_kill: Mutex::new(false),
+            suppress_next_focus_advise: Mutex::new(false),
             unseen_output: Mutex::new(false),
             user_vars: Mutex::new(HashMap::new()),
             config: Mutex::new(None),
@@ -225,6 +227,7 @@ impl ClientPane {
                 // has been changed on the server, so we work to apply
                 // it here.
                 log::trace!("advised of remote pane focus: {pane_id}");
+                *self.suppress_next_focus_advise.lock() = true;
 
                 let mux = Mux::get();
                 if let Err(err) = mux.focus_pane_and_containing_tab(self.local_pane_id) {
@@ -556,8 +559,13 @@ impl Pane for ClientPane {
 
     fn focus_changed(&self, focused: bool) {
         if focused {
-            self.advise_focus();
+            let suppress = std::mem::replace(&mut *self.suppress_next_focus_advise.lock(), false);
+            if !suppress {
+                self.advise_focus();
+            }
             *self.unseen_output.lock() = false;
+        } else {
+            *self.suppress_next_focus_advise.lock() = false;
         }
     }
 

--- a/wezterm-mux-server-impl/src/sessionhandler.rs
+++ b/wezterm-mux-server-impl/src/sessionhandler.rs
@@ -1,12 +1,12 @@
 use crate::PKI;
-use anyhow::{anyhow, Context};
+use anyhow::{Context, anyhow};
 use codec::*;
 use config::TermConfig;
 use mux::client::ClientId;
 use mux::domain::SplitSource;
 use mux::pane::{CachePolicy, Pane, PaneId};
 use mux::renderable::{RenderableDimensions, StableCursorPosition};
-use mux::tab::TabId;
+use mux::tab::{NotifyMux, TabId};
 use mux::{Mux, MuxNotification};
 use promise::spawn::spawn_into_main_thread;
 use std::collections::HashMap;
@@ -14,8 +14,8 @@ use std::sync::{Arc, Mutex};
 use std::time::Instant;
 use termwiz::surface::SequenceNo;
 use url::Url;
-use wezterm_term::terminal::Alert;
 use wezterm_term::StableRowIndex;
+use wezterm_term::terminal::Alert;
 
 #[derive(Clone)]
 pub struct PduSender {
@@ -358,7 +358,7 @@ impl SessionHandler {
                             let tab = mux
                                 .get_tab(tab_id)
                                 .ok_or_else(|| anyhow::anyhow!("tab {tab_id} not found"))?;
-                            tab.set_active_pane(&pane);
+                            tab.set_active_pane(&pane, NotifyMux::No);
 
                             mux.record_focus_for_current_identity(pane_id);
                             mux.notify(mux::MuxNotification::PaneFocused(pane_id));
@@ -564,14 +564,14 @@ impl SessionHandler {
                                     if is_zoomed != zoomed {
                                         tab.set_zoomed(false);
                                         if zoomed {
-                                            tab.set_active_pane(&pane);
+                                            tab.set_active_pane(&pane, NotifyMux::Yes);
                                             tab.set_zoomed(zoomed);
                                         }
                                     }
                                 }
                                 None => {
                                     if zoomed {
-                                        tab.set_active_pane(&pane);
+                                        tab.set_active_pane(&pane, NotifyMux::Yes);
                                         tab.set_zoomed(zoomed);
                                     }
                                 }
@@ -974,7 +974,7 @@ impl SessionHandler {
                                     return Err(anyhow!(
                                         "Failed to retrieve tab with ID {}",
                                         tab_id
-                                    ))
+                                    ));
                                 }
                             };
 


### PR DESCRIPTION
fixes: #6885 

I had the same constant flickering issue, when logging in on macbook+windows to my linux box.

When multiple clients are connected to the same mux server, changing pane focus creates a feedback loop: the client tells the server, the server broadcasts back to all clients, and the receiving client treats it as a new focus change and tells the server again, causing the screen to flash repeatedly.

The fix breaks this loop by distinguishing server-originated focus changes from local ones. `set_active_pane` takes a `NotifyMux` flag so that focus changes applied from the server don't re-broadcast, and `ClientPane` suppresses the next `advise_focus` call after receiving a `PaneFocused` notification from the server.

I've been testing for about a week with no flickering.