### PR TITLE
feat: ranking for InputSelector items

### DIFF
--- a/config/src/keyassignment.rs
+++ b/config/src/keyassignment.rs
@@ -482,6 +482,8 @@ fn default_prompt() -> String {
 pub struct InputSelectorEntry {
     pub label: String,
     pub id: Option<String>,
+    #[dynamic(default)]
+    pub priority: u32,
 }
 
 #[derive(Debug, Clone, PartialEq, FromDynamic, ToDynamic)]
@@ -503,6 +505,9 @@ pub struct InputSelector {
 
     #[dynamic(default = "default_fuzzy_description")]
     pub fuzzy_description: String,
+
+    #[dynamic(default = "default_score_per_priority")]
+    pub score_per_priority: u32,
 }
 
 fn default_num_alphabet() -> String {
@@ -515,6 +520,10 @@ fn default_description() -> String {
 
 fn default_fuzzy_description() -> String {
     "Fuzzy matching: ".to_string()
+}
+
+fn default_score_per_priority() -> u32 {
+    20
 }
 
 #[derive(Debug, Clone, PartialEq, FromDynamic, ToDynamic)]

--- a/docs/config/lua/keyassignment/InputSelector.md
+++ b/docs/config/lua/keyassignment/InputSelector.md
@@ -17,10 +17,18 @@ upon the input.
 
 * `title` - the title that will be set for the overlay pane
 * `choices` - a lua table consisting of the potential choices. Each entry
-  is itself a table with a `label` field and an optional `id` field.
+  is itself a table with a `label` field, an optional `id` field, and
+  an optional `priority` field. {{since('nightly', inline=True)}}
   The label will be shown in the list, while the id can be a different
   string that is meaningful to your action. The label can be used together
   with [wezterm.format](../wezterm/format.md) to produce styled text.
+  The `priority` field is a non-negative integer that acts as a soft priority
+  during fuzzy filtering. Each priority level adds `score_per_priority` points
+  to the fuzzy match score, so higher-priority entries float above
+  similarly-scoring entries. A sufficiently better fuzzy match can still
+  overcome a priority difference. When no filter is active, entries are also
+  sorted by priority (highest first), preserving insertion order within the
+  same priority level. Defaults to `0`.
 * `action` - and event callback registered via `wezterm.action_callback`.  The
   callback's function signature is `(window, pane, id, label)` where `window` and
   `pane` are the [Window](../window/index.md) and [Pane](../pane/index.md)
@@ -44,7 +52,12 @@ These additional fields are also available:
   `"Select an item and press Enter = accept,  Esc = cancel,  / = filter"`.
 * `fuzzy_description` - a string to display when in fuzzy finding mode. Defaults to:
   `"Fuzzy matching: "`.
-
+* `score_per_priority` - a non-negative integer that controls how much each priority
+  level contributes to the effective fuzzy score. The effective score is computed
+  as `fuzzy_score + (priority * score_per_priority)`. Defaults to `20`.
+  Increase this value to make priority differences harder to overcome by fuzzy
+  score alone. A value of `0` disables the priority influence entirely.
+  {{since('nightly', inline=True)}}
 
 ### Key Assignments
 
@@ -233,10 +246,92 @@ config.keys = {
 return config
 ```
 
+## Example of using `priority` as a soft priority for fuzzy results
 
+{{since('nightly')}}
 
+You can use `priority` to apply a soft priority to fuzzy results.
+Higher-priority entries receive bonus points (`score_per_priority` per level),
+so they float above similarly-scoring entries. A significantly better fuzzy
+match can still win regardless of priority.
+
+In the example below, **active** workspaces use priority 2, **personal** projects
+use priority 1, and **public** projects use the default priority 0:
+
+```lua
+local wezterm = require 'wezterm'
+local act = wezterm.action
+local config = wezterm.config_builder()
+
+-- Helper to turn a list of names into InputSelector choices, all with the
+-- same priority value.
+local function choices_with_priority(names, priority)
+  local result = {}
+  for _, name in ipairs(names) do
+    table.insert(result, { label = name, priority = priority })
+  end
+  return result
+end
+
+config.keys = {
+  {
+    key = 'S',
+    mods = 'CTRL|SHIFT',
+    action = wezterm.action_callback(function(window, pane)
+      -- Active workspaces — priority 2 (highest): biased toward the top
+      local active = choices_with_priority({
+        'my-project (active)',
+        'my-other-project (active)',
+      }, 2)
+
+      -- Personal projects — priority 1: appear after active workspaces
+      local personal = choices_with_priority({
+        'my-project',
+        'my-other-project',
+        'my-side-project',
+      }, 1)
+
+      -- Public/shared projects — priority 0 (default): appear last
+      local public = choices_with_priority({
+        'my-project (public)',
+        'my-other-project (public)',
+        'shared-library',
+      }, 0)
+
+      -- Concatenate all tiers into a single choices list
+      local choices = {}
+      for _, tier in ipairs({ active, personal, public }) do
+        for _, entry in ipairs(tier) do
+          table.insert(choices, entry)
+        end
+      end
+
+      window:perform_action(
+        act.InputSelector {
+          action = wezterm.action_callback(
+            function(inner_window, inner_pane, id, label)
+              if label then
+                inner_window:perform_action(
+                  act.SwitchToWorkspace { name = label },
+                  inner_pane
+                )
+              end
+            end
+          ),
+          title = 'Switch Workspace',
+          choices = choices,
+          fuzzy = true,
+          -- score_per_priority = 30,  -- optional: increase to make priority harder to overcome
+        },
+        pane
+      )
+    end),
+  },
+}
+
+return config
+```
 
 See also:
    * [PromptInputLine](PromptInputLine.md).
    * [Confirmation](Confirmation.md).
-

--- a/wezterm-gui/src/overlay/selector.rs
+++ b/wezterm-gui/src/overlay/selector.rs
@@ -37,6 +37,49 @@ pub fn matcher_pattern(s: &str) -> Pattern {
     )
 }
 
+struct MatchResult {
+    row_idx: usize,
+    score: u32,
+    priority: u32,
+}
+
+/// Score and sort `entries` against `filter` using fuzzy matching boosted by
+/// [`InputSelectorEntry::priority`].  Returns results ordered by effective score
+/// (descending), with insertion order as tie-breaker.
+fn priority_filtered_entries(
+    entries: &[InputSelectorEntry],
+    filter: &str,
+    score_per_priority: u32,
+) -> Vec<MatchResult> {
+    let pattern = matcher_pattern(filter);
+
+    let mut scores: Vec<MatchResult> = entries
+        .par_iter()
+        .enumerate()
+        .filter_map(|(row_idx, entry)| {
+            let score = matcher_score(&pattern, &entry.label)?;
+            Some(MatchResult {
+                row_idx,
+                score,
+                priority: entry.priority,
+            })
+        })
+        .collect();
+
+    let effective = |r: &MatchResult| {
+        r.score
+            .saturating_add(r.priority.saturating_mul(score_per_priority))
+    };
+
+    scores.sort_by(|a, b| {
+        effective(b)
+            .cmp(&effective(a))
+            .then(a.row_idx.cmp(&b.row_idx))
+    });
+
+    scores
+}
+
 struct SelectorState {
     active_idx: usize,
     max_items: usize,
@@ -57,31 +100,28 @@ impl SelectorState {
     fn update_filter(&mut self) {
         if self.filter_term.is_empty() {
             self.filtered_entries = self.args.choices.clone();
+            self.filtered_entries
+                .sort_by(|a, b| b.priority.cmp(&a.priority));
             return;
         }
 
-        self.filtered_entries.clear();
+        let scores = priority_filtered_entries(
+            &self.args.choices,
+            &self.filter_term,
+            self.args.score_per_priority,
+        );
 
-        struct MatchResult {
-            row_idx: usize,
-            score: u32,
+        for r in &scores {
+            log::trace!(
+                "inputselector filter={:?} priority={} score={} label={:?}",
+                self.filter_term,
+                r.priority,
+                r.score,
+                self.args.choices[r.row_idx].label
+            );
         }
 
-        let pattern = matcher_pattern(&self.filter_term);
-
-        let mut scores: Vec<MatchResult> = self
-            .args
-            .choices
-            .par_iter()
-            .enumerate()
-            .filter_map(|(row_idx, entry)| {
-                let score = matcher_score(&pattern, &entry.label)?;
-                Some(MatchResult { row_idx, score })
-            })
-            .collect();
-
-        scores.sort_by(|a, b| a.score.cmp(&b.score).reverse());
-
+        self.filtered_entries.clear();
         for result in scores {
             self.filtered_entries
                 .push(self.args.choices[result.row_idx].clone());
@@ -445,4 +485,76 @@ pub fn selector(
     state.update_filter();
     state.render(&mut term)?;
     state.run_loop(&mut term)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::priority_filtered_entries;
+    use config::keyassignment::InputSelectorEntry;
+
+    fn entry(label: &str, priority: u32) -> InputSelectorEntry {
+        InputSelectorEntry {
+            label: label.to_string(),
+            id: None,
+            priority,
+        }
+    }
+
+    fn filtered_order(
+        entries: &[InputSelectorEntry],
+        filter: &str,
+        score_per_priority: u32,
+    ) -> Vec<String> {
+        priority_filtered_entries(entries, filter, score_per_priority)
+            .into_iter()
+            .map(|r| entries[r.row_idx].label.clone())
+            .collect()
+    }
+
+    #[test]
+    fn strong_match_overcomes_higher_priority() {
+        let entries = vec![entry("foo-bar", 1), entry("bar-baz-quux-unrelated", 3)];
+        let order = filtered_order(&entries, "foo", 20);
+        assert_eq!(order[0], "foo-bar");
+    }
+
+    #[test]
+    fn same_priority_sorts_by_score() {
+        let entries = vec![entry("weak-zzz", 0), entry("strong-aaa", 0)];
+        let order = filtered_order(&entries, "strong", 20);
+        assert_eq!(order[0], "strong-aaa");
+    }
+
+    #[test]
+    fn ansi_escape_labels_with_priority() {
+        let decorated = "\x1b[0;36mwidget (primary)\x1b[0m";
+        let plain = "other-widget";
+
+        let entries = vec![entry(decorated, 2), entry(plain, 0)];
+        let order = filtered_order(&entries, "widget", 20);
+
+        assert_eq!(
+            order.len(),
+            2,
+            "both entries should match 'widget' regardless of ANSI escape sequences"
+        );
+        assert_eq!(
+            order.first().map(String::as_str),
+            Some(decorated),
+            "higher-priority entry should rank first even with ANSI escape sequences in label"
+        );
+    }
+
+    #[test]
+    fn higher_priority_wins_with_similar_scores() {
+        let entries = vec![entry("alpha-project", 1), entry("bravo-project", 2)];
+
+        let order = filtered_order(&entries, "project", 20);
+
+        assert_eq!(
+            order.first().map(String::as_str),
+            Some("bravo-project"),
+            "priority 2 should beat priority 1 when fuzzy scores are similar"
+        );
+    }
 }


### PR DESCRIPTION
Small change I have been running locally for a week now.  Allows biasing items in the InputSelector by setting a priority (ranking) to individual items, which gets multiplied by an (optionally configurable) score.

Main use-case I had for this was wanting the fuzzy results for my workspace switcher to bias towards open workspaces as I have quite a few with similar names.  Also wanted to prefer my work related repos on my work machine and personal on personal.

Not 100% sure on the naming, looking for some suggestions there.

First time doing some Rust, wrote the code myself after some LLM pointers for where to start, please let me know if anything is off. 