### PR TITLE
fonts: add configurable font thickening

### DIFF
--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -288,6 +288,19 @@ pub struct Config {
     pub freetype_render_target: Option<FreeTypeLoadTarget>,
     #[dynamic(default)]
     pub freetype_load_flags: Option<FreeTypeLoadFlags>,
+    /// Draw fonts with a thicker stroke, if supported.
+    #[dynamic(default)]
+    pub font_thicken: bool,
+    /// Strength of thickening when `font_thicken` is enabled.
+    ///
+    /// Valid values are integers between `0` and `255`. `0` does not
+    /// correspond to *no* thickening, rather it corresponds to the
+    /// lightest available thickening.
+    ///
+    /// Has no effect when `font_thicken` is set to `false`.
+    ///
+    #[dynamic(default = "default_font_thicken_strength")]
+    pub font_thicken_strength: u8,
 
     /// Selects the freetype interpret version to use.
     /// Likely values are 35, 38 and 40 which have different
@@ -2192,4 +2205,8 @@ fn default_macos_forward_mods() -> Modifiers {
 
 fn default_colr_rasterizer() -> FontRasterizerSelection {
     FontRasterizerSelection::Harfbuzz
+}
+
+fn default_font_thicken_strength() -> u8 {
+    255
 }

--- a/docs/config/fonts.md
+++ b/docs/config/fonts.md
@@ -58,6 +58,8 @@ Additional options for configuring fonts can be found elsewhere in the docs:
 * [font_locator](lua/config/font_locator.md) - override the system font resolver
 * [font_rules](lua/config/font_rules.md) - advanced control over which fonts are used for italic, bold and other textual styles
 * [font_shaper](lua/config/font_shaper.md) - affects kerning and ligatures
+* [font_thicken](lua/config/font_thicken.md) - draw fonts with a thicker stroke
+* [font_thicken_strength](lua/config/font_thicken_strength.md) - control the amount of thickening
 * [font_size](lua/config/font_size.md) - change the size of the text
 * [freetype_load_flags](lua/config/freetype_load_flags.md) - advanced hinting configuration
 * [freetype_load_target](lua/config/freetype_load_target.md) - configure hinting and anti-aliasing

--- a/docs/config/lua/config/font_thicken.md
+++ b/docs/config/lua/config/font_thicken.md
@@ -1,0 +1,17 @@
+---
+tags:
+  - font
+---
+# `font_thicken = false`
+
+Draw fonts with a thicker stroke.
+
+This is implemented for the `FreeType` font rasterizer and applies to
+outline glyphs.
+
+```lua
+config.font_thicken = true
+```
+
+Use [font_thicken_strength](font_thicken_strength.md) to control the amount
+of thickening.

--- a/docs/config/lua/config/font_thicken_strength.md
+++ b/docs/config/lua/config/font_thicken_strength.md
@@ -1,0 +1,18 @@
+---
+tags:
+  - font
+---
+# `font_thicken_strength = 255`
+
+Controls the strength of [font_thicken](font_thicken.md).
+
+Valid values are integers between `0` and `255`. `0` does not correspond to
+no thickening; it selects the lightest available thickening.
+
+This setting only has an effect when `font_thicken = true`, using the
+`FreeType` rasterizer for outline glyphs.
+
+```lua
+config.font_thicken = true
+config.font_thicken_strength = 128
+```

--- a/wezterm-font/src/ftwrap.rs
+++ b/wezterm-font/src/ftwrap.rs
@@ -914,6 +914,8 @@ impl Face {
         load_flags: FT_Int32,
         render_mode: FT_Render_Mode,
         synthesize_bold: bool,
+        thicken: bool,
+        thicken_strength: u8,
     ) -> anyhow::Result<&FT_GlyphSlotRec_> {
         unsafe {
             ft_result(
@@ -934,6 +936,17 @@ impl Face {
 
             if synthesize_bold {
                 FT_GlyphSlot_Embolden(slot as *mut _);
+            }
+
+            if thicken && slot.format == FT_Glyph_Format_::FT_GLYPH_FORMAT_OUTLINE {
+                let strength = thicken_strength as i64;
+                // Maps [0, 255] to [1, 37] in F26Dot6 units (64 units = 1 pixel),
+                // giving a thickening range of roughly 0.016–0.578 pixels.
+                // The +1 ensures a minimum non-zero thickening when enabled.
+                let amount = 1 + (strength * 36 / 255);
+                let amount = FT_Pos::from(FT_F26Dot6::from_bits(amount as _));
+                ft_result(FT_Outline_EmboldenXY(&mut slot.outline, amount, amount), ())
+                    .context("load_and_render_glyph: FT_Outline_EmboldenXY")?;
             }
 
             // Current versions of freetype overload the operation of FT_LOAD_COLOR
@@ -976,7 +989,8 @@ impl Face {
             anyhow::bail!("no I from which to compute cap height");
         }
         let (load_flags, render_mode) = compute_load_flags_from_config(None, None, None, None);
-        let ft_glyph = self.load_and_render_glyph(glyph_pos, load_flags, render_mode, false)?;
+        let ft_glyph =
+            self.load_and_render_glyph(glyph_pos, load_flags, render_mode, false, false, 255)?;
 
         let mode: FT_Pixel_Mode =
             unsafe { std::mem::transmute(u32::from(ft_glyph.bitmap.pixel_mode)) };

--- a/wezterm-font/src/lib.rs
+++ b/wezterm-font/src/lib.rs
@@ -271,17 +271,28 @@ impl LoadedFont {
         if let Some(raster) = rasterizers.get(&fallback) {
             raster.rasterize_glyph(glyph_pos, self.font_size, self.dpi)
         } else {
-            let raster_selection = self
-                .font_config
-                .upgrade()
+            let font_config = self.font_config.upgrade();
+            let raster_selection = font_config
+                .as_ref()
                 .map_or(FontRasterizerSelection::default(), |c| {
                     c.config.borrow().font_rasterizer
                 });
-            let raster = new_rasterizer(
-                raster_selection,
-                &(self.handles.borrow())[fallback],
-                self.pixel_geometry,
-            )?;
+            let raster = if let Some(c) = &font_config {
+                let cfg = c.config.borrow();
+                new_rasterizer(
+                    raster_selection,
+                    &(self.handles.borrow())[fallback],
+                    self.pixel_geometry,
+                    &cfg,
+                )?
+            } else {
+                new_rasterizer(
+                    raster_selection,
+                    &(self.handles.borrow())[fallback],
+                    self.pixel_geometry,
+                    &Default::default(),
+                )?
+            };
             let result = raster.rasterize_glyph(glyph_pos, self.font_size, self.dpi);
             rasterizers.insert(fallback, raster);
             result

--- a/wezterm-font/src/rasterizer/freetype.rs
+++ b/wezterm-font/src/rasterizer/freetype.rs
@@ -29,6 +29,8 @@ pub struct FreeTypeRasterizer {
     face: RefCell<ftwrap::Face>,
     _lib: ftwrap::Library,
     synthesize_bold: bool,
+    font_thicken: bool,
+    font_thicken_strength: u8,
     freetype_load_target: Option<FreeTypeLoadTarget>,
     freetype_render_target: Option<FreeTypeLoadTarget>,
     freetype_load_flags: Option<FreeTypeLoadFlags>,
@@ -62,6 +64,8 @@ impl FontRasterizer for FreeTypeRasterizer {
             load_flags,
             render_mode,
             self.synthesize_bold,
+            self.font_thicken,
+            self.font_thicken_strength,
         ) {
             Ok(g) => g,
             Err(err) => {
@@ -380,6 +384,7 @@ impl FreeTypeRasterizer {
     pub fn from_locator(
         parsed: &ParsedFont,
         display_pixel_geometry: DisplayPixelGeometry,
+        config: &config::Config,
     ) -> anyhow::Result<Self> {
         log::trace!("Rasterizier wants {:?}", parsed);
         let lib = ftwrap::Library::new()?;
@@ -402,6 +407,8 @@ impl FreeTypeRasterizer {
             face: RefCell::new(face),
             has_color,
             synthesize_bold: parsed.synthesize_bold,
+            font_thicken: config.font_thicken,
+            font_thicken_strength: config.font_thicken_strength,
             freetype_load_flags: parsed.freetype_load_flags,
             freetype_load_target: parsed.freetype_load_target,
             freetype_render_target: parsed.freetype_render_target,

--- a/wezterm-font/src/rasterizer/mod.rs
+++ b/wezterm-font/src/rasterizer/mod.rs
@@ -41,10 +41,11 @@ pub fn new_rasterizer(
     rasterizer: FontRasterizerSelection,
     handle: &ParsedFont,
     pixel_geometry: config::DisplayPixelGeometry,
+    config: &config::Config,
 ) -> anyhow::Result<Box<dyn FontRasterizer>> {
     match rasterizer {
         FontRasterizerSelection::FreeType => Ok(Box::new(
-            freetype::FreeTypeRasterizer::from_locator(handle, pixel_geometry)?,
+            freetype::FreeTypeRasterizer::from_locator(handle, pixel_geometry, config)?,
         )),
         FontRasterizerSelection::Harfbuzz => Ok(Box::new(
             harfbuzz::HarfbuzzRasterizer::from_locator(handle)?,


### PR DESCRIPTION
Hi! First of all, thanks a lot for the project!

I was considering about switching to WezTerm and the major blocker that I noticed was the thin font rendering compared to other terminals like Alacritty or Ghostty on macOS. Then searching in the existing issues, I noticed some filed already that had some attention. So this fixes #3774 and fixes #7192.

I initially had the same issue when I first tried Ghostty, and I managed to fix it by using [`font-thicken = true`](https://ghostty.org/docs/config/reference#font-thicken) in their config. That's why I was looking at how Ghostty implemented it, and it was actually pretty straightforward. So I did something similar to WezTerm in this PR. I might be biased, but I think this is one of big reasons for people to bounce after trying it a bit (at least on macOS).

So this PR adds a `font_thicken` option, along with `font_thicken_strength`, to render glyphs with a slightly heavier stroke.

I saw that Ghostty's implementation was macOS only. But I think it's because they use CoreText/CoreGraphics to do it. This PR only adds it to FreeType rasterizer, and I didn't limit this config option to macOS only since it isn't platform dependent. But happy to hear your thoughts and would be happy to change if you prefer. I `FT_Outline_EmboldenXY` to implement the thickening right now, which works fairly well in my local testing. See also the side by side comparisons below.

One thing that I'm not super happy with is the 36 magic number that I pass to `FT_Outline_EmboldenXY`. Since we don't use CoreText, this is mostly an approximation instead of a native value. But I fine tuned it to look very close and I'm happy with this current state now.

Please let me know what you think!


Before (left is ghostty, right is wezterm):
<img width="928" height="335" alt="Screenshot 2026-03-21 at 11 59 14 PM" src="https://github.com/user-attachments/assets/50ebb4be-db91-4471-b1a6-672a9d12fd6e" />

After (left is ghostty, right is wezterm):
<img width="926" height="331" alt="Screenshot 2026-03-22 at 12 37 34 AM" src="https://github.com/user-attachments/assets/715fae35-2229-4572-9800-5c71ba3e718a" />
