### PR TITLE
feat: add workspace sidebar panel with tree view and Finder-style UX

### DIFF
--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -512,6 +512,18 @@ pub struct Config {
     #[dynamic(try_from = "crate::units::PixelUnit", default = "default_half_cell")]
     pub min_scroll_bar_height: Dimension,
 
+    #[dynamic(
+        try_from = "crate::units::PixelUnit",
+        default = "default_sidebar_width"
+    )]
+    pub sidebar_width: Dimension,
+
+    #[dynamic(default)]
+    pub sidebar_position: SidebarPosition,
+
+    #[dynamic(default)]
+    pub sidebar_default_visible: bool,
+
     /// If false, do not try to use a Wayland protocol connection
     /// when starting the gui frontend, and instead use X11.
     /// This option is only considered on X11/Wayland systems and
@@ -1927,6 +1939,10 @@ const fn default_half_cell() -> Dimension {
     Dimension::Cells(0.5)
 }
 
+const fn default_sidebar_width() -> Dimension {
+    Dimension::Pixels(220.0)
+}
+
 const fn default_reverse_video_cursor_min_contrast() -> f32 {
     2.5
 }
@@ -1958,6 +1974,13 @@ impl Default for WindowPadding {
 pub struct WindowContentAlignment {
     pub horizontal: HorizontalWindowContentAlignment,
     pub vertical: VerticalWindowContentAlignment,
+}
+
+#[derive(Debug, FromDynamic, ToDynamic, Clone, Copy, PartialEq, Eq, Default)]
+pub enum SidebarPosition {
+    #[default]
+    Right,
+    Left,
 }
 
 #[derive(Debug, FromDynamic, ToDynamic, Clone, Copy, PartialEq, Eq, Default)]

--- a/config/src/keyassignment.rs
+++ b/config/src/keyassignment.rs
@@ -646,6 +646,7 @@ pub enum KeyAssignment {
     PromptInputLine(PromptInputLine),
     InputSelector(InputSelector),
     Confirmation(Confirmation),
+    ToggleSidebar,
 }
 impl_lua_conversion_dynamic!(KeyAssignment);
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -69,6 +69,7 @@ As features stabilize some brief notes about them will accumulate here.
   @mgpinf! #6801
 
 #### New
+* Added workspace sidebar panel — a toggleable tree view showing all workspaces and their tabs. Toggle with `CTRL+SHIFT+E` (configurable). Features include click-to-switch, double-click to rename workspaces and tabs, per-item hover close buttons, new tab/workspace creation, and theme-aware colors. Configure position, width, and default visibility via [sidebar_width](config/lua/config/sidebar_width.md), [sidebar_position](config/lua/config/sidebar_position.md), and [sidebar_default_visible](config/lua/config/sidebar_default_visible.md). [See Sidebar Guide](sidebar.md).
 * [wezterm.serde](config/lua/wezterm.serde/index.md) module for serialization
   and deserialization of JSON, TOML and YAML. Thanks to @expnn! #4969
 * `wezterm ssh` now supports agent forwarding. Thanks to @Riatre! #5345

--- a/docs/config/default-keys.md
+++ b/docs/config/default-keys.md
@@ -87,6 +87,7 @@ in a form that you can copy and paste into your own configuration.
 | `CTRL+SHIFT` | `UpArrow`    | `ActivatePaneDirection="Up"` |
 | `CTRL+SHIFT` | `DownArrow`    | `ActivatePaneDirection="Down"` |
 | `CTRL+SHIFT` | `Z`    | `TogglePaneZoomState` |
+| `CTRL+SHIFT` | `E`    | `ToggleSidebar` |
 
 If you don't want the default assignments to be registered, you can
 disable all of them with this configuration; if you chose to do this,

--- a/docs/config/lua/config/sidebar_default_visible.md
+++ b/docs/config/lua/config/sidebar_default_visible.md
@@ -1,0 +1,21 @@
+---
+tags:
+  - appearance
+  - sidebar
+---
+# `sidebar_default_visible = false`
+
+Controls whether the workspace sidebar panel is visible when a new
+window is opened.
+
+Set to `true` to have the sidebar open automatically on startup.
+The default is `false`.
+
+```lua
+-- Show the sidebar when WezTerm starts
+config.sidebar_default_visible = true
+```
+
+See also: [sidebar_width](sidebar_width.md),
+[sidebar_position](sidebar_position.md), and the
+[Sidebar Guide](../../sidebar.md).

--- a/docs/config/lua/config/sidebar_position.md
+++ b/docs/config/lua/config/sidebar_position.md
@@ -1,0 +1,20 @@
+---
+tags:
+  - appearance
+  - sidebar
+---
+# `sidebar_position = "Right"`
+
+Controls which side of the window the workspace sidebar panel is
+displayed on. Accepted values are `"Left"` and `"Right"`.
+
+The default is `"Right"`.
+
+```lua
+-- Place the sidebar on the left side of the window
+config.sidebar_position = "Left"
+```
+
+See also: [sidebar_width](sidebar_width.md),
+[sidebar_default_visible](sidebar_default_visible.md), and the
+[Sidebar Guide](../../sidebar.md).

--- a/docs/config/lua/config/sidebar_width.md
+++ b/docs/config/lua/config/sidebar_width.md
@@ -1,0 +1,20 @@
+---
+tags:
+  - appearance
+  - sidebar
+---
+# `sidebar_width = 40`
+
+Controls the width of the workspace sidebar panel, measured in terminal
+cell columns.
+
+The default is `40`.
+
+```lua
+-- Make the sidebar a bit wider
+config.sidebar_width = 50
+```
+
+See also: [sidebar_position](sidebar_position.md),
+[sidebar_default_visible](sidebar_default_visible.md), and the
+[Sidebar Guide](../../sidebar.md).

--- a/docs/config/lua/keyassignment/ToggleSidebar.md
+++ b/docs/config/lua/keyassignment/ToggleSidebar.md
@@ -1,0 +1,24 @@
+# `ToggleSidebar`
+
+Toggles the workspace sidebar panel for the current window.
+
+The sidebar displays a tree view of all workspaces and their tabs,
+allowing you to switch workspaces, rename them, create new workspaces,
+and close existing ones.
+
+```lua
+local wezterm = require 'wezterm'
+
+config.keys = {
+  {
+    key = 'e',
+    mods = 'SHIFT|CTRL',
+    action = wezterm.action.ToggleSidebar,
+  },
+}
+```
+
+See also: [sidebar_width](../config/sidebar_width.md),
+[sidebar_position](../config/sidebar_position.md),
+[sidebar_default_visible](../config/sidebar_default_visible.md),
+and the [Sidebar Guide](../../../sidebar.md).

--- a/docs/sidebar.md
+++ b/docs/sidebar.md
@@ -1,0 +1,105 @@
+The workspace sidebar is a toggleable panel that displays a tree view of all
+workspaces and their tabs, giving you a visual overview of your terminal
+session and quick access to workspace management.
+
+```
++----------------------------------------------+-------------------+
+|                                              | WORKSPACES        |
+|                                              |▼ default    + ✕   |
+|  Terminal content area                       |  ● 0: ~        ✕  |
+|                                              |    1: nvim     ✕  |
+|                                              |► build             |
+|                                              |► deploy            |
+|                                              |                    |
+|                                              | + New Workspace    |
++----------------------------------------------+-------------------+
+  ^                                              ^
+  terminal panes                                 sidebar
+```
+
+### Toggling the Sidebar
+
+The sidebar is toggled with <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>E</kbd>
+by default. You can rebind this using the
+[ToggleSidebar](config/lua/keyassignment/ToggleSidebar.md) key assignment:
+
+```lua
+local wezterm = require 'wezterm'
+
+config.keys = {
+  {
+    key = 'b',
+    mods = 'SHIFT|CTRL',
+    action = wezterm.action.ToggleSidebar,
+  },
+}
+```
+
+### Workspace Operations
+
+The sidebar lists all workspaces. Each workspace can be expanded or collapsed
+to show or hide its tabs.
+
+| Action | How |
+|--------|-----|
+| Switch workspace | Click the workspace name |
+| Expand / collapse tab list | Click the `▶` / `▼` disclosure triangle |
+| Rename workspace | Double-click the workspace name |
+| Create new tab in workspace | Hover over the workspace row and click the `+` button |
+| Close workspace | Hover over the workspace row and click the `✕` button |
+| Create new workspace | Click `+ New Workspace` at the bottom of the sidebar |
+
+The `+` and `✕` buttons are hidden by default and appear when you hover over
+the workspace row. The `✕` button turns red on hover as a safety indicator.
+
+### Tab Operations
+
+When a workspace is expanded, its tabs are listed beneath it. The active tab
+is marked with a green `●` indicator.
+
+| Action | How |
+|--------|-----|
+| Switch to tab | Click the tab name |
+| Rename tab | Double-click the tab name |
+| Close tab | Hover over the tab row and click the `✕` button |
+
+### Inline Rename
+
+Double-clicking a workspace name or tab title enters inline rename mode. A
+cursor appears at the end of the current name. The following keys are
+available during rename:
+
+| Key | Action |
+|-----|--------|
+| <kbd>Enter</kbd> | Confirm the new name |
+| <kbd>Escape</kbd> | Cancel and revert to the original name |
+| <kbd>Backspace</kbd> | Delete the previous character |
+| Click elsewhere | Confirm the new name |
+
+All other printable keys are inserted into the name.
+
+### Configuration
+
+The sidebar appearance and behavior can be configured through the following
+options:
+
+```lua
+-- Width of the sidebar in cell columns (default: 40)
+config.sidebar_width = 40
+
+-- Which side of the window: "Left" or "Right" (default: "Right")
+config.sidebar_position = "Right"
+
+-- Whether the sidebar is open when a new window is created (default: false)
+config.sidebar_default_visible = false
+```
+
+The sidebar uses your existing theme colors from
+[window_frame](config/lua/config/window_frame.md) and
+[tab_bar](config/lua/config/colors.md) configuration for a consistent look.
+
+See the individual config docs for details:
+
+* [sidebar_width](config/lua/config/sidebar_width.md)
+* [sidebar_position](config/lua/config/sidebar_position.md)
+* [sidebar_default_visible](config/lua/config/sidebar_default_visible.md)

--- a/wezterm-gui/src/commands.rs
+++ b/wezterm-gui/src/commands.rs
@@ -681,6 +681,14 @@ pub fn derive_command_from_key_assignment(action: &KeyAssignment) -> Option<Comm
             menubar: &["View"],
             icon: Some("md_fullscreen"),
         },
