### PR TITLE
Fix tab:set_title flashing in unix domain mode

### DIFF
--- a/mux/src/tab.rs
+++ b/mux/src/tab.rs
@@ -2525,4 +2525,27 @@ mod test {
     fn tab_is_send_and_sync() {
         assert!(is_send_and_sync::<Tab>());
     }
+
+    #[test]
+    fn tab_get_set_title() {
+        let size = TerminalSize {
+            rows: 24,
+            cols: 80,
+            pixel_width: 800,
+            pixel_height: 600,
+            dpi: 96,
+        };
+        let tab = Tab::new(&size);
+
+        assert_eq!(tab.get_title(), "");
+
+        tab.set_title("hello");
+        assert_eq!(tab.get_title(), "hello");
+
+        tab.set_title("hello");
+        assert_eq!(tab.get_title(), "hello");
+
+        tab.set_title("world");
+        assert_eq!(tab.get_title(), "world");
+    }
 }

--- a/wezterm-client/src/domain.rs
+++ b/wezterm-client/src/domain.rs
@@ -14,6 +14,7 @@ use mux::{Mux, MuxNotification};
 use portable_pty::CommandBuilder;
 use promise::spawn::spawn_into_new_thread;
 use std::collections::{HashMap, HashSet};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use wezterm_term::TerminalSize;
 
@@ -255,6 +256,7 @@ pub struct ClientDomain {
     label: String,
     inner: Mutex<Option<Arc<ClientInner>>>,
     local_domain_id: DomainId,
+    processing_remote_title_update: AtomicBool,
 }
 
 async fn update_remote_workspace(
@@ -339,6 +341,12 @@ fn mux_notify_client_domain(local_domain_id: DomainId, notif: MuxNotification) -
             .detach();
         }
         MuxNotification::TabTitleChanged { tab_id, title } => {
+            if client_domain
+                .processing_remote_title_update
+                .load(Ordering::SeqCst)
+            {
+                return true;
+            }
             if let Some(remote_tab_id) = client_domain.local_to_remote_tab_id(tab_id) {
                 if let Some(inner) = client_domain.inner() {
                     promise::spawn::spawn(async move {
@@ -405,6 +413,7 @@ impl ClientDomain {
             label,
             inner: Mutex::new(None),
             local_domain_id,
+            processing_remote_title_update: AtomicBool::new(false),
         }
     }
 
@@ -495,7 +504,11 @@ impl ClientDomain {
         if let Some(inner) = self.inner() {
             if let Some(local_tab_id) = inner.remote_to_local_tab_id(remote_tab_id) {
                 if let Some(tab) = Mux::get().get_tab(local_tab_id) {
+                    self.processing_remote_title_update
+                        .store(true, Ordering::SeqCst);
                     tab.set_title(&title);
+                    self.processing_remote_title_update
+                        .store(false, Ordering::SeqCst);
                 }
             }
         }
@@ -573,7 +586,9 @@ impl ClientDomain {
                     inner.record_remote_to_local_tab_mapping(remote_tab_id, tab.tab_id());
                 }
 
-                tab.set_title(tab_title);
+                if !tab_title.is_empty() || tab.get_title().is_empty() {
+                    tab.set_title(tab_title);
+                }
 
                 log::debug!("domain: {} tree: {:#?}", inner.local_domain_id, tabroot);
                 let mut workspace = None;


### PR DESCRIPTION
When connected via a unix, calling tab:set_title causes the tab title to rapidly flash between the set title and the shell's process title. This does not occur in local mode or when using wezterm cli set-tab-title, the workaround in #5849.

The root cause seems to be a bidirectional sync loop. When the client calls set_title, it sets local state and fires a MuxNotification. The client notification handler sees this and sends a TabTitleChanged PDU to the server. The server sets the title and broadcasts the change back to all clients. The client receives the broadcast, calls tab.set_title again, which fires another notification, which gets sent back to the server, and so on.

There is a guard `if inner.title != title` that should stop the loop when the title has not changed. However, I suspect async round-trips cause windows where format-tab-title fires with inconsistent state. Like client / server spidermen pointing at each other about what the title should be.

A second related bug: when a tab is spawned, the client's callback sets the title (e.g. "lazygit") and sends it to the server asynchronously. But the server also sends a TabAddedToWindow notification, which triggers a resync on the client. The resync asks the server for the current pane list, and the server responds with an empty tab title because the title PDU has not arrived yet. The resync then overwrites the local title with "".

## Fixes considered

- Debounce (the WindowTitleChanged approach mentioned [here](https://github.com/wez/wezterm/blob/577474d89ee61aef4a48145cdec82a638d874751/wezterm-client/src/domain.rs?plain=1#L372-L379)) that acknowledges this exact race condition. Adding the same for TabTitleChanged would mask the loop rather than eliminate it. It still allows one wasted round-trip per second and leaves a fragile timing dependency.
- Origin tracking. Add a Local/Remote enum to TabTitleChanged. Tag notifications from set_title as Local, and notifications from process_remote_tab_title_change as Remote. Have mux_notify_client_domain skip remote-origin notifications. To me, that doesn't seem to address the underlying issue where the client acts as a source of truth in cases where only the server should.
- Unidirectional flow with domain awareness in Tab. Have set_title detect whether the tab belongs to a remote domain and skip setting local state, only forwarding to the server. Seems like a clean idea, but Tab does not have a domain_id, and the mux crate can't depend on wezterm-client to get that information.

## Implemented fix

An AtomicBool flag `processing_remote_title_update` is added to ClientDomain. When the client receives a title change from the server, process_remote_tab_title_change sets the flag to true, calls set_title, then sets the flag to false. Mux::notify calls subscribers synchronously, so when set_title fires the MuxNotification, mux_notify_client_domain runs within that same call while the flag is still true. It checks the flag and skips forwarding breaking the echo loop.

User-initiated title changes are unaffected because the flag is false, so they propagate to the server normally.

For the resync race, a guard is added to process_pane_list. If the server reports an empty tab title but the client already has a non-empty title (in-flight to the server), the client preserves its local value instead of overwriting it.

As an aside, I can't build main, because it has a pre-existing issue in mux/src/client.rs (Utc::now() requires the chrono clock feature, which is not enabled in Cargo.toml). So I had to add that to build, but didn't include it in this branch.

### Before

https://github.com/user-attachments/assets/892337f3-fbd4-4699-a167-cb035d1e6dff

### After

https://github.com/user-attachments/assets/f4a04a2f-81df-4a78-b95a-31d0c12ad068

Fixes #5849

---

Disclosure: I don't know this project's current stance, but I did use LLM's to some extent to chase down the issue and to consider some fixes, but after selecting a solution, the code was written by me. I hope this is an okay contribution.