### PR TITLE
feat: add `Child::main_thread_handle`

### DIFF
--- a/pty/src/lib.rs
+++ b/pty/src/lib.rs
@@ -143,6 +143,10 @@ pub trait Child: std::fmt::Debug + ChildKiller + Downcast + Send {
     /// Only available on Windows.
     #[cfg(windows)]
     fn as_raw_handle(&self) -> Option<std::os::windows::io::RawHandle>;
+    /// Returns a handle to the main thread of the child process, if applicable.
+    /// Only available on Windows.
+    #[cfg(windows)]
+    fn main_thread_handle(&self) -> Option<std::os::windows::io::BorrowedHandle<'_>>;
 }
 impl_downcast!(Child);
 
@@ -287,6 +291,14 @@ impl Child for std::process::Child {
     #[cfg(windows)]
     fn as_raw_handle(&self) -> Option<std::os::windows::io::RawHandle> {
         Some(std::os::windows::io::AsRawHandle::as_raw_handle(self))
+    }
+
+    #[cfg(windows)]
+    fn main_thread_handle(&self) -> Option<std::os::windows::io::BorrowedHandle<'_>> {
+        // TODO: once `windows_process_extensions_main_thread_handle` is stabilized
+        // we should return the main thread handle here instead of None.
+        // Some(std::os::windows::process::ChildExt::main_thread_handle(self))
+        None
     }
 }
 

--- a/pty/src/serial.rs
+++ b/pty/src/serial.rs
@@ -164,6 +164,11 @@ impl Child for SerialChild {
     fn as_raw_handle(&self) -> Option<std::os::windows::io::RawHandle> {
         None
     }
+
+    #[cfg(windows)]
+    fn main_thread_handle(&self) -> Option<std::os::windows::io::BorrowedHandle<'_>> {
+        None
+    }
 }
 
 impl ChildKiller for SerialChild {

--- a/pty/src/win/mod.rs
+++ b/pty/src/win/mod.rs
@@ -20,6 +20,7 @@ use filedescriptor::OwnedHandle;
 #[derive(Debug)]
 pub struct WinChild {
     proc: Mutex<OwnedHandle>,
+    main_thread: Mutex<OwnedHandle>,
 }
 
 impl WinChild {
@@ -118,6 +119,12 @@ impl Child for WinChild {
     fn as_raw_handle(&self) -> Option<std::os::windows::io::RawHandle> {
         let proc = self.proc.lock().unwrap();
         Some(proc.as_raw_handle())
+    }
+
+    fn main_thread_handle(&self) -> Option<std::os::windows::io::BorrowedHandle<'_>> {
+        let main_thread = self.main_thread.lock().unwrap();
+        let raw_handle = main_thread.as_raw_handle();
+        Some(unsafe { std::os::windows::io::BorrowedHandle::borrow_raw(raw_handle) })
     }
 }
 

--- a/pty/src/win/psuedocon.rs
+++ b/pty/src/win/psuedocon.rs
@@ -165,11 +165,12 @@ impl PsuedoCon {
 
         // Make sure we close out the thread handle so we don't leak it;
         // we do this simply by making it owned
-        let _main_thread = unsafe { OwnedHandle::from_raw_handle(pi.hThread as _) };
+        let main_thread = unsafe { OwnedHandle::from_raw_handle(pi.hThread as _) };
         let proc = unsafe { OwnedHandle::from_raw_handle(pi.hProcess as _) };
 
         Ok(WinChild {
             proc: Mutex::new(proc),
+            main_thread: Mutex::new(main_thread),
         })
     }
 }


### PR DESCRIPTION
With this PR and #7604 , I can created a suspended PTY, inject a DLL, assign to a Job object...etc and then later call `ResumeThread`