### PR TITLE
Implement tab:move_to_window method to allow moving tabs between windows using Lua

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -22,6 +22,8 @@ usually the best available version.
 As features stabilize some brief notes about them will accumulate here.
 
 #### Changed
+* Added [tab:move_to_window()](config/lua/MuxTab/move_to_window.md) method to move
+  entire tabs (including all panes and split layouts) between windows.
 * Wayland: currently being reimplemented, it maybe more unstable than usual.
   Please file GH issues for any problems you see.
   Many thanks to @tzx and @tmccombs! #4777 #5781

--- a/docs/config/lua/MuxTab/move_to_window.md
+++ b/docs/config/lua/MuxTab/move_to_window.md
@@ -1,0 +1,64 @@
+# `tab:move_to_window(target_window)`
+
+{{since('nightly')}}
+
+Moves the tab (including all its panes and split layout) from its current window
+to the specified target window. The tab is appended to the end of the target window's
+tab list.
+
+Returns `true` on success.
+
+## Parameters
+
+- `target_window` - A [MuxWindow](../mux-window/index.md) object representing the
+  destination window
+
+## Returns
+
+Returns `true` on success. Raises a Lua error if the operation fails.
+
+## Example
+
+```lua
+local wezterm = require 'wezterm'
+local config = wezterm.config_builder()
+
+config.keys = {
+  {
+    key = 'M',
+    mods = 'LEADER|SHIFT',
+    action = wezterm.action_callback(function(win, pane)
+      local tab = pane:tab()
+      local windows = wezterm.mux.all_windows()
+
+      -- Move current tab to the next window
+      if #windows >= 2 then
+        local current_window = pane:window()
+        for _, w in ipairs(windows) do
+          if w:window_id() ~= current_window:window_id() then
+            tab:move_to_window(w)
+            break
+          end
+        end
+      end
+    end),
+  },
+}
+
+return config
+```
+
+## Notes
+
+- If the tab is already in the target window, this is a no-op
+- The source window gets closed if it becomes empty after the move
+- All panes and their split layout within the tab are preserved
+- The target window's currently active tab is not changed
+
+## See Also
+
+- [tab:activate()](activate.md)
+- [pane:move_to_new_tab()](../pane/move_to_new_tab.md)
+- [pane:move_to_new_window()](../pane/move_to_new_window.md)
+- [wezterm.mux.all_windows()](../mux/all_windows.md)
+- [MuxWindow](../mux-window/index.md)

--- a/docs/config/lua/MuxTab/move_to_window.md
+++ b/docs/config/lua/MuxTab/move_to_window.md
@@ -6,7 +6,8 @@ Moves the tab (including all its panes and split layout) from its current window
 to the specified target window. The tab is appended to the end of the target window's
 tab list.
 
-Returns `true` on success.
+Returns `true` if the tab moved to a different window and `false` if it was
+already in the target window.
 
 ## Parameters
 
@@ -15,7 +16,8 @@ Returns `true` on success.
 
 ## Returns
 
-Returns `true` on success. Raises a Lua error if the operation fails.
+Returns `true` if the tab moved, and `false` if it was already in the target
+window. Raises a Lua error if the operation fails.
 
 ## Example
 

--- a/lua-api-crates/mux/src/tab.rs
+++ b/lua-api-crates/mux/src/tab.rs
@@ -159,9 +159,10 @@ impl UserData for MuxTab {
         methods.add_method("move_to_window", |_, this, target: mlua::AnyUserData| {
             let target: MuxWindow = *target.borrow()?;
             let mux = Mux::get();
-            mux.move_tab_to_window(this.0, target.0)
+            let moved = mux
+                .move_tab_to_window(this.0, target.0)
                 .map_err(|e| mlua::Error::external(format!("{:#}", e)))?;
-            Ok(true)
+            Ok(moved)
         });
     }
 }

--- a/lua-api-crates/mux/src/tab.rs
+++ b/lua-api-crates/mux/src/tab.rs
@@ -155,5 +155,13 @@ impl UserData for MuxTab {
             }
             Ok(())
         });
