### PR TITLE
feat: add option to disable usage of `PSUEDOCONSOLE_INHERIT_CURSOR`

### DIFF
--- a/pty/src/win/conpty.rs
+++ b/pty/src/win/conpty.rs
@@ -6,8 +6,29 @@ use filedescriptor::{FileDescriptor, Pipe};
 use std::sync::{Arc, Mutex};
 use winapi::um::wincon::COORD;
 
-#[derive(Default)]
-pub struct ConPtySystem {}
+pub struct ConPtySystem {
+    inherit_cursor: bool,
+}
+
+impl Default for ConPtySystem {
+    fn default() -> Self {
+        Self {
+            inherit_cursor: true,
+        }
+    }
+}
+
+impl ConPtySystem {
+    /// Whether the cursor should be inherited, enabled by default.
+    ///
+    /// This corresponds to [`PSUEDOCONSOLE_INHERIT_CURSOR`]
+    ///
+    /// [`PSUEDOCONSOLE_INHERIT_CURSOR`]: https://learn.microsoft.com/en-us/windows/console/createpseudoconsole
+    pub fn inherit_cursor(mut self, inherit: bool) -> Self {
+        self.inherit_cursor = inherit;
+        self
+    }
+}
 
 impl PtySystem for ConPtySystem {
     fn openpty(&self, size: PtySize) -> anyhow::Result<PtyPair> {
@@ -21,6 +42,7 @@ impl PtySystem for ConPtySystem {
             },
             stdin.read,
             stdout.write,
+            self.inherit_cursor,
         )?;
 
         let master = ConPtyMasterPty {

--- a/pty/src/win/psuedocon.rs
+++ b/pty/src/win/psuedocon.rs
@@ -77,16 +77,25 @@ impl Drop for PsuedoCon {
 }
 
 impl PsuedoCon {
-    pub fn new(size: COORD, input: FileDescriptor, output: FileDescriptor) -> Result<Self, Error> {
+    pub fn new(
+        size: COORD,
+        input: FileDescriptor,
+        output: FileDescriptor,
+        inherit_cursor: bool,
+    ) -> Result<Self, Error> {
         let mut con: HPCON = INVALID_HANDLE_VALUE;
+
+        let mut flags = PSEUDOCONSOLE_RESIZE_QUIRK | PSEUDOCONSOLE_WIN32_INPUT_MODE;
+        if inherit_cursor {
+            flags |= PSUEDOCONSOLE_INHERIT_CURSOR;
+        }
+
         let result = unsafe {
             (CONPTY.CreatePseudoConsole)(
                 size,
                 input.as_raw_handle() as _,
                 output.as_raw_handle() as _,
-                PSUEDOCONSOLE_INHERIT_CURSOR
-                    | PSEUDOCONSOLE_RESIZE_QUIRK
-                    | PSEUDOCONSOLE_WIN32_INPUT_MODE,
+                flags,
                 &mut con,
             )
         };


### PR DESCRIPTION
When cursor is inherited, I get the following when running the bash example:

```
You can now type commands for Bash (type 'exit' to quit):
^[[25;1R
```
and then it just freezes

I couldn't figure if there is a way to fix this so I thought I'd just make it configurable 