### PR TITLE
feat: add AVIF image support via dav1d decoder

### DIFF
--- a/.github/workflows/gen_macos.yml
+++ b/.github/workflows/gen_macos.yml
@@ -56,6 +56,9 @@ jobs:
       - name: "Install System Deps"
         shell: bash
         run: "env CI=yes PATH=$PATH ./get-deps"
+      - name: "Install dav1d"
+        shell: bash
+        run: "brew install dav1d"
       - name: "Build wezterm (Release mode Intel)"
         shell: bash
         run: "cargo build --target x86_64-apple-darwin -p wezterm --release"

--- a/.github/workflows/gen_macos_continuous.yml
+++ b/.github/workflows/gen_macos_continuous.yml
@@ -59,6 +59,9 @@ jobs:
       - name: "Install System Deps"
         shell: bash
         run: "env CI=yes PATH=$PATH ./get-deps"
+      - name: "Install dav1d"
+        shell: bash
+        run: "brew install dav1d"
       - name: "Build wezterm (Release mode Intel)"
         shell: bash
         run: "cargo build --target x86_64-apple-darwin -p wezterm --release"

--- a/.github/workflows/gen_macos_tag.yml
+++ b/.github/workflows/gen_macos_tag.yml
@@ -43,6 +43,9 @@ jobs:
       - name: "Install System Deps"
         shell: bash
         run: "env CI=yes PATH=$PATH ./get-deps"
+      - name: "Install dav1d"
+        shell: bash
+        run: "brew install dav1d"
       - name: "Build wezterm (Release mode Intel)"
         shell: bash
         run: "cargo build --target x86_64-apple-darwin -p wezterm --release"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -370,6 +370,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "av-data"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fca67ba5d317924c02180c576157afd54babe48a76ebc66ce6d34bb8ba08308e"
