### PR TITLE
fix: CI improvements - GCC bug, winget hash, and docs

### DIFF
--- a/.github/workflows/gen_macos_continuous.yml
+++ b/.github/workflows/gen_macos_continuous.yml
@@ -51,7 +51,7 @@ jobs:
           path: |
             vendor
             .cargo/config
-          key: "cargo-deps-${{ hashFiles('**/Cargo.lock') }}"
+          key: "cargo-deps-${{ hashFiles('Cargo.lock') }}"
       - name: "Vendor dependecies"
         if: steps.cache-cargo-vendor.outputs.cache-hit != 'true'
         shell: bash

--- a/.github/workflows/gen_ubuntu20.04.yml
+++ b/.github/workflows/gen_ubuntu20.04.yml
@@ -85,6 +85,12 @@ jobs:
       - name: "Install System Deps"
         shell: bash
         run: "env CI=yes PATH=$PATH ./get-deps"
+      - name: "Install gcc-10 and clang"
+        shell: bash
+        run: "apt-get install -y gcc-10 g++-10 clang"
+      - name: "Set CC to clang"
+        shell: bash
+        run: "echo 'CC=clang' >> $GITHUB_ENV"
       - name: "Build wezterm (Release mode)"
         shell: bash
         run: "cargo build -p wezterm --release"

--- a/.github/workflows/gen_ubuntu20.04_continuous.yml
+++ b/.github/workflows/gen_ubuntu20.04_continuous.yml
@@ -88,6 +88,12 @@ jobs:
       - name: "Install System Deps"
         shell: bash
         run: "env CI=yes PATH=$PATH ./get-deps"
+      - name: "Install gcc-10 and clang"
+        shell: bash
+        run: "apt-get install -y gcc-10 g++-10 clang"
+      - name: "Set CC to clang"
+        shell: bash
+        run: "echo 'CC=clang' >> $GITHUB_ENV"
       - name: "Build wezterm (Release mode)"
         shell: bash
         run: "cargo build -p wezterm --release"

--- a/.github/workflows/gen_ubuntu20.04_tag.yml
+++ b/.github/workflows/gen_ubuntu20.04_tag.yml
@@ -64,6 +64,12 @@ jobs:
       - name: "Install System Deps"
         shell: bash
         run: "env CI=yes PATH=$PATH ./get-deps"
+      - name: "Install gcc-10 and clang"
+        shell: bash
+        run: "apt-get install -y gcc-10 g++-10 clang"
+      - name: "Set CC to clang"
+        shell: bash
+        run: "echo 'CC=clang' >> $GITHUB_ENV"
       - name: "Build wezterm (Release mode)"
         shell: bash
         run: "cargo build -p wezterm --release"

--- a/.github/workflows/gen_windows_continuous.yml
+++ b/.github/workflows/gen_windows_continuous.yml
@@ -118,3 +118,60 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         shell: bash
         run: "bash ci/retry.sh gh release upload --clobber nightly WezTerm-*.zip WezTerm-*.exe *.sha256"
