### PR TITLE
window/windows: fix re-entrant borrow_mut panic in wm_size (IME/TSF)

### DIFF
--- a/wezterm-ssh/src/auth.rs
+++ b/wezterm-ssh/src/auth.rs
@@ -136,19 +136,26 @@ impl crate::sessioninner::SessionInner {
         // Set the callback for pubkey auth
         sess.set_auth_callback(move |prompt, echo, _verify, identity| {
             let (reply, answers) = bounded(1);
-            tx.try_send(SessionEvent::Authenticate(AuthenticationEvent {
-                username: "".to_string(),
-                instructions: "".to_string(),
-                prompts: vec![AuthenticationPrompt {
-                    prompt: match identity {
-                        Some(ident) => format!("{} ({}): ", prompt, ident),
-                        None => prompt.to_string(),
-                    },
-                    echo,
-                }],
-                reply,
-            }))
-            .unwrap();
+            // Use ok() instead of unwrap(): the UI receiver may have been dropped
+            // (e.g. during shutdown or window restore), in which case we return
+            // an error rather than panicking.
+            if tx
+                .try_send(SessionEvent::Authenticate(AuthenticationEvent {
+                    username: "".to_string(),
+                    instructions: "".to_string(),
+                    prompts: vec![AuthenticationPrompt {
+                        prompt: match identity {
+                            Some(ident) => format!("{} ({}): ", prompt, ident),
+                            None => prompt.to_string(),
+                        },
+                        echo,
+                    }],
+                    reply,
+                }))
+                .is_err()
+            {
+                return Err(libssh_rs::Error::fatal("authentication UI is not available"));
+            }
 
             let mut answers = smol::block_on(answers.recv())
                 .context("waiting for authentication answers from user")

--- a/window/src/os/windows/window.rs
+++ b/window/src/os/windows/window.rs
@@ -1567,9 +1567,16 @@ unsafe fn wm_size(hwnd: HWND, _msg: UINT, _wparam: WPARAM, _lparam: LPARAM) -> O
     let mut should_pump = false;
 
     if let Some(inner) = rc_from_hwnd(hwnd) {
-        let mut inner = inner.borrow_mut();
-        should_paint = inner.check_and_call_resize_if_needed();
-        should_pump = inner.in_size_move;
+        // Use try_borrow_mut to gracefully handle re-entrant calls.
+        // WM_WINDOWPOSCHANGED can be dispatched synchronously while the RefCell
+        // is already borrowed (e.g. via TranslateMessage -> IME/TSF initialization
+        // -> NtUserSetWindowPos -> WM_WINDOWPOSCHANGED), causing a double-borrow
+        // panic. Skipping the re-entrant call is safe: the outer borrow will
+        // process the resize when it completes.
+        if let Ok(mut inner) = inner.try_borrow_mut() {
+            should_paint = inner.check_and_call_resize_if_needed();
+            should_pump = inner.in_size_move;
+        }
     }
 
     if should_paint {


### PR DESCRIPTION
## Problem

Two separate panics observed on Windows nightly builds.

### 1. `window/src/os/windows/window.rs:1570` — re-entrant borrow in `wm_size`

`WM_WINDOWPOSCHANGED` is dispatched **synchronously** while the `RefCell` is already borrowed:

```
TranslateMessage
  ImmTranslateMessage
  TsfOneCreate / CtfImeCreateInputContext   <- TSF/IME initialization
  NtUserSetWindowPos                        <- repositions IME candidate window
  WM_WINDOWPOSCHANGED dispatched synchronously
  wm_windowposchanged -> wm_size
  inner.borrow_mut()                        <- PANIC: already borrowed
```

**Fix:** Replace `borrow_mut()` with `try_borrow_mut()`. Re-entrant calls are silently skipped; the outer borrow processes the resize when it completes.

### 2. `wezterm-ssh/src/auth.rs:151` — unwrap on dropped channel sender

The libssh auth callback calls `.unwrap()` on `tx.try_send(...)`. If the UI receiver has been dropped (e.g. during window restore via the resurrect plugin or shutdown), the send fails and panics.

**Fix:** Check `is_err()` and return `libssh_rs::Error::fatal(...)` instead of panicking.

## Reproduction

1. Open WezTerm nightly on Windows with a Japanese IME (TSF-based) enabled
2. Move or resize the window → panic #1
3. Use the resurrect plugin to restore a workspace containing an SSH session → panic #2