### PR TITLE
Fix builds on MSVC aarch64 environments by removing GNU assembly NEON stub

### DIFF
--- a/deps/freetype/build.rs
+++ b/deps/freetype/build.rs
@@ -78,7 +78,6 @@ fn libpng() {
         match arch.as_str() {
             "aarch64" | "arm" => {
                 cfg.file("libpng/arm/arm_init.c")
-                    .file("libpng/arm/filter_neon.S")
                     .file("libpng/arm/filter_neon_intrinsics.c")
                     .file("libpng/arm/palette_neon_intrinsics.c");
             }


### PR DESCRIPTION
This PR removes the [`libpng/arm/filter_neon.S`](https://github.com/pnggroup/libpng/blob/libpng18/arm/filter_neon.S) stub from the build script. This file is a GNU assembly file, which gets skipped by the MSVC assembler and triggers linking failures. It can be removed safely since it is just a stub that exists not to break old libpng build scripts. Citing the top comment on the fie itself:
```c
/* IMPORTANT NOTE:
 *
 * Historically, the hand-coded assembler implementation of Neon optimizations
 * in this module had not been in sync with the intrinsics-based implementation
 * in filter_neon_intrinsics.c and palette_neon_intrinsics.c, at least since
 * the introduction of riffled palette optimizations. Moreover, the assembler
 * code used to work on 32-bit ARM only, and it caused problems, even if empty,
 * on 64-bit ARM.
 *
 * All references to this module from our internal build scripts and projects
 * have been removed.
 *
 * For the external projects that might still expect this module to be present,
 * we leave this stub in place, for the remaining lifetime of libpng-1.6.x.
 * Everything should continue to function normally, as long as there are no
 * deliberate attempts to use the old hand-made assembler code. A build error
 * will be raised otherwise.
 */

```

This PR enables building for Windows on ARM64 (WoA) targets, and we could add support for them on CI.