+        ToggleSidebar => CommandDef {
+            brief: "Toggle workspace sidebar".into(),
+            doc: "Toggles the workspace sidebar panel".into(),
+            keys: vec![(Modifiers::CTRL | Modifiers::SHIFT, "e".into())],
+            args: &[ArgType::ActiveWindow],
+            menubar: &["View"],
+            icon: None,
+        },
         ToggleAlwaysOnTop => CommandDef {
             brief: "Toggle always on Top".into(),
             doc: "Toggles the window between floating and non-floating states to stay on top of other windows.".into(),
@@ -2064,6 +2072,7 @@ fn compute_default_actions() -> Vec<KeyAssignment> {
         ScrollToTop,
         ScrollToBottom,
         // ----------------- Window
+        ToggleSidebar,
         ToggleFullScreen,
         ToggleAlwaysOnTop,
         ToggleAlwaysOnBottom,

--- a/wezterm-gui/src/termwindow/keyevent.rs
+++ b/wezterm-gui/src/termwindow/keyevent.rs
@@ -5,6 +5,7 @@ use ::window::{
 use anyhow::Context;
 use config::keyassignment::{KeyAssignment, KeyTableEntry};
 use mux::pane::{Pane, PerformAssignmentResult};
+use mux::Mux;
 use smol::Timer;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -264,6 +265,15 @@ impl super::TermWindow {
                     })
                     .detach();
                 }
+                return true;
+            }
+        }
+
+        if is_down
+            && self.sidebar_rename_active.is_some()
+            && only_key_bindings == OnlyKeyBindings::No
+        {
+            if self.handle_sidebar_rename_key(keycode) {
                 return true;
             }
         }
@@ -865,5 +875,54 @@ impl super::TermWindow {
             WK::KeyPadPageDown => KC::KeyPadPageDown,
         };
         Key::Code(code)
+    }
+
+    /// Handle key events when the sidebar rename text field is active.
+    /// Returns `true` if the key was consumed.
+    fn handle_sidebar_rename_key(&mut self, keycode: &KeyCode) -> bool {
+        match keycode {
+            KeyCode::Char(c) if !c.is_control() => {
+                self.sidebar_rename_buffer.push(*c);
+                self.invalidate_sidebar();
+                self.window.as_ref().unwrap().invalidate();
+                true
+            }
+            // Backspace is represented as Char('\u{8}')
+            KeyCode::Char('\u{8}') => {
+                self.sidebar_rename_buffer.pop();
+                self.invalidate_sidebar();
+                self.window.as_ref().unwrap().invalidate();
+                true
+            }
+            // Enter is represented as Char('\r')
+            KeyCode::Char('\r') => {
+                if let Some(target) = self.sidebar_rename_active.take() {
+                    let mux = Mux::get();
+                    match target {
+                        crate::termwindow::SidebarRenameTarget::Workspace(old_name) => {
+                            mux.rename_workspace(&old_name, &self.sidebar_rename_buffer);
+                        }
+                        crate::termwindow::SidebarRenameTarget::Tab(tab_id) => {
+                            if let Some(tab) = mux.get_tab(tab_id) {
+                                tab.set_title(&self.sidebar_rename_buffer);
+                            }
+                        }
+                    }
+                }
+                self.sidebar_rename_buffer.clear();
+                self.invalidate_sidebar();
+                self.window.as_ref().unwrap().invalidate();
+                true
+            }
+            // Escape is represented as Char('\u{1b}')
+            KeyCode::Char('\u{1b}') => {
+                self.sidebar_rename_active = None;
+                self.sidebar_rename_buffer.clear();
+                self.invalidate_sidebar();
+                self.window.as_ref().unwrap().invalidate();
+                true
+            }
+            _ => false,
+        }
     }
 }

--- a/wezterm-gui/src/termwindow/mod.rs
+++ b/wezterm-gui/src/termwindow/mod.rs
@@ -54,7 +54,7 @@ use mux_lua::MuxPane;
 use smol::channel::Sender;
 use smol::Timer;
 use std::cell::{RefCell, RefMut};
-use std::collections::{HashMap, LinkedList};
+use std::collections::{HashMap, HashSet, LinkedList};
 use std::ops::Add;
 use std::rc::Rc;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -85,8 +85,42 @@ pub mod spawn;
 pub mod webgpu;
 use crate::spawn::SpawnWhere;
 use prevcursor::PrevCursorPos;
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
 
 const ATLAS_SIZE: usize = 128;
