### PR TITLE
feat: add `CommandBuilder::creation_flags`

### DIFF
--- a/pty/src/cmdbuilder.rs
+++ b/pty/src/cmdbuilder.rs
@@ -207,6 +207,8 @@ pub struct CommandBuilder {
     #[cfg(unix)]
     pub(crate) umask: Option<libc::mode_t>,
     controlling_tty: bool,
+    #[cfg(windows)]
+    pub(crate) creation_flags: u32,
 }
 
 impl CommandBuilder {
@@ -220,6 +222,8 @@ impl CommandBuilder {
             #[cfg(unix)]
             umask: None,
             controlling_tty: true,
+            #[cfg(windows)]
+            creation_flags: 0,
         }
     }
 
@@ -232,6 +236,8 @@ impl CommandBuilder {
             #[cfg(unix)]
             umask: None,
             controlling_tty: true,
+            #[cfg(windows)]
+            creation_flags: 0,
         }
     }
 
@@ -259,6 +265,8 @@ impl CommandBuilder {
             #[cfg(unix)]
             umask: None,
             controlling_tty: true,
+            #[cfg(windows)]
+            creation_flags: 0,
         }
     }
 
@@ -758,6 +766,15 @@ impl CommandBuilder {
             i += 1;
         }
         cmdline.push('"' as u16);
+    }
+
+    /// Sets the [process creation flags] to be passed to `CreateProcess`.
+    ///
+    /// These will always be ORed with `EXTENDED_STARTUPINFO_PRESENT |CREATE_UNICODE_ENVIRONMENT`.
+    ///
+    /// [process creation flags]: https://docs.microsoft.com/en-us/windows/win32/procthread/process-creation-flags
+    pub fn creation_flags(&mut self, flags: u32) {
+        self.creation_flags = flags;
     }
 }
 

--- a/pty/src/win/psuedocon.rs
+++ b/pty/src/win/psuedocon.rs
@@ -135,6 +135,9 @@ impl PsuedoCon {
 
         let cwd = cmd.current_directory();
 
+        let creation_flags =
+            EXTENDED_STARTUPINFO_PRESENT | CREATE_UNICODE_ENVIRONMENT | cmd.creation_flags;
+
         let res = unsafe {
             CreateProcessW(
                 exe.as_mut_slice().as_mut_ptr(),
@@ -142,7 +145,7 @@ impl PsuedoCon {
                 ptr::null_mut(),
                 ptr::null_mut(),
                 0,
-                EXTENDED_STARTUPINFO_PRESENT | CREATE_UNICODE_ENVIRONMENT,
+                creation_flags,
                 cmd.environment_block().as_mut_slice().as_mut_ptr() as *mut _,
                 cwd.as_ref()
                     .map(|c| c.as_slice().as_ptr())


### PR DESCRIPTION
This adds support for passing creation_flags similar to Rust std::Command::creation_flags