### PR TITLE
Add window-tab-switched event for Lua config

### DIFF
--- a/mux/src/lib.rs
+++ b/mux/src/lib.rs
@@ -95,6 +95,10 @@ pub enum MuxNotification {
         old_workspace: String,
         new_workspace: String,
     },
+    ActiveTabChanged {
+        window_id: WindowId,
+        tab_id: TabId,
+    },
 }
 
 static SUB_ID: AtomicUsize = AtomicUsize::new(0);

--- a/mux/src/window.rs
+++ b/mux/src/window.rs
@@ -203,7 +203,8 @@ impl Window {
     /// The saved tab id is not changed.
     pub fn set_active_without_saving(&mut self, idx: usize) {
         assert!(idx < self.tabs.len());
-        if self.active != idx {
+        let changed = self.active != idx;
+        if changed {
             if let Some(tab) = self.tabs.get(self.active) {
                 if let Some(pane) = tab.get_active_pane() {
                     pane.focus_changed(false);
@@ -212,6 +213,15 @@ impl Window {
         }
         self.active = idx;
         self.invalidate();
+        if changed {
+            if let Some(tab) = self.tabs.get(idx) {
+                let mux = Mux::get();
+                mux.notify(MuxNotification::ActiveTabChanged {
+                    window_id: self.id,
+                    tab_id: tab.tab_id(),
+                });
+            }
+        }
     }
 
     pub fn iter(&self) -> impl Iterator<Item = &Arc<Tab>> {

--- a/wezterm-gui/src/frontend.rs
+++ b/wezterm-gui/src/frontend.rs
@@ -94,6 +94,7 @@ impl GuiFrontEnd {
                 MuxNotification::WindowInvalidated(_) => {}
                 MuxNotification::PaneOutput(_) => {}
                 MuxNotification::PaneAdded(_) => {}
+                MuxNotification::ActiveTabChanged { .. } => {}
                 MuxNotification::Alert {
                     pane_id,
                     alert:

--- a/wezterm-gui/src/termwindow/mod.rs
+++ b/wezterm-gui/src/termwindow/mod.rs
@@ -1308,6 +1308,11 @@ impl TermWindow {
                 MuxNotification::TabTitleChanged { .. } => {
                     self.update_title_post_status();
                 }
+                MuxNotification::ActiveTabChanged { tab_id, .. } => {
+                    self.emit_window_event("window-tab-switched", None);
+                    window.invalidate();
+                    let _ = tab_id;
+                }
                 MuxNotification::PaneAdded(_)
                 | MuxNotification::WorkspaceRenamed { .. }
                 | MuxNotification::PaneRemoved(_)
@@ -1493,7 +1498,8 @@ impl TermWindow {
             }
             MuxNotification::TabAddedToWindow { window_id, .. }
             | MuxNotification::WindowTitleChanged { window_id, .. }
-            | MuxNotification::WindowInvalidated(window_id) => {
+            | MuxNotification::WindowInvalidated(window_id)
+            | MuxNotification::ActiveTabChanged { window_id, .. } => {
                 if window_id != mux_window_id {
                     return true;
                 }

--- a/wezterm-mux-server-impl/src/dispatch.rs
+++ b/wezterm-mux-server-impl/src/dispatch.rs
@@ -203,6 +203,7 @@ where
                 stream.flush().await.context("flushing PDU to client")?;
             }
             Ok(Item::Notif(MuxNotification::ActiveWorkspaceChanged(_))) => {}
+            Ok(Item::Notif(MuxNotification::ActiveTabChanged { .. })) => {}
             Ok(Item::Notif(MuxNotification::Empty)) => {}
             Err(err) => {
                 log::error!("process_async Err {}", err);


### PR DESCRIPTION
This adds a new MuxNotification::ActiveTabChanged that is emitted whenever the active tab changes in a window. The GUI then emits a "window-tab-switched" Lua event that config scripts can listen to.

This is useful for features like per-tab backgrounds, where the config needs to update the window appearance when switching tabs. Previously, this only worked when switching tabs via keyboard shortcuts that explicitly called the update function, but not when clicking on tabs with the mouse.

Usage in wezterm.lua:

    wezterm.on('window-tab-switched', function(window, pane)
      -- Update background or other per-tab settings
    end)