### PR TITLE
Feature: add support to sync input between all pane in same tab

### DIFF
--- a/config/src/keyassignment.rs
+++ b/config/src/keyassignment.rs
@@ -646,6 +646,7 @@ pub enum KeyAssignment {
     PromptInputLine(PromptInputLine),
     InputSelector(InputSelector),
     Confirmation(Confirmation),
+    TogglePaneInputSynchronization,
 }
 impl_lua_conversion_dynamic!(KeyAssignment);
 

--- a/lua-api-crates/mux/src/tab.rs
+++ b/lua-api-crates/mux/src/tab.rs
@@ -80,6 +80,19 @@ impl UserData for MuxTab {
             Ok(was_zoomed)
         });
 
+        methods.add_method("get_input_synchronization", |_, this, _: ()| {
+            let mux = get_mux()?;
+            let tab = this.resolve(&mux)?;
+            Ok(tab.sync_input())
+        });
+
+        methods.add_method("set_input_synchronization", |_, this, enabled: bool| {
+            let mux = get_mux()?;
+            let tab = this.resolve(&mux)?;
+            tab.set_sync_input(enabled);
+            Ok(())
+        });
+
         methods.add_method("panes_with_info", |lua, this, _: ()| {
             let mux = get_mux()?;
             let tab = this.resolve(&mux)?;

--- a/mux/src/tab.rs
+++ b/mux/src/tab.rs
@@ -46,6 +46,8 @@ struct TabInner {
     zoomed: Option<Arc<dyn Pane>>,
     title: String,
     recency: Recency,
+    /// When true, keyboard input is mirrored to every pane in this tab
+    sync_input: bool,
 }
 
 /// A Tab is a container of Panes
@@ -706,6 +708,17 @@ impl Tab {
         self.inner.lock().set_active_idx(pane_index)
     }
 
+    /// Returns whether synchronized input is enabled for this tab.
+    /// When enabled, every keystroke is mirrored to all panes in the tab.
+    pub fn sync_input(&self) -> bool {
+        self.inner.lock().sync_input
+    }
+
+    /// Enable or disable synchronized input for this tab.
+    pub fn set_sync_input(&self, enabled: bool) {
+        self.inner.lock().sync_input = enabled;
+    }
+
     /// Assigns the root pane.
     /// This is suitable when creating a new tab and then assigning
     /// the initial pane
@@ -764,6 +777,7 @@ impl TabInner {
             zoomed: None,
             title: String::new(),
             recency: Recency::default(),
+            sync_input: false,
         }
     }
 

--- a/wezterm-gui/src/commands.rs
+++ b/wezterm-gui/src/commands.rs
@@ -2011,6 +2011,14 @@ pub fn derive_command_from_key_assignment(action: &KeyAssignment) -> Option<Comm
             menubar: &["Edit"],
             icon: None,
         },
+        TogglePaneInputSynchronization => CommandDef {
+            brief: "Toggle pane input synchronization".into(),
+            doc: "Mirrors keyboard input to all panes in the current tab when enabled".into(),
+            keys: vec![],
+            args: &[ArgType::ActivePane],
+            menubar: &["View"],
+            icon: Some("md_sync"),
+        },
     })
 }
 