+dependencies = [
+ "byte-slice-cast",
+ "bytes",
+ "num-derive",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
 name = "av1-grain"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -493,6 +506,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitreader"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "886559b1e163d56c765bc3a985febb4eee8009f625244511d8ee3c432e08c066"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "bitstream-io"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -557,6 +579,12 @@ name = "bumpalo"
 version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+
+[[package]]
+name = "byte-slice-cast"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7575182f7272186991736b70173b0ea045398f984bf5ebbb3804736ce1330c9d"
 
 [[package]]
 name = "bytemuck"
@@ -654,7 +682,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d067ad48b8650848b989a59a86c6c36a995d02d2bf778d45c3c5d57bc2718f02"
 dependencies = [
  "smallvec",
- "target-lexicon",
+ "target-lexicon 0.12.16",
+]
+
+[[package]]
+name = "cfg-expr"
+version = "0.20.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c6b04e07d8080154ed4ac03546d9a2b303cc2fe1901ba0b35b301516e289368"
+dependencies = [
+ "smallvec",
+ "target-lexicon 0.13.3",
 ]
 
 [[package]]
@@ -1233,6 +1271,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
 
 [[package]]
+name = "dav1d"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80c3f80814db85397819d464bb553268992c393b4b3b5554b89c1655996d5926"
+dependencies = [
+ "av-data",
+ "bitflags 2.10.0",
+ "dav1d-sys",
+ "static_assertions",
+]
+
+[[package]]
+name = "dav1d-sys"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3c91aea6668645415331133ed6f8ddf0e7f40160cd97a12d59e68716a58704b"
+dependencies = [
+ "libc",
+ "system-deps 7.0.7",
+]
+
+[[package]]
 name = "deltae"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1637,6 +1697,15 @@ name = "fallible-streaming-iterator"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
+name = "fallible_collections"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a88c69768c0a15262df21899142bc6df9b9b823546d4b4b9a7bc2d6c448ec6fd"
+dependencies = [
+ "hashbrown 0.13.2",
+]
 
 [[package]]
 name = "fancy-regex"
@@ -2290,6 +2359,15 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
@@ -2693,10 +2771,12 @@ dependencies = [
  "bytemuck",
  "byteorder-lite",
  "color_quant",
+ "dav1d",
  "exr",
  "gif",
  "image-webp",
  "moxcms",
+ "mp4parse",
  "num-traits",
  "png 0.18.0",
  "qoi",
@@ -3448,6 +3528,20 @@ checksum = "0fbdd3d7436f8b5e892b8b7ea114271ff0fa00bc5acae845d53b07d498616ef6"
 dependencies = [
  "num-traits",
  "pxfm",
+]
+
+[[package]]
+name = "mp4parse"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63a35203d3c6ce92d5251c77520acb2e57108c88728695aa883f70023624c570"
+dependencies = [
+ "bitreader",
+ "byteorder",
+ "fallible_collections",
+ "log",
+ "num-traits",
+ "static_assertions",
 ]
 
 [[package]]
@@ -4631,7 +4725,7 @@ dependencies = [
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "simd_helpers",
- "system-deps",
+ "system-deps 6.2.2",
  "thiserror 1.0.69",
  "v_frame",
  "wasm-bindgen",
@@ -5128,6 +5222,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
+dependencies = [
+ "serde_core",
 ]
 
 [[package]]
@@ -5631,10 +5734,23 @@ version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3e535eb8dded36d55ec13eddacd30dec501792ff23a0b1682c38601b8cf2349"
 dependencies = [
- "cfg-expr",
+ "cfg-expr 0.15.8",
  "heck",
  "pkg-config",
  "toml 0.8.23",
+ "version-compare",
+]
+
+[[package]]
+name = "system-deps"
+version = "7.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c8f33736f986f16d69b6cb8b03f55ddcad5c41acc4ccc39dd88e84aa805e7f"
+dependencies = [
+ "cfg-expr 0.20.7",
+ "heck",
+ "pkg-config",
+ "toml 0.9.6",
  "version-compare",
 ]
 
@@ -5661,6 +5777,12 @@ name = "target-lexicon"
 version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
+
+[[package]]
+name = "target-lexicon"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df7f62577c25e07834649fc3b39fafdc597c0a3527dc1c60129201ccfcbaa50c"
 
 [[package]]
 name = "tempfile"
@@ -6037,9 +6159,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
- "serde_spanned",
+ "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
  "toml_edit 0.22.27",
+]
+
+[[package]]
+name = "toml"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae2a4cf385da23d1d53bc15cdfa5c2109e93d8d362393c801e87da2f72f0e201"
+dependencies = [
+ "indexmap 2.12.0",
+ "serde_core",
+ "serde_spanned 1.0.4",
+ "toml_datetime 0.7.3",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
 ]
 
 [[package]]
@@ -6068,7 +6205,7 @@ checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
  "indexmap 2.12.0",
  "serde",
- "serde_spanned",
+ "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
  "toml_write",
  "winnow",
@@ -6100,6 +6237,12 @@ name = "toml_write"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
+name = "toml_writer"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc842091f2def52017664b53082ecbbeb5c7731092bad69d2c63050401dfd64"
 
 [[package]]
 name = "tower"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,7 +119,7 @@ http_req = "0.11"
 human-sort = "0.2"
 humansize = "2.1"
 humantime = "2.1"
-image = "0.25"
+image = { version = "0.25", features = ["avif-native"] }
 intrusive-collections = "0.9"
 k9 = "0.12.0"
 lazy_static = "1.4"

--- a/get-deps
+++ b/get-deps
@@ -48,6 +48,7 @@ alpine_deps() {
     'bash' \
     'build-base' \
     'coreutils' \
+    'dav1d-dev' \
     'fontconfig-dev' \
     'libssh2-dev' \
     'libx11-dev' \
@@ -87,6 +88,7 @@ fedora_deps() {
     'make' \
     'gcc' \
     'gcc-c++' \
+    'dav1d-devel' \
     'flatpak-builder' \
     'fontconfig-devel' \
     'openssl-devel' \
@@ -127,6 +129,7 @@ suse_deps() {
     'gcc' \
     'gcc-c++' \
     'fontconfig-devel' \
+    'libdav1d-devel' \
     'libopenssl-devel' \
     'perl' \
     'python3' \
@@ -156,6 +159,7 @@ debian_deps() {
     'fakeroot' \
     'gcc' \
     'g++' \
+    'libdav1d-dev' \
     'libegl1-mesa-dev' \
     'libssl-dev' \
     'libfontconfig1-dev' \
@@ -190,6 +194,7 @@ arch_deps() {
     'base-devel' \
     'cargo' \
     'cmake' \
+    'dav1d' \
     'fontconfig' \
     'git' \
     'hicolor-icon-theme' \
@@ -214,6 +219,7 @@ freebsd_deps() {
   $PKG install -y \
     'cmake' \
     'curl' \
+    'dav1d' \
     'egl-wayland' \
     'expat' \
     'fontconfig' \
@@ -244,6 +250,7 @@ netbsd_deps() {
   PKG="$SUDO pkgin"
   $PKG -y install \
     'bash' \
+    'dav1d' \
     'fontconfig' \
     'git-base' \
     'hicolor-icon-theme' \
@@ -264,6 +271,7 @@ gentoo_deps() {
   for pkg in \
     'cmake' \
     'fontconfig' \
+    'media-libs/dav1d' \
     'openssl' \
     'dev-vcs/git' \
     'libX11' \
@@ -287,6 +295,7 @@ void_deps() {
   $XBPS -S \
     'gcc' \
     'pkgconf' \
+    'dav1d-devel' \
     'fontconfig-devel' \
     'openssl-devel' \
     'wayland-devel' \
@@ -309,6 +318,7 @@ solus_deps() {
   EOPKG="$SUDO eopkg"
   $EOPKG install -y -c system.devel
   $EOPKG install -y \
+    dav1d-devel \
     xcb-util-devel \
     xcb-util-image-devel \
     libxkbcommon-devel \

--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -62,6 +62,7 @@
         buildInputs =
           with pkgs;
           [
+            dav1d
             fontconfig
             openssl
             zlib


### PR DESCRIPTION
## Summary
- Enable native AVIF decoding by activating the `avif-native` feature on the `image` crate
- Add `dav1d` as a system dependency across all supported platforms (Alpine, Fedora, Debian/Ubuntu, Arch, openSUSE, FreeBSD, NetBSD, Gentoo, Void, Solus, and Nix)
- Update macOS CI workflows to install `dav1d` via Homebrew

## Motivation
AVIF is an increasingly popular image format based on the AV1 codec, offering excellent compression ratios. This change allows WezTerm to display AVIF images inline via `imgcat` and other image rendering paths (like background images).

## Preview
Preview of the background working and showing it via imgcat command:
![SCR-20260318-pcmk](https://github.com/user-attachments/assets/ebdcc794-2e6c-4ce4-98c3-cd67e277b51a)

## Changes
- **`Cargo.toml`**: Enable `avif-native` feature on the `image` crate (uses system `dav1d` library)
- **`get-deps`**: Add `dav1d` dev packages for all Linux distros, FreeBSD, and NetBSD
- **`nix/flake.nix`**: Add `dav1d` to Nix build inputs
- **`.github/workflows/gen_macos*.yml`**: Add `brew install dav1d` step to macOS CI

## Test plan
- [x] `cargo build --release` succeeds on macOS (Apple Silicon)
- [x] `wezterm imgcat test.avif` decodes and renders AVIF images
- [ ] CI passes on all platforms
