### PR TITLE
theme: add humans color schema

### DIFF
--- a/docs/colorschemes/data.json
+++ b/docs/colorschemes/data.json
@@ -18964,6 +18964,86 @@
   {
     "colors": {
       "ansi": [
+        "#1f2328",
+        "#ff8142",
+        "#32cd32",
+        "#ffd700",
+        "#1e90ff",
+        "#ff69b4",
+        "#00ced1",
+        "#ffffff"
+      ],
+      "background": "#191917",
+      "brights": [
+        "#808080",
+        "#ff5e26",
+        "#4ee44e",
+        "#ffeb3b",
+        "#42a5f5",
+        "#ff80ab",
+        "#4dd0e1",
+        "#ffffff"
+      ],
+      "cursor_bg": "#f3f3f3",
+      "cursor_border": "#f3f3f3",
+      "cursor_fg": "#191917",
+      "foreground": "#f3f3f3",
+      "indexed": {},
+      "selection_bg": "#ad7fa8",
+      "selection_fg": "#f3f3f3"
+    },
+    "metadata": {
+      "aliases": [],
+      "author": "Ender Bonnet (@enbonnet)",
+      "name": "Humans",
+      "origin_url": "https://github.com/enBonnet/humans-color-schemes",
+      "prefix": "h",
+      "wezterm_version": "20220807-113146-c2fee766"
+    }
+  },
+  {
+    "colors": {
+      "ansi": [
+        "#1f2328",
+        "#ff8142",
+        "#32cd32",
+        "#ffd700",
+        "#1e90ff",
+        "#ff69b4",
+        "#00ced1",
+        "#000000"
+      ],
+      "background": "#f6f8fa",
+      "brights": [
+        "#808080",
+        "#ff3c00",
+        "#32cd32",
+        "#ffd700",
+        "#1e90ff",
+        "#ff69b4",
+        "#00ced1",
+        "#000000"
+      ],
+      "cursor_bg": "#1f2328",
+      "cursor_border": "#1f2328",
+      "cursor_fg": "#f6f8fa",
+      "foreground": "#1f2328",
+      "indexed": {},
+      "selection_bg": "#75507b",
+      "selection_fg": "#1f2328"
+    },
+    "metadata": {
+      "aliases": [],
+      "author": "Ender Bonnet (@enbonnet)",
+      "name": "Humans Light",
+      "origin_url": "https://github.com/enBonnet/humans-color-schemes",
+      "prefix": "h",
+      "wezterm_version": "20220807-113146-c2fee766"
+    }
+  },
+  {
+    "colors": {
+      "ansi": [
         "#222222",
         "#e84f4f",
         "#b7ce42",


### PR DESCRIPTION
Adding the humans theme, those are the previews:

|Dark|Light|
|---|---|
|<img width="551" height="333" alt="gyw-dark" src="https://github.com/user-attachments/assets/bf51d904-c70e-44fd-be31-d0720a476415" />|<img width="557" height="336" alt="gyw-light" src="https://github.com/user-attachments/assets/a25ae70d-fa08-4c3f-bab7-551758b2fb6a" />|
|<img width="422" height="127" alt="preview-dark" src="https://github.com/user-attachments/assets/9c36bd7b-0642-4890-a780-f33483fbfd95" />|<img width="420" height="124" alt="preview-light" src="https://github.com/user-attachments/assets/3a93dd67-30d7-467a-b80c-43a742092ec1" />|