--- a/wezterm-gui/src/termwindow/keyevent.rs
+++ b/wezterm-gui/src/termwindow/keyevent.rs
@@ -5,6 +5,7 @@ use ::window::{
 use anyhow::Context;
 use config::keyassignment::{KeyAssignment, KeyTableEntry};
 use mux::pane::{Pane, PerformAssignmentResult};
+use mux::Mux;
 use smol::Timer;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -205,6 +206,81 @@ impl super::TermWindow {
             Some(key.encode_kitty(flags))
         } else {
             None
+        }
+    }
+
+    /// When synchronized input is enabled for the active tab, mirror the key event
+    /// to every pane in that tab except the one that already received it.
+    /// Each pane is encoded individually so that per-pane keyboard protocols
+    /// (win32, kitty) are respected.  Errors from individual panes are logged and
+    /// swallowed so a malfunctioning pane never disrupts the primary input path.
+    fn sync_input_to_other_panes(&mut self, active_pane: &Arc<dyn Pane>, window_key: &KeyEvent) {
+        let mux = Mux::get();
+        let tab = match mux.get_active_tab_for_window(self.mux_window_id) {
+            Some(tab) => tab,
+            None => return,
+        };
+        if !tab.sync_input() {
+            return;
+        }
+        let active_id = active_pane.pane_id();
+        // Collect into a Vec to release the tab/mux lock before we call &mut self methods.
+        let other_panes: Vec<Arc<dyn Pane>> = tab
+            .iter_panes_ignoring_zoom()
+            .into_iter()
+            .filter(|p| p.pane.pane_id() != active_id)
+            .map(|p| p.pane)
+            .collect();
+        drop(tab);
+        drop(mux);
+
+        // Decode the key once outside the loop — same result for every pane.
+        let key = self.win_key_code_to_termwiz_key_code(&window_key.key);
+
+        for other in other_panes {
+            // Do not forward into panes that have an overlay (copy mode, search, etc.)
+            // to avoid corrupting their state.
+            if self.pane_state(other.pane_id()).overlay.is_some() {
+                continue;
+            }
+            match &key {
+                Key::Code(key_code) => {
+                    let res = if let Some(encoded) = self.encode_win32_input(&other, window_key) {
+                        other
+                            .writer()
+                            .write_all(encoded.as_bytes())
+                            .context("sync: win32-input-mode")
+                    } else if let Some(encoded) = self.encode_kitty_input(&other, window_key) {
+                        other
+                            .writer()
+                            .write_all(encoded.as_bytes())
+                            .context("sync: kitty encoded")
+                    } else if window_key.key_is_down {
+                        other.key_down(*key_code, window_key.modifiers).context("sync: key_down")
+                    } else {
+                        other.key_up(*key_code, window_key.modifiers).context("sync: key_up")
+                    };
+                    if let Err(err) = res {
+                        log::warn!("sync_input pane {}: {:#}", other.pane_id(), err);
+                    } else if window_key.key_is_down && !key_code.is_modifier() {
+                        self.maybe_scroll_to_bottom_for_input(&other);
+                    }
+                }
+                Key::Composed(s) => {
+                    if window_key.key_is_down {
+                        if let Err(err) = other.writer().write_all(s.as_bytes()) {
+                            log::warn!(
+                                "sync_input pane {} composed: {:#}",
+                                other.pane_id(),
+                                err
+                            );
+                        } else {
+                            self.maybe_scroll_to_bottom_for_input(&other);
+                        }
+                    }
+                }
+                Key::None => {}
+            }
         }
     }
 
@@ -717,6 +793,11 @@ impl super::TermWindow {
                     }
                     if !key.is_modifier() {
                         context.invalidate();
+                        // Mirror to other panes only when no overlay is active on
+                        // the source pane, matching the same guard used above.
+                        if self.pane_state(pane.pane_id()).overlay.is_none() {
+                            self.sync_input_to_other_panes(&pane, &window_key);
+                        }
                     }
                 }
             }
@@ -737,6 +818,7 @@ impl super::TermWindow {
                 }
                 pane.writer().write_all(s.as_bytes()).ok();
                 self.maybe_scroll_to_bottom_for_input(&pane);
+                self.sync_input_to_other_panes(&pane, &window_key);
                 context.invalidate();
             }
             Key::None => {}

--- a/wezterm-gui/src/termwindow/mod.rs
+++ b/wezterm-gui/src/termwindow/mod.rs
@@ -3162,6 +3162,18 @@ impl TermWindow {
             PromptInputLine(args) => self.show_prompt_input_line(args),
             InputSelector(args) => self.show_input_selector(args),
             Confirmation(args) => self.show_confirmation(args),
+            TogglePaneInputSynchronization => {
+                let mux = Mux::get();
+                if let Some(tab) = mux.get_active_tab_for_window(self.mux_window_id) {
+                    let enabled = !tab.sync_input();
+                    tab.set_sync_input(enabled);
+                    log::info!(
+                        "Pane input synchronization {}",
+                        if enabled { "enabled" } else { "disabled" }
+                    );
+                    self.update_title();
+                }
+            }
         };
         Ok(PerformAssignmentResult::Handled)
     }


### PR DESCRIPTION
this feature will add wezterm to support sync input at all pane in the same tab.

add this toggle shortcut in the .wezterm.lua config as default

-- Toggle synchronized input to all panes in the current tab
    {
      key = 'i',
      mods = 'CTRL|SHIFT',
      action = wezterm.action.TogglePaneInputSynchronization,
    },

you can change the toggle shortcut as you like.