+      - name: "Checkout winget-pkgs"
+        uses: actions/checkout@v4
+        with:
+          repository: "microsoft/winget-pkgs"
+          path: "winget-pkgs"
+          token: "${{ secrets.GH_PAT }}"
+          fetch-depth: 0
+      - name: "Setup email for winget repo"
+        shell: bash
+        run: "cd winget-pkgs && git config user.email wez@wezfurlong.org"
+      - name: "Setup name for winget repo"
+        shell: bash
+        run: "cd winget-pkgs && git config user.name 'Wez Furlong'"
+      - name: "Compute Sha256 hash"
+        id: hash
+        shell: bash
+        run: |
+          echo "sha256=$(sha256sum -b WezTerm-*.exe | cut -f1 -d' ' | tr a-f A-F)" >> $GITHUB_OUTPUT
+      - name: "Update winget nightly manifest"
+        shell: bash
+        run: |
+          cd winget-pkgs
+          NIGHTLY_DIR="manifests/w/wez/wezterm.nightly"
+          if [ -d "$NIGHTLY_DIR" ]; then
+            cd "$NIGHTLY_DIR"
+            LATEST_VERSION=$(ls -1 | sort -r | head -1)
+            if [ -n "$LATEST_VERSION" ] && [ -f "$LATEST_VERSION/wez.wezterm.nightly.installer.yaml" ]; then
+              sed -i "s/InstallerSha256:.*/InstallerSha256: ${{ steps.hash.outputs.sha256 }}/" "$LATEST_VERSION/wez.wezterm.nightly.installer.yaml"
+              echo "Updated nightly manifest: $LATEST_VERSION"
+            fi
+          else
+            echo "No nightly manifest found"
+            exit 1
+          fi
+      - name: "Commit and push winget changes"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_PAT }}
+        shell: bash
+        run: |
+          cd winget-pkgs
+          git add --all
+          git diff --cached --quiet || git commit -m "wezterm nightly: update installer hash" || echo "No changes to commit"
+          git push origin master --quiet || echo "Push skipped - no changes"
+      - name: "Submit winget PR"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_PAT }}
+        shell: bash
+        run: |
+          cd winget-pkgs
+          if git diff --quiet; then
+            echo "No changes to push"
+          else
+            BRANCH="wezterm-nightly-$(date +%Y%m%d%H%M%S)"
+            git checkout -b "$BRANCH"
+            git push --set-upstream origin "$BRANCH" --quiet
+            gh pr create --fill --body "Auto-update wezterm nightly installer hash" --base master --repo Microsoft/winget-pkgs || echo "PR creation skipped or failed"
+          fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -127,3 +127,33 @@ $ cargo test --all
 $ cargo fmt --all
 ```
 
+## CI Troubleshooting
+
+Sometimes CI builds fail due to infrastructure issues rather than code problems.
+
+### macOS - Apple Notary Agreement Expired
+
+```
+Error: HTTP status code: 403. A required agreement is missing or has expired.
+```
+
+This is an infrastructure issue with the maintainer's Apple Developer account.
+
+### Ubuntu - GCC Compiler Bug
+
+```
+### COMPILER BUG DETECTED ###
+Your compiler (cc) is not supported due to a memcmp related bug
+reported in https://gcc.gnu.org/bugzilla/show_bug.cgi?id=95189
+```
+
+This is due to an older GCC version on Ubuntu 20.04. Use clang instead.
+
+### Cirrus CI - GitHub Token Expired
+
+```
+HTTP 401: Bad credentials
+```
+
+The GITHUB_TOKEN in .cirrus.yml has expired.
+


### PR DESCRIPTION
## Summary

This PR addresses multiple CI infrastructure issues:

### 1. Ubuntu 20.04 GCC Compiler Bug
The ubuntu20.04 continuous workflow fails due to a [GCC memcmp bug](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=95189) that causes `aws-lc-sys` compilation to fail.

**Fix:** Install clang and set CC=clang before building.

### 2. macOS Continuous hashFiles Issue
The macos_continuous workflow fails with hashFiles error.

**Fix:** Change `hashFiles('**/Cargo.lock')` to `hashFiles('Cargo.lock')` for more specific path matching.

### 3. Windows winget Nightly Hash Mismatch
The windows_continuous workflow uploads a new installer but doesn't update the winget manifest hash, causing `winget install` to fail with hash mismatch error.

**Fix:** Add post-upload step to update InstallerSha256 in the winget nightly manifest.

### 4. CI Troubleshooting Documentation
Added a new section to CONTRIBUTING.md documenting known CI infrastructure issues.

## Changes

- `.github/workflows/gen_ubuntu20.04.yml` - Add clang installation
- `.github/workflows/gen_ubuntu20.04_continuous.yml` - Add clang installation  
- `.github/workflows/gen_ubuntu20.04_tag.yml` - Add clang installation
- `.github/workflows/gen_macos_continuous.yml` - Fix hashFiles path
- `.github/workflows/gen_windows_continuous.yml` - Add winget manifest update
- `CONTRIBUTING.md` - Add CI Troubleshooting section

## Related Issues
- Fixes #7713 (winget hash mismatch)
- Fixes #7717 (macOS + Ubuntu GCC)
- Related #7716 (Cirrus CI token)