+
+#[derive(Serialize, Deserialize, Default)]
+struct SidebarPersistentState {
+    visible: bool,
+    collapsed: Vec<String>,
+}
+
+fn sidebar_state_path() -> PathBuf {
+    config::DATA_DIR.join("sidebar_state.json")
+}
+
+pub(crate) fn save_sidebar_state(visible: bool, collapsed: &HashSet<String>) {
+    let state = SidebarPersistentState {
+        visible,
+        collapsed: collapsed.iter().cloned().collect(),
+    };
+    if let Ok(json) = serde_json::to_string_pretty(&state) {
+        let path = sidebar_state_path();
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).ok();
+        }
+        std::fs::write(&path, json).ok();
+    }
+}
+
+fn load_sidebar_state() -> SidebarPersistentState {
+    let path = sidebar_state_path();
+    std::fs::read_to_string(&path)
+        .ok()
+        .and_then(|s| serde_json::from_str(&s).ok())
+        .unwrap_or_default()
+}
 
 lazy_static::lazy_static! {
     static ref WINDOW_CLASS: Mutex<String> = Mutex::new(wezterm_gui_subcommands::DEFAULT_WINDOW_CLASS.to_owned());
@@ -152,6 +186,26 @@ pub enum TermWindowNotif {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
+pub enum SidebarItem {
+    Background,
+    WorkspaceHeader { name: String },
+    WorkspaceDisclosure { name: String },
+    WorkspaceCloseButton { name: String },
+    TabEntry { workspace: String, window_id: MuxWindowId, tab_id: TabId },
+    TabCloseButton { tab_id: TabId },
+    NewTabButton { workspace: String },
+    NewWorkspaceButton,
+    RenameTextField,
+}
+
+/// Tracks what is currently being renamed in the sidebar
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum SidebarRenameTarget {
+    Workspace(String),
+    Tab(TabId),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum UIItemType {
     TabBar(TabBarItem),
     CloseTab(usize),
@@ -159,6 +213,7 @@ pub enum UIItemType {
     ScrollThumb,
     BelowScrollThumb,
     Split(PositionedSplit),
+    Sidebar(SidebarItem),
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -391,6 +446,17 @@ pub struct TermWindow {
     show_scroll_bar: bool,
     tab_bar: TabBarState,
     fancy_tab_bar: Option<box_model::ComputedElement>,
+    sidebar_visible: bool,
+    sidebar_collapsed: HashSet<String>,
+    sidebar_rename_active: Option<SidebarRenameTarget>,
+    sidebar_rename_buffer: String,
+    #[allow(dead_code)] // Used in future hover tracking
+    sidebar_hover_item: Option<SidebarItem>,
+    sidebar_scroll_offset: f32,
+    sidebar_element: Option<box_model::ComputedElement>,
+    sidebar_footer_element: Option<box_model::ComputedElement>,
+    sidebar_last_click_time: Option<std::time::Instant>,
+    sidebar_last_click_item: Option<String>,
     pub right_status: String,
     pub left_status: String,
     last_ui_item: Option<UIItem>,
@@ -677,6 +743,9 @@ impl TermWindow {
 
         let connection_name = Connection::get().unwrap().name();
 
+        let persisted_sidebar = load_sidebar_state();
+        let has_persisted_sidebar = sidebar_state_path().exists();
+
         let myself = Self {
             created: Instant::now(),
             connection_name,
@@ -712,6 +781,20 @@ impl TermWindow {
             show_scroll_bar: config.enable_scroll_bar,
             tab_bar: TabBarState::default(),
             fancy_tab_bar: None,
+            sidebar_visible: if has_persisted_sidebar {
+                persisted_sidebar.visible
+            } else {
+                config.sidebar_default_visible
+            },
+            sidebar_collapsed: persisted_sidebar.collapsed.into_iter().collect(),
+            sidebar_rename_active: None,
+            sidebar_rename_buffer: String::new(),
+            sidebar_hover_item: None,
+            sidebar_scroll_offset: 0.0,
+            sidebar_element: None,
+            sidebar_footer_element: None,
+            sidebar_last_click_time: None,
+            sidebar_last_click_item: None,
             right_status: String::new(),
             left_status: String::new(),
             last_mouse_coords: (0, -1),
@@ -1213,6 +1296,7 @@ impl TermWindow {
                     ..
                 } => {
                     self.update_title();
+                    self.invalidate_sidebar();
                 }
                 MuxNotification::Alert {
                     alert: Alert::PaletteChanged,
@@ -1242,8 +1326,11 @@ impl TermWindow {
                     log::trace!("Ding! (this is the bell) in pane {}", pane_id);
                     self.emit_window_event("bell", Some(pane_id));
 
-                    let mut per_pane = self.pane_state(pane_id);
-                    per_pane.bell_start.replace(Instant::now());
+                    {
+                        let mut per_pane = self.pane_state(pane_id);
+                        per_pane.bell_start.replace(Instant::now());
+                    }
+                    self.invalidate_sidebar();
                     window.invalidate();
                 }
                 MuxNotification::Alert {
@@ -1789,6 +1876,8 @@ impl TermWindow {
             .borrow_mut()
             .update_config(&config);
         self.fancy_tab_bar.take();
+        self.sidebar_element.take();
+        self.sidebar_footer_element.take();
         self.invalidate_fancy_tab_bar();
         self.invalidate_modal();
         self.input_map = InputMap::new(&config);
@@ -1848,6 +1937,11 @@ impl TermWindow {
                 window.invalidate();
             }
         }
+    }
+
+    pub fn invalidate_sidebar(&mut self) {
+        self.sidebar_element.take();
+        self.sidebar_footer_element.take();
     }
 
     pub fn cancel_modal(&self) {
@@ -2672,6 +2766,17 @@ impl TermWindow {
                         top_level: false,
                     }),
                 );
+            }
+            ToggleSidebar => {
+                self.sidebar_visible = !self.sidebar_visible;
+                save_sidebar_state(self.sidebar_visible, &self.sidebar_collapsed);
+                self.sidebar_element.take();
+                self.sidebar_footer_element.take();
+                self.update_title();
+                let dims = self.dimensions;
+                let window = self.window.as_ref().unwrap().clone();
+                window.invalidate();
+                self.apply_dimensions(&dims, None, &window);
             }
             ToggleFullScreen => {
                 self.window.as_ref().unwrap().toggle_fullscreen();

--- a/wezterm-gui/src/termwindow/mouseevent.rs
+++ b/wezterm-gui/src/termwindow/mouseevent.rs
@@ -1,12 +1,15 @@
 use crate::tabbar::TabBarItem;
 use crate::termwindow::{
-    GuiWin, MouseCapture, PositionedSplit, ScrollHit, TermWindowNotif, UIItem, UIItemType, TMB,
+    save_sidebar_state, GuiWin, MouseCapture, PositionedSplit, ScrollHit, SidebarItem, SidebarRenameTarget,
+    TermWindowNotif, UIItem, UIItemType, TMB,
 };
 use ::window::{
     MouseButtons as WMB, MouseCursor, MouseEvent, MouseEventKind as WMEK, MousePress,
     WindowDecorations, WindowOps, WindowState,
 };
-use config::keyassignment::{KeyAssignment, MouseEventTrigger, SpawnTabDomain};
+use crate::spawn::SpawnWhere;
+use config::keyassignment::{KeyAssignment, MouseEventTrigger, SpawnCommand, SpawnTabDomain};
+use config::{SidebarPosition, TermConfig};
 use config::MouseEventAltScreen;
 use mux::pane::{Pane, WithPaneLines};
 use mux::tab::SplitDirection;
@@ -43,7 +46,8 @@ impl super::TermWindow {
             | UIItemType::AboveScrollThumb
             | UIItemType::BelowScrollThumb
             | UIItemType::ScrollThumb
-            | UIItemType::Split(_) => {}
+            | UIItemType::Split(_)
+            | UIItemType::Sidebar(_) => {}
         }
     }
 
@@ -54,7 +58,8 @@ impl super::TermWindow {
             | UIItemType::AboveScrollThumb
             | UIItemType::BelowScrollThumb
             | UIItemType::ScrollThumb
-            | UIItemType::Split(_) => {}
+            | UIItemType::Split(_)
+            | UIItemType::Sidebar(_) => {}
         }
     }
 
@@ -185,6 +190,39 @@ impl super::TermWindow {
                 }
             }
             _ => {}
+        }
+
+        // Intercept scroll events over the sidebar region so they don't
+        // fall through to the terminal pane.
+        if self.sidebar_visible {
+            let h_context = config::DimensionContext {
+                dpi: self.dimensions.dpi as f32,
+                pixel_max: self.dimensions.pixel_width as f32,
+                pixel_cell: self.render_metrics.cell_size.width as f32,
+            };
+            let sidebar_px =
+                self.config.sidebar_width.evaluate_as_pixels(h_context) as usize;
+            let is_over_sidebar = if self.config.sidebar_position == SidebarPosition::Right {
+                event.coords.x as usize
+                    > self.dimensions.pixel_width.saturating_sub(sidebar_px)
+            } else {
+                (event.coords.x as usize) < sidebar_px
+            };
+            if is_over_sidebar {
+                if let Some(item) = self.resolve_ui_item(&event) {
+                    if let UIItemType::Sidebar(_) = &item.item_type {
+                        if let WMEK::VertWheel(amount) = event.kind {
+                            self.sidebar_scroll_offset -= amount as f32 * 20.0;
+                            if self.sidebar_scroll_offset < 0.0 {
+                                self.sidebar_scroll_offset = 0.0;
+                            }
+                            self.invalidate_sidebar();
+                            self.window.as_ref().unwrap().invalidate();
+                            return;
+                        }
+                    }
+                }
+            }
         }
 
         let prior_ui_item = self.last_ui_item.clone();
@@ -382,6 +420,9 @@ impl super::TermWindow {
             UIItemType::CloseTab(idx) => {
                 self.mouse_event_close_tab(idx, event, context);
             }
+            UIItemType::Sidebar(sidebar_item) => {
+                self.mouse_event_sidebar(sidebar_item, event, context);
+            }
         }
     }
 
@@ -395,6 +436,224 @@ impl super::TermWindow {
             WMEK::Press(MousePress::Left) => {
                 log::debug!("Should close tab {}", idx);
                 self.close_specific_tab(idx, true);
+            }
+            _ => {}
+        }
+        context.set_cursor(Some(MouseCursor::Arrow));
+    }
+
+    /// If a rename is in progress, commit it (save the current buffer).
+    fn commit_sidebar_rename(&mut self) {
+        if let Some(target) = self.sidebar_rename_active.take() {
+            let mux = Mux::get();
+            match target {
+                SidebarRenameTarget::Workspace(old_name) => {
+                    mux.rename_workspace(&old_name, &self.sidebar_rename_buffer);
+                }
+                SidebarRenameTarget::Tab(tab_id) => {
+                    if let Some(tab) = mux.get_tab(tab_id) {
+                        tab.set_title(&self.sidebar_rename_buffer);
+                    }
+                }
+            }
+            self.sidebar_rename_buffer.clear();
+        }
+    }
+
+    fn mouse_event_sidebar(
+        &mut self,
+        item: SidebarItem,
+        event: MouseEvent,
+        context: &dyn WindowOps,
+    ) {
+        // Any click while renaming commits the rename first
+        if self.sidebar_rename_active.is_some() {
+            if matches!(event.kind, WMEK::Press(MousePress::Left)) {
+                // Don't commit if clicking the rename text field itself
+                if !matches!(item, SidebarItem::RenameTextField) {
+                    self.commit_sidebar_rename();
+                }
+            }
+        }
+
+        match (&item, &event.kind) {
+            (SidebarItem::WorkspaceHeader { name }, WMEK::Press(MousePress::Left)) => {
+                let now = std::time::Instant::now();
+                let click_key = format!("ws:{}", name);
+                let is_double_click = self
+                    .sidebar_last_click_time
+                    .map(|t| now.duration_since(t).as_millis() < 400)
+                    .unwrap_or(false)
+                    && self.sidebar_last_click_item.as_deref() == Some(click_key.as_str());
+
+                if is_double_click {
+                    // Double-click: enter rename mode
+                    self.sidebar_rename_active =
+                        Some(SidebarRenameTarget::Workspace(name.clone()));
+                    self.sidebar_rename_buffer = name.clone();
+                    self.sidebar_last_click_time = None;
+                    self.sidebar_last_click_item = None;
+                } else {
+                    // Single click: switch workspace
+                    let mux = Mux::get();
+                    let switcher = crate::frontend::WorkspaceSwitcher::new(name);
+                    mux.set_active_workspace(name);
+                    drop(switcher);
+                    self.sidebar_last_click_time = Some(now);
+                    self.sidebar_last_click_item = Some(click_key);
+                }
+                self.invalidate_sidebar();
+            }
+            (SidebarItem::WorkspaceDisclosure { name }, WMEK::Press(MousePress::Left)) => {
+                if !self.sidebar_collapsed.remove(name) {
+                    self.sidebar_collapsed.insert(name.clone());
+                }
+                save_sidebar_state(self.sidebar_visible, &self.sidebar_collapsed);
+                self.invalidate_sidebar();
+                self.window.as_ref().unwrap().invalidate();
+            }
+            (
+                SidebarItem::TabEntry {
+                    workspace,
+                    window_id,
+                    tab_id,
+                },
+                WMEK::Press(MousePress::Left),
+            ) => {
+                let now = std::time::Instant::now();
+                let click_key = format!("tab:{}", tab_id);
+                let is_double_click = self
+                    .sidebar_last_click_time
+                    .map(|t| now.duration_since(t).as_millis() < 400)
+                    .unwrap_or(false)
+                    && self.sidebar_last_click_item.as_deref() == Some(click_key.as_str());
+
+                if is_double_click {
+                    // Double-click: enter rename mode
+                    let mux = Mux::get();
+                    let current_title = mux
+                        .get_tab(*tab_id)
+                        .map(|tab| {
+                            let t = tab.get_title();
+                            if t.is_empty() {
+                                tab.get_active_pane()
+                                    .map(|p| p.get_title())
+                                    .unwrap_or_default()
+                            } else {
+                                t
+                            }
+                        })
+                        .unwrap_or_default();
+                    self.sidebar_rename_active = Some(SidebarRenameTarget::Tab(*tab_id));
+                    self.sidebar_rename_buffer = current_title;
+                    self.sidebar_last_click_time = None;
+                    self.sidebar_last_click_item = None;
+                } else {
+                    // Single click: switch to tab
+                    let mux = Mux::get();
+                    let active_ws = mux.active_workspace();
+                    if active_ws != *workspace {
+                        let switcher = crate::frontend::WorkspaceSwitcher::new(workspace);
+                        mux.set_active_workspace(workspace);
+                        drop(switcher);
+                    }
+                    if let Some(mut window) = mux.get_window_mut(*window_id) {
+                        if let Some(idx) = window.idx_by_id(*tab_id) {
+                            window.save_and_then_set_active(idx);
+                        }
+                        drop(window);
+                    }
+                    self.update_title();
+                    self.update_scrollbar();
+                    self.sidebar_last_click_time = Some(now);
+                    self.sidebar_last_click_item = Some(click_key);
+                }
+                self.invalidate_sidebar();
+                self.window.as_ref().unwrap().invalidate();
+            }
+            (SidebarItem::NewWorkspaceButton, WMEK::Press(MousePress::Left)) => {
+                let mux = Mux::get();
+                let name = mux.generate_workspace_name();
+                let switcher = crate::frontend::WorkspaceSwitcher::new(&name);
+                mux.set_active_workspace(&name);
+
+                if mux.iter_windows_in_workspace(&name).is_empty() {
+                    let spawn = SpawnCommand::default();
+                    let size = self.terminal_size;
+                    let term_config = Arc::new(TermConfig::with_config(self.config.clone()));
+                    let src_window_id = self.mux_window_id;
+
+                    promise::spawn::spawn(async move {
+                        if let Err(err) = crate::spawn::spawn_command_internal(
+                            spawn,
+                            SpawnWhere::NewWindow,
+                            size,
+                            Some(src_window_id),
+                            term_config,
+                        )
+                        .await
+                        {
+                            log::error!("Failed to spawn: {:#}", err);
+                        }
+                        switcher.do_switch();
+                    })
+                    .detach();
+                } else {
+                    switcher.do_switch();
+                }
+
+                self.sidebar_rename_active = Some(SidebarRenameTarget::Workspace(name.clone()));
+                self.sidebar_rename_buffer = name;
+                self.invalidate_sidebar();
+                self.window.as_ref().unwrap().invalidate();
+            }
+            (SidebarItem::NewTabButton { workspace }, WMEK::Press(MousePress::Left)) => {
+                let mux = Mux::get();
+                let active_ws = mux.active_workspace();
+                if active_ws != *workspace {
+                    let switcher = crate::frontend::WorkspaceSwitcher::new(workspace);
+                    mux.set_active_workspace(workspace);
+                    drop(switcher);
+                }
+                let spawn = SpawnCommand {
+                    domain: SpawnTabDomain::CurrentPaneDomain,
+                    ..Default::default()
+                };
+                let size = self.terminal_size;
+                let term_config =
+                    std::sync::Arc::new(TermConfig::with_config(self.config.clone()));
+                let src_window_id = self.mux_window_id;
+                promise::spawn::spawn(async move {
+                    if let Err(err) = crate::spawn::spawn_command_internal(
+                        spawn,
+                        SpawnWhere::NewTab,
+                        size,
+                        Some(src_window_id),
+                        term_config,
+                    )
+                    .await
+                    {
+                        log::error!("Failed to spawn new tab: {:#}", err);
+                    }
+                })
+                .detach();
+                self.invalidate_sidebar();
+                self.window.as_ref().unwrap().invalidate();
+            }
+            (SidebarItem::WorkspaceCloseButton { name }, WMEK::Press(MousePress::Left)) => {
+                let mux = Mux::get();
+                let window_ids = mux.iter_windows_in_workspace(name);
+                for wid in window_ids {
+                    mux.kill_window(wid);
+                }
+                self.invalidate_sidebar();
+                self.window.as_ref().unwrap().invalidate();
+            }
+            (SidebarItem::TabCloseButton { tab_id }, WMEK::Press(MousePress::Left)) => {
+                let mux = Mux::get();
+                mux.remove_tab(*tab_id);
+                self.invalidate_sidebar();
+                self.window.as_ref().unwrap().invalidate();
             }
             _ => {}
         }

--- a/wezterm-gui/src/termwindow/render/mod.rs
+++ b/wezterm-gui/src/termwindow/render/mod.rs
@@ -43,6 +43,7 @@ pub mod pane;
 pub mod screen_line;
 pub mod split;
 pub mod tab_bar;
+pub mod sidebar;
 pub mod window_buttons;
 
 /// The data that we associate with a line; we use this to cache it shape hash

--- a/wezterm-gui/src/termwindow/render/paint.rs
+++ b/wezterm-gui/src/termwindow/render/paint.rs
@@ -272,6 +272,11 @@ impl crate::TermWindow {
         self.paint_window_borders(&mut layers)
             .context("paint_window_borders")?;
         drop(layers);
+
+        if self.sidebar_visible {
+            self.paint_sidebar().context("paint_sidebar")?;
+        }
+
         self.paint_modal().context("paint_modal")?;
 
         Ok(())

--- a/wezterm-gui/src/termwindow/render/pane.rs
+++ b/wezterm-gui/src/termwindow/render/pane.rs
@@ -9,7 +9,7 @@ use crate::termwindow::{ScrollHit, UIItem, UIItemType};
 use ::window::bitmaps::TextureRect;
 use ::window::DeadKeyStatus;
 use anyhow::Context;
-use config::VisualBellTarget;
+use config::{DimensionContext, VisualBellTarget};
 use mux::pane::{PaneId, WithPaneLines};
 use mux::renderable::{RenderableDimensions, StableCursorPosition};
 use mux::tab::PositionedPane;
@@ -247,7 +247,22 @@ impl crate::TermWindow {
             let config = &self.config;
             let padding = self.effective_right_padding(&config) as f32;
 
-            let thumb_x = self.dimensions.pixel_width - padding as usize - border.right.get();
+            let sidebar_px = if self.sidebar_visible {
+                self.config.sidebar_width.evaluate_as_pixels(
+                    DimensionContext {
+                        dpi: self.dimensions.dpi as f32,
+                        pixel_max: self.dimensions.pixel_width as f32,
+                        pixel_cell: self.render_metrics.cell_size.width as f32,
+                    }
+                ) as usize
+            } else {
+                0
+            };
+
+            let thumb_x = self.dimensions.pixel_width
+                - padding as usize
+                - border.right.get()
+                - sidebar_px;
 
             // Register the scroll bar location
             self.ui_items.push(UIItem {

--- a/wezterm-gui/src/termwindow/render/sidebar.rs
+++ b/wezterm-gui/src/termwindow/render/sidebar.rs
@@ -1,0 +1,576 @@
+use crate::termwindow::box_model::*;
+use crate::termwindow::{SidebarItem, SidebarRenameTarget, UIItemType};
+use crate::utilsprites::RenderMetrics;
+use config::{Dimension, DimensionContext, TabBarColors};
+use mux::Mux;
+use window::color::LinearRgba;
+
+impl super::super::TermWindow {
+    pub fn paint_sidebar(&mut self) -> anyhow::Result<()> {
+        if !self.sidebar_visible {
+            return Ok(());
+        }
+
+        // Always rebuild to reflect current state (active tab, workspace changes, etc.)
+        let content = self.build_sidebar_content()?;
+        let footer = self.build_sidebar_footer()?;
+
+        let gl_state = self.render_state.as_ref().unwrap();
+
+        let mut ui_items = content.ui_items();
+        self.render_element(&content, gl_state, None)?;
+        self.ui_items.append(&mut ui_items);
+
+        let mut footer_items = footer.ui_items();
+        self.render_element(&footer, gl_state, None)?;
+        self.ui_items.append(&mut footer_items);
+
+        Ok(())
+    }
+
+    fn sidebar_colors(&self) -> SidebarColors {
+        let colors = self
+            .config
+            .colors
+            .as_ref()
+            .and_then(|c| c.tab_bar.as_ref())
+            .cloned()
+            .unwrap_or_else(TabBarColors::default);
+
+        let bg_color = if self.focused.is_some() {
+            self.config.window_frame.active_titlebar_bg
+        } else {
+            self.config.window_frame.inactive_titlebar_bg
+        }
+        .to_linear();
+
+        let fg_color = if self.focused.is_some() {
+            self.config.window_frame.active_titlebar_fg
+        } else {
+            self.config.window_frame.inactive_titlebar_fg
+        }
+        .to_linear();
+
+        let active_tab = colors.active_tab();
+        let inactive_tab = colors.inactive_tab();
+        let hover_tab = colors.inactive_tab_hover();
+
+        // Ghost color: barely visible against background
+        let ghost = LinearRgba::with_components(
+            bg_color.0 + 0.06,
+            bg_color.1 + 0.06,
+            bg_color.2 + 0.06,
+            1.0,
+        );
+
+        SidebarColors {
+            bg: bg_color,
+            fg: fg_color,
+            active_bg: active_tab.bg_color.to_linear(),
+            active_fg: active_tab.fg_color.to_linear(),
+            tab_fg: inactive_tab.fg_color.to_linear(),
+            hover_bg: hover_tab.bg_color.to_linear(),
+            hover_fg: hover_tab.fg_color.to_linear(),
+            header_fg: self.config.window_frame.button_fg.to_linear(),
+            border_color: colors.inactive_tab_edge().to_linear(),
+            ghost,
+        }
+    }
+
+    fn build_sidebar_content(&self) -> anyhow::Result<ComputedElement> {
+        let font = self.fonts.title_font()?;
+        let btn_font = self.fonts.command_palette_font()?;
+        let metrics = RenderMetrics::with_font_metrics(&font.metrics());
+
+        let mux = Mux::get();
+        let active_ws = mux.active_workspace();
+        let workspaces = mux.iter_workspaces();
+        let c = self.sidebar_colors();
+
+        log::debug!(
+            "sidebar: active_ws={:?}, workspaces={:?}, collapsed={:?}",
+            active_ws,
+            workspaces,
+            self.sidebar_collapsed
+        );
+
+        // Header: "WORKSPACES"
+        let mut elements = vec![
+            Element::new(&font, ElementContent::Text("WORKSPACES".to_string()))
+                .colors(ElementColors {
+                    border: BorderColor {
+                        left: LinearRgba::TRANSPARENT,
+                        top: LinearRgba::TRANSPARENT,
+                        right: LinearRgba::TRANSPARENT,
+                        bottom: c.border_color,
+                    },
+                    bg: c.bg.into(),
+                    text: c.header_fg.into(),
+                })
+                .border(BoxDimension {
+                    left: Dimension::Pixels(0.0),
+                    top: Dimension::Pixels(0.0),
+                    right: Dimension::Pixels(0.0),
+                    bottom: Dimension::Pixels(1.0),
+                })
+                .padding(BoxDimension {
+                    left: Dimension::Cells(0.75),
+                    right: Dimension::Cells(0.5),
+                    top: Dimension::Cells(0.5),
+                    bottom: Dimension::Cells(0.4),
+                })
+                .min_width(Some(Dimension::Percent(1.0)))
+                .display(DisplayType::Block)
+                .zindex(5),
+        ];
+
+        // Workspace rows
+        for ws_name in &workspaces {
+            let is_active = ws_name == &active_ws;
+            let is_expanded = !self.sidebar_collapsed.contains(ws_name.as_str());
+            let is_renaming = matches!(
+                &self.sidebar_rename_active,
+                Some(SidebarRenameTarget::Workspace(n)) if n == ws_name
+            );
+
+            let row_bg = if is_active { c.active_bg } else { c.bg };
+            let row_fg = if is_active { c.active_fg } else { c.fg };
+
+            let mut row_children = Vec::new();
+
+            // Disclosure triangle
+            let disclosure_char = if is_expanded { "\u{25BC}" } else { "\u{25B6}" };
+            row_children.push(
+                Element::new(&font, ElementContent::Text(disclosure_char.to_string()))
+                    .colors(ElementColors {
+                        border: BorderColor::default(),
+                        bg: LinearRgba::TRANSPARENT.into(),
+                        text: c.header_fg.into(),
+                    })
+                    .padding(BoxDimension {
+                        left: Dimension::Cells(0.0),
+                        right: Dimension::Cells(0.3),
+                        top: Dimension::Cells(0.0),
+                        bottom: Dimension::Cells(0.0),
+                    })
+                    .item_type(UIItemType::Sidebar(SidebarItem::WorkspaceDisclosure {
+                        name: ws_name.clone(),
+                    })),
+            );
+
+            // Workspace name or rename field
+            if is_renaming {
+                let rename_text = format!("{}|", self.sidebar_rename_buffer);
+                row_children.push(
+                    Element::new(&font, ElementContent::Text(rename_text))
+                        .colors(ElementColors {
+                            border: BorderColor::default(),
+                            bg: LinearRgba::TRANSPARENT.into(),
+                            text: c.fg.into(),
+                        })
+                        .item_type(UIItemType::Sidebar(SidebarItem::RenameTextField)),
+                );
+            } else {
+                row_children.push(
+                    Element::new(&font, ElementContent::Text(ws_name.clone()))
+                        .colors(ElementColors {
+                            border: BorderColor::default(),
+                            bg: LinearRgba::TRANSPARENT.into(),
+                            text: row_fg.into(),
+                        })
+                        .item_type(UIItemType::Sidebar(SidebarItem::WorkspaceHeader {
+                            name: ws_name.clone(),
+                        })),
+                );
+            }
+
+            // Close button — ghost, red danger on hover (uses larger font)
+            row_children.push(
+                Element::new(&btn_font, ElementContent::Text("\u{2715}".to_string()))
+                    .float(Float::Right)
+                    .padding(BoxDimension {
+                        left: Dimension::Cells(0.25),
+                        right: Dimension::Cells(0.0),
+                        top: Dimension::Cells(0.0),
+                        bottom: Dimension::Cells(0.0),
+                    })
+                    .colors(ElementColors {
+                        border: BorderColor::default(),
+                        bg: LinearRgba::TRANSPARENT.into(),
+                        text: c.ghost.into(),
+                    })
+                    .hover_colors(Some(ElementColors {
+                        border: BorderColor::default(),
+                        bg: LinearRgba::with_components(0.7, 0.2, 0.2, 1.0).into(),
+                        text: LinearRgba::with_components(1.0, 1.0, 1.0, 1.0).into(),
+                    }))
+                    .item_type(UIItemType::Sidebar(SidebarItem::WorkspaceCloseButton {
+                        name: ws_name.clone(),
+                    })),
+            );
+
+            // New tab button (+) — ghost, brightens on hover (uses larger font)
+            row_children.push(
+                Element::new(&btn_font, ElementContent::Text("+".to_string()))
+                    .float(Float::Right)
+                    .padding(BoxDimension {
+                        left: Dimension::Cells(0.25),
+                        right: Dimension::Cells(0.25),
+                        top: Dimension::Cells(0.0),
+                        bottom: Dimension::Cells(0.0),
+                    })
+                    .colors(ElementColors {
+                        border: BorderColor::default(),
+                        bg: LinearRgba::TRANSPARENT.into(),
+                        text: c.ghost.into(),
+                    })
+                    .hover_colors(Some(ElementColors {
+                        border: BorderColor::default(),
+                        bg: c.hover_bg.into(),
+                        text: c.hover_fg.into(),
+                    }))
+                    .item_type(UIItemType::Sidebar(SidebarItem::NewTabButton {
+                        workspace: ws_name.clone(),
+                    })),
+            );
+
+            // Workspace row container
+            let ws_row = Element::new(&font, ElementContent::Children(row_children))
+                .colors(ElementColors {
+                    border: if is_active {
+                        BorderColor {
+                            left: c.active_fg,
+                            top: LinearRgba::TRANSPARENT,
+                            right: LinearRgba::TRANSPARENT,
+                            bottom: LinearRgba::TRANSPARENT,
+                        }
+                    } else {
+                        BorderColor::default()
+                    },
+                    bg: row_bg.into(),
+                    text: row_fg.into(),
+                })
+                .border(if is_active {
+                    BoxDimension {
+                        left: Dimension::Pixels(2.0),
+                        top: Dimension::Pixels(0.0),
+                        right: Dimension::Pixels(0.0),
+                        bottom: Dimension::Pixels(0.0),
+                    }
+                } else {
+                    BoxDimension::default()
+                })
+                .hover_colors(Some(ElementColors {
+                    border: BorderColor::default(),
+                    bg: c.hover_bg.into(),
+                    text: c.hover_fg.into(),
+                }))
+                .padding(BoxDimension {
+                    left: Dimension::Cells(0.5),
+                    right: Dimension::Cells(0.5),
+                    top: Dimension::Cells(0.4),
+                    bottom: Dimension::Cells(0.4),
+                })
+                .line_height(Some(1.25))
+                .min_width(Some(Dimension::Percent(1.0)))
+                .display(DisplayType::Block)
+                .zindex(5);
+
+            elements.push(ws_row);
+
+            // Expanded tabs
+            if is_expanded {
+                let wids = mux.iter_windows_in_workspace(ws_name);
+                for wid in wids {
+                    if let Some(window) = mux.get_window(wid) {
+                        for tab in window.iter() {
+                            let tab_title = tab.get_title();
+                            let title = if tab_title.is_empty() {
+                                tab.get_active_pane()
+                                    .map(|pane| pane.get_title())
+                                    .unwrap_or_else(|| "(no pane)".to_string())
+                            } else {
+                                tab_title
+                            };
+                            let tid = tab.tab_id();
+
+                            // Check if this is the currently viewed tab
+                            // (active tab in the active workspace only)
+                            let is_current_tab = is_active
+                                && mux
+                                    .get_active_tab_for_window(wid)
+                                    .map(|active| active.tab_id() == tid)
+                                    .unwrap_or(false);
+
+                            let is_tab_renaming = matches!(
+                                &self.sidebar_rename_active,
+                                Some(SidebarRenameTarget::Tab(id)) if *id == tid
+                            );
+
+                            let mut tab_children = Vec::new();
+
+                            if is_tab_renaming {
+                                let rename_text = format!("{}|", self.sidebar_rename_buffer);
+                                tab_children.push(
+                                    Element::new(&font, ElementContent::Text(rename_text))
+                                        .colors(ElementColors {
+                                            border: BorderColor::default(),
+                                            bg: LinearRgba::TRANSPARENT.into(),
+                                            text: c.fg.into(),
+                                        })
+                                        .item_type(UIItemType::Sidebar(SidebarItem::RenameTextField)),
+                                );
+                            } else {
+                                // Green dot only for the tab currently being viewed
+                                let activity_prefix = if is_current_tab {
+                                    "\u{25CF} "
+                                } else {
+                                    "  "
+                                };
+                                let display_title =
+                                    format!("{}{}", activity_prefix, title);
+                                tab_children.push(
+                                    Element::new(
+                                        &font,
+                                        ElementContent::Text(display_title),
+                                    )
+                                    .colors(ElementColors {
+                                        border: BorderColor::default(),
+                                        bg: LinearRgba::TRANSPARENT.into(),
+                                        text: c.tab_fg.into(),
+                                    })
+                                    .item_type(UIItemType::Sidebar(SidebarItem::TabEntry {
+                                        workspace: ws_name.clone(),
+                                        window_id: wid,
+                                        tab_id: tid,
+                                    })),
+                                );
+                            }
+
+                            // Tab close button — ghost, subtle on hover (larger font)
+                            tab_children.push(
+                                Element::new(
+                                    &btn_font,
+                                    ElementContent::Text("\u{2715}".to_string()),
+                                )
+                                .float(Float::Right)
+                                .padding(BoxDimension {
+                                    left: Dimension::Cells(0.3),
+                                    right: Dimension::Cells(0.1),
+                                    top: Dimension::Cells(0.0),
+                                    bottom: Dimension::Cells(0.0),
+                                })
+                                .colors(ElementColors {
+                                    border: BorderColor::default(),
+                                    bg: LinearRgba::TRANSPARENT.into(),
+                                    text: c.ghost.into(),
+                                })
+                                .hover_colors(Some(ElementColors {
+                                    border: BorderColor::default(),
+                                    bg: c.hover_bg.into(),
+                                    text: c.hover_fg.into(),
+                                }))
+                                .item_type(UIItemType::Sidebar(SidebarItem::TabCloseButton {
+                                    tab_id: tid,
+                                })),
+                            );
+
+                            let tab_row =
+                                Element::new(&font, ElementContent::Children(tab_children))
+                                    .colors(ElementColors {
+                                        border: BorderColor::default(),
+                                        bg: c.bg.into(),
+                                        text: c.tab_fg.into(),
+                                    })
+                                    .hover_colors(Some(ElementColors {
+                                        border: BorderColor::default(),
+                                        bg: c.hover_bg.into(),
+                                        text: c.hover_fg.into(),
+                                    }))
+                                    .padding(BoxDimension {
+                                        left: Dimension::Cells(1.5),
+                                        right: Dimension::Cells(0.5),
+                                        top: Dimension::Cells(0.3),
+                                        bottom: Dimension::Cells(0.3),
+                                    })
+                                    .line_height(Some(1.25))
+                                    .item_type(UIItemType::Sidebar(SidebarItem::TabEntry {
+                                        workspace: ws_name.clone(),
+                                        window_id: wid,
+                                        tab_id: tid,
+                                    }))
+                                    .min_width(Some(Dimension::Percent(1.0)))
+                                    .display(DisplayType::Block)
+                                    .zindex(5);
+
+                            elements.push(tab_row);
+                        }
+                        drop(window);
+                    }
+                }
+            }
+        }
+
+        // Root container (scrollable content)
+        let root = Element::new(&font, ElementContent::Children(elements))
+            .colors(ElementColors {
+                border: BorderColor {
+                    left: c.border_color,
+                    top: LinearRgba::TRANSPARENT,
+                    right: LinearRgba::TRANSPARENT,
+                    bottom: LinearRgba::TRANSPARENT,
+                },
+                bg: c.bg.into(),
+                text: c.fg.into(),
+            })
+            .border(BoxDimension {
+                left: Dimension::Pixels(1.0),
+                top: Dimension::Pixels(0.0),
+                right: Dimension::Pixels(0.0),
+                bottom: Dimension::Pixels(0.0),
+            })
+            .min_height(Some(Dimension::Percent(1.0)))
+            .item_type(UIItemType::Sidebar(SidebarItem::Background))
+            .display(DisplayType::Block)
+            .zindex(5);
+
+        // Position the sidebar
+        let border = self.get_os_border();
+        let tab_bar_y = if self.show_tab_bar {
+            self.tab_bar_pixel_height().unwrap_or(0.)
+        } else {
+            0.
+        };
+
+        let h_context = DimensionContext {
+            dpi: self.dimensions.dpi as f32,
+            pixel_max: self.dimensions.pixel_width as f32,
+            pixel_cell: metrics.cell_size.width as f32,
+        };
+        let sidebar_width = self.config.sidebar_width.evaluate_as_pixels(h_context);
+
+        let pixel_width = self.dimensions.pixel_width as f32;
+        let pixel_height = self.dimensions.pixel_height as f32;
+        let sidebar_x = pixel_width - sidebar_width - border.right.get() as f32;
+        let sidebar_y = border.top.get() as f32 + tab_bar_y;
+
+        let mut computed = self.compute_element(
+            &LayoutContext {
+                height: DimensionContext {
+                    dpi: self.dimensions.dpi as f32,
+                    pixel_max: pixel_height,
+                    pixel_cell: metrics.cell_size.height as f32,
+                },
+                width: DimensionContext {
+                    dpi: self.dimensions.dpi as f32,
+                    pixel_max: sidebar_width,
+                    pixel_cell: metrics.cell_size.width as f32,
+                },
+                bounds: euclid::rect(0., 0., sidebar_width, pixel_height - sidebar_y),
+                metrics: &metrics,
+                gl_state: self.render_state.as_ref().unwrap(),
+                zindex: 5,
+            },
+            &root,
+        )?;
+
+        computed.translate(euclid::vec2(sidebar_x, sidebar_y - self.sidebar_scroll_offset));
+
+        Ok(computed)
+    }
+
+    fn build_sidebar_footer(&self) -> anyhow::Result<ComputedElement> {
+        let font = self.fonts.title_font()?;
+        let metrics = RenderMetrics::with_font_metrics(&font.metrics());
+        let c = self.sidebar_colors();
+
+        let footer = Element::new(
+            &font,
+            ElementContent::Text("+ New Workspace".to_string()),
+        )
+        .colors(ElementColors {
+            border: BorderColor {
+                left: c.border_color,
+                top: c.border_color,
+                right: LinearRgba::TRANSPARENT,
+                bottom: LinearRgba::TRANSPARENT,
+            },
+            bg: c.bg.into(),
+            text: c.header_fg.into(),
+        })
+        .border(BoxDimension {
+            left: Dimension::Pixels(1.0),
+            top: Dimension::Pixels(1.0),
+            right: Dimension::Pixels(0.0),
+            bottom: Dimension::Pixels(0.0),
+        })
+        .hover_colors(Some(ElementColors {
+            border: BorderColor::default(),
+            bg: c.hover_bg.into(),
+            text: c.hover_fg.into(),
+        }))
+        .padding(BoxDimension {
+            left: Dimension::Cells(0.75),
+            right: Dimension::Cells(0.5),
+            top: Dimension::Cells(0.5),
+            bottom: Dimension::Cells(0.5),
+        })
+        .min_width(Some(Dimension::Percent(1.0)))
+        .item_type(UIItemType::Sidebar(SidebarItem::NewWorkspaceButton))
+        .display(DisplayType::Block)
+        .zindex(5);
+
+        // Position at bottom of sidebar
+        let border = self.get_os_border();
+        let h_context = DimensionContext {
+            dpi: self.dimensions.dpi as f32,
+            pixel_max: self.dimensions.pixel_width as f32,
+            pixel_cell: metrics.cell_size.width as f32,
+        };
+        let sidebar_width = self.config.sidebar_width.evaluate_as_pixels(h_context);
+
+        let pixel_width = self.dimensions.pixel_width as f32;
+        let pixel_height = self.dimensions.pixel_height as f32;
+        let sidebar_x = pixel_width - sidebar_width - border.right.get() as f32;
+
+        // Compute the footer element to get its height
+        let layout_ctx = LayoutContext {
+            height: DimensionContext {
+                dpi: self.dimensions.dpi as f32,
+                pixel_max: pixel_height,
+                pixel_cell: metrics.cell_size.height as f32,
+            },
+            width: DimensionContext {
+                dpi: self.dimensions.dpi as f32,
+                pixel_max: sidebar_width,
+                pixel_cell: metrics.cell_size.width as f32,
+            },
+            bounds: euclid::rect(0., 0., sidebar_width, pixel_height),
+            metrics: &metrics,
+            gl_state: self.render_state.as_ref().unwrap(),
+            zindex: 5,
+        };
+
+        let mut computed = self.compute_element(&layout_ctx, &footer)?;
+        let footer_height = computed.bounds.height();
+        let footer_y = pixel_height - footer_height - border.bottom.get() as f32;
+
+        computed.translate(euclid::vec2(sidebar_x, footer_y));
+
+        Ok(computed)
+    }
+}
+
+/// Colors used throughout the sidebar, derived from config theme.
+struct SidebarColors {
+    bg: LinearRgba,
+    fg: LinearRgba,
+    active_bg: LinearRgba,
+    active_fg: LinearRgba,
+    tab_fg: LinearRgba,
+    hover_bg: LinearRgba,
+    hover_fg: LinearRgba,
+    header_fg: LinearRgba,
+    border_color: LinearRgba,
+    ghost: LinearRgba,
+}

--- a/wezterm-gui/src/termwindow/resize.rs
+++ b/wezterm-gui/src/termwindow/resize.rs
@@ -201,6 +201,22 @@ impl super::TermWindow {
                 config.window_padding.bottom.evaluate_as_pixels(v_context) as usize;
             let padding_right = effective_right_padding(&config, h_context);
 
+            let evaluated_sidebar_width = if self.sidebar_visible {
+                self.config.sidebar_width.evaluate_as_pixels(h_context) as usize
+            } else {
+                0
+            };
+            let sidebar_px = if evaluated_sidebar_width > 0 {
+                let tentative_cols = cols;
+                if tentative_cols < 40 {
+                    0
+                } else {
+                    evaluated_sidebar_width
+                }
+            } else {
+                0
+            };
+
             let pixel_height = (rows * self.render_metrics.cell_size.height as usize)
                 + (padding_top + padding_bottom)
                 + (border.top + border.bottom).get() as usize
@@ -208,7 +224,8 @@ impl super::TermWindow {
 
             let pixel_width = (cols * self.render_metrics.cell_size.width as usize)
                 + (padding_left + padding_right)
-                + (border.left + border.right).get() as usize;
+                + (border.left + border.right).get() as usize
+                + sidebar_px;
 
             let dims = Dimensions {
                 pixel_width: pixel_width as usize,
@@ -221,7 +238,7 @@ impl super::TermWindow {
                 y: self.render_metrics.cell_size.height as u16,
                 padding_left: padding_left,
                 padding_top: padding_top,
-                padding_right: padding_right,
+                padding_right: padding_right + sidebar_px,
                 padding_bottom: padding_bottom,
                 border: border,
                 tab_bar_height: tab_bar_height as usize,
@@ -247,9 +264,30 @@ impl super::TermWindow {
                 config.window_padding.bottom.evaluate_as_pixels(v_context) as usize;
             let padding_right = effective_right_padding(&config, h_context);
 
+            let evaluated_sidebar_width = if self.sidebar_visible {
+                self.config.sidebar_width.evaluate_as_pixels(h_context) as usize
+            } else {
+                0
+            };
+            let sidebar_px = if evaluated_sidebar_width > 0 {
+                let tentative_avail = dimensions.pixel_width.saturating_sub(
+                    (padding_left + padding_right) as usize
+                        + (border.left + border.right).get() as usize
+                        + evaluated_sidebar_width,
+                );
+                let tentative_cols = tentative_avail / self.render_metrics.cell_size.width as usize;
+                if tentative_cols < 40 {
+                    0
+                } else {
+                    evaluated_sidebar_width
+                }
+            } else {
+                0
+            };
             let avail_width = dimensions.pixel_width.saturating_sub(
                 (padding_left + padding_right) as usize
-                    + (border.left + border.right).get() as usize,
+                    + (border.left + border.right).get() as usize
+                    + sidebar_px,
             );
             let avail_height = dimensions
                 .pixel_height
@@ -279,7 +317,7 @@ impl super::TermWindow {
                 y: self.render_metrics.cell_size.height as u16,
                 padding_left: padding_left,
                 padding_top: padding_top,
-                padding_right: padding_right,
+                padding_right: padding_right + sidebar_px,
                 padding_bottom: padding_bottom,
                 border: border,
                 tab_bar_height: tab_bar_height as usize,


### PR DESCRIPTION
Add a native, toggleable workspace sidebar that displays all workspaces and their tabs in a tree view. Toggle with Ctrl+Shift+E (configurable).

Features:
- Click to switch workspaces and tabs
- Double-click to inline rename workspaces and tabs
- Per-item hover close buttons (red danger zone for workspaces)
- Ghost buttons (+/✕) that reveal on hover
- Active tab indicator (green dot)
- Bottom-pinned "+ New Workspace" footer
- Theme-aware colors from window_frame and tab_bar config
- Configurable width, position (left/right), and default visibility
- Scroll support and persistent expand/collapse state

New config options: sidebar_width, sidebar_position, sidebar_default_visible
New key assignment: ToggleSidebar


Alright imma be real, this feature is 100% vibe coded. I wanted a better way to manage wor spaces and tabs and im a visual kinda guy. 100% reject this or redesign it if you want idrc, i just figure id share it.