+
+        methods.add_method("move_to_window", |_, this, target: mlua::AnyUserData| {
+            let target: MuxWindow = *target.borrow()?;
+            let mux = Mux::get();
+            mux.move_tab_to_window(this.0, target.0)
+                .map_err(|e| mlua::Error::external(format!("{:#}", e)))?;
+            Ok(true)
+        });
     }
 }

--- a/mux/src/lib.rs
+++ b/mux/src/lib.rs
@@ -1317,7 +1317,7 @@ impl Mux {
         &self,
         tab_id: TabId,
         target_window_id: WindowId,
-    ) -> anyhow::Result<()> {
+    ) -> anyhow::Result<bool> {
         // Find which window currently contains this tab
         let src_window_id = self
             .get_window_containing_tab(tab_id)
@@ -1325,7 +1325,7 @@ impl Mux {
 
         // No-op if already in target window
         if src_window_id == target_window_id {
-            return Ok(());
+            return Ok(false);
         }
 
         // Verify target window exists
@@ -1377,7 +1377,7 @@ impl Mux {
         self.notify(MuxNotification::WindowInvalidated(target_window_id));
         self.prune_dead_windows();
 
-        Ok(())
+        Ok(true)
     }
 
     pub async fn spawn_tab_or_window(

--- a/mux/src/lib.rs
+++ b/mux/src/lib.rs
@@ -1304,6 +1304,82 @@ impl Mux {
         Ok((tab, window_id))
     }
 
+    pub fn get_window_containing_tab(&self, tab_id: TabId) -> Option<WindowId> {
+        for window in self.windows.read().values() {
+            if window.idx_by_id(tab_id).is_some() {
+                return Some(window.window_id());
+            }
+        }
+        None
+    }
+
+    pub fn move_tab_to_window(
+        &self,
+        tab_id: TabId,
+        target_window_id: WindowId,
+    ) -> anyhow::Result<()> {
+        // Find which window currently contains this tab
+        let src_window_id = self
+            .get_window_containing_tab(tab_id)
+            .ok_or_else(|| anyhow::anyhow!("tab {} not found in any window", tab_id))?;
+
+        // No-op if already in target window
+        if src_window_id == target_window_id {
+            return Ok(());
+        }
+
+        // Verify target window exists
+        if self.get_window(target_window_id).is_none() {
+            anyhow::bail!("target window {} not found", target_window_id);
+        }
+
+        // Get the tab reference before removing it
+        let tab = self
+            .get_tab(tab_id)
+            .ok_or_else(|| anyhow::anyhow!("tab {} not found", tab_id))?;
+
+        // Remove from source window
+        {
+            let mut src_window = self
+                .get_window_mut(src_window_id)
+                .ok_or_else(|| anyhow::anyhow!("source window {} not found", src_window_id))?;
+            src_window.remove_by_id(tab_id);
+        }
+
+        // Get the target window's active tab size to resize our moved tab
+        let target_size = {
+            let target_window = self
+                .get_window_mut(target_window_id)
+                .ok_or_else(|| anyhow::anyhow!("target window {} not found", target_window_id))?;
+            target_window
+                .get_active()
+                .map(|t| t.get_size())
+                .unwrap_or_else(|| tab.get_size())
+        };
+
+        // Add to target window
+        {
+            let mut target_window = self
+                .get_window_mut(target_window_id)
+                .ok_or_else(|| anyhow::anyhow!("target window {} not found", target_window_id))?;
+            target_window.push(&tab);
+        }
+
+        // Resize the tab to match the target window's dimensions
+        // This ensures panes reinitialize their graphics contexts for the new window
+        tab.resize(target_size);
+
+        self.recompute_pane_count();
+        self.notify(MuxNotification::TabAddedToWindow {
+            tab_id,
+            window_id: target_window_id,
+        });
+        self.notify(MuxNotification::WindowInvalidated(target_window_id));
+        self.prune_dead_windows();
+
+        Ok(())
+    }
+
     pub async fn spawn_tab_or_window(
         &self,
         window_id: Option<WindowId>,


### PR DESCRIPTION
Potentially/partially closes #5976

Depends on #7617 

Implements `tab:move_to_window(target_window)`, which moves the tab (including all its panes and split layout) from its current window to the specified target window. The tab is appended to the end of the target window's
tab list.

I implemented this because I always have a gazillion WezTerm windows open and I wanted to implement an action that automatically combines all of them into one window.