### PR TITLE
Fix IPv6 rule in quick select parsing

### DIFF
--- a/wezterm-gui/src/overlay/quickselect.rs
+++ b/wezterm-gui/src/overlay/quickselect.rs
@@ -47,7 +47,7 @@ const PATTERNS: [&str; 14] = [
     // ip
     r"\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}",
     // ipv6
-    r"[A-f0-9:]+:+[A-f0-9:]+[%\w\d]+",
+    r"[a-fA-F0-9:]+:+[a-fA-F0-9:]+[%\w\d]+",
     // address
     r"0x[0-9a-fA-F]+",
     // number


### PR DESCRIPTION
`A-f` ≠ `A-Fa-f`, but includes a few extra symbols like `\~]^`

Closes https://github.com/wezterm/wezterm/issues/7729