### PR TITLE
Prevent "screen scraping", disable DECRQCRA

### DIFF
--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -260,6 +260,12 @@ pub struct Config {
     #[dynamic(default)]
     pub enable_title_reporting: bool,
 
+    /// Whether the terminal should respond to DECRQCRA checksum requests.
+    /// Disabled by default as it allows programs to read screen contents.
+    /// <https://vt100.net/docs/vt510-rm/DECRQCRA.html>
+    #[dynamic(default)]
+    pub enable_checksum_rectangular_area: bool,
+
     /// Specifies the width of a new window, expressed in character cells
     #[dynamic(default = "default_initial_cols", validate = "validate_row_or_col")]
     pub initial_cols: u16,

--- a/config/src/terminal.rs
+++ b/config/src/terminal.rs
@@ -82,6 +82,10 @@ impl wezterm_term::TerminalConfiguration for TermConfig {
         self.configuration().enable_title_reporting
     }
 
+    fn enable_checksum_rectangular_area(&self) -> bool {
+        self.configuration().enable_checksum_rectangular_area
+    }
+
     fn enable_kitty_keyboard(&self) -> bool {
         self.configuration().enable_kitty_keyboard
     }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -24,6 +24,7 @@ As features stabilize some brief notes about them will accumulate here.
 #### Changed
 * DECRQCRA is now disabled by default to prevent silent screen scraping.
   Set `enable_checksum_rectangular_area = true` to re-enable it.
+  Thanks to @jquast! #7701
 * Wayland: currently being reimplemented, it maybe more unstable than usual.
   Please file GH issues for any problems you see.
   Many thanks to @tzx and @tmccombs! #4777 #5781

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -22,6 +22,8 @@ usually the best available version.
 As features stabilize some brief notes about them will accumulate here.
 
 #### Changed
+* DECRQCRA is now disabled by default to prevent silent screen scraping.
+  Set `enable_checksum_rectangular_area = true` to re-enable it.
 * Wayland: currently being reimplemented, it maybe more unstable than usual.
   Please file GH issues for any problems you see.
   Many thanks to @tzx and @tmccombs! #4777 #5781

--- a/term/src/config.rs
+++ b/term/src/config.rs
@@ -220,6 +220,10 @@ pub trait TerminalConfiguration: Downcast + std::fmt::Debug + Send + Sync {
         false
     }
 
+    fn enable_checksum_rectangular_area(&self) -> bool {
+        false
+    }
+
     fn log_unknown_escape_sequences(&self) -> bool {
         false
     }

--- a/term/src/terminalstate/mod.rs
+++ b/term/src/terminalstate/mod.rs
@@ -2073,14 +2073,16 @@ impl TerminalState {
                 right,
                 ..
             } => {
-                let checksum = self.checksum_rectangle(
-                    left.as_zero_based(),
-                    top.as_zero_based(),
-                    right.as_zero_based(),
-                    bottom.as_zero_based(),
-                );
-                write!(self.writer, "\x1bP{}!~{:04x}\x1b\\", request_id, checksum).ok();
-                self.writer.flush().ok();
+                if self.config.enable_checksum_rectangular_area() {
+                    let checksum = self.checksum_rectangle(
+                        left.as_zero_based(),
+                        top.as_zero_based(),
+                        right.as_zero_based(),
+                        bottom.as_zero_based(),
+                    );
+                    write!(self.writer, "\x1bP{}!~{:04x}\x1b\\", request_id, checksum).ok();
+                    self.writer.flush().ok();
+                }
             }
             Window::ResizeWindowCells { .. } => {
                 // We don't allow the application to change the window size; that's


### PR DESCRIPTION
Problem
-------

March 17 2019 ``DECRQCRA`` was added in 6cbb3ba43, for integration and testing of esctest, 9702d1cf5. Days later, March 23, esctest was removed in c93f967bc, but ``DECRQCRA`` remained enabled for all WezTerm releases since.

On March 2023, @j4james mentioned WezTerm has this option enabled by default https://github.com/microsoft/terminal/issues/14974, "some people consider it a security risk" and on September 2023, @dgl writes in article, "[\E\[31m"?! ANSI Terminal security in 2023 and finding 10 CVEs](https://dgl.cx/2023/09/ansi-terminal-security#_)",

> "using DECRQCRA [..] potential attack here is reading what is displayed on the terminal before a user SSHes to a remote system."

Scraping can occur during/after ssh login, telnet, netcat, serial, or other bidirectional socket-to-terminal connection, the attack is best used early at the login banner stage to collect maximum amount of pre-connection screen data.

Example
------------

In this example, a victim uses sensitive files before a "[screen-scrape.py](https://github.com/jquast/blessed/blob/master/bin/screen-scrape.py)" is executed,

https://github.com/user-attachments/assets/e9f77e29-ed03-4a80-b00f-c9b6bba0a34e

It is more surprising that by switching to "alternate screen" it also possible to scrape the display of last-executed TUI's alternate buffer, such as the contents of the file last opened in an editor as depicted in this video.

Solution
--------

Disable https://vt100.net/docs/vt510-rm/DECRQCRA.html by default, may be re-enabled by configuration.