### PR TITLE
build(deps): bump getrandom from 0.3 to 0.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,7 +104,7 @@ futures = "0.3"
 futures-lite = "2.3"
 futures-util = "0.3"
 gethostname = "0.5"
-getrandom = "0.3.1"
+getrandom = "0.4.1"
 git2 = { version = "0.20", default-features = false, features = ["https"] }
 gl_generator = "0.14"
 glium = { version = "0.35", default-features = false }


### PR DESCRIPTION
getrandom 0.4.1 was released on 2026-02-03. wezterm-blob-leases can use it